### PR TITLE
feat: Transport implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
   - 1.11.x
   - 1.12.x
 
+env:
+  - GO111MODULE=on
+
 before_install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
 

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"context"
+	"time"
 )
 
 func Init(options ClientOptions) error {
@@ -82,12 +83,12 @@ func PopScope() {
 	hub.PopScope()
 }
 
-func Flush(timeout int) {
+func Flush(timeout time.Duration) bool {
 	hub := CurrentHub()
-	hub.Flush(timeout)
+	return hub.Flush(timeout)
 }
 
-func LastEventID() {
+func LastEventID() string {
 	hub := CurrentHub()
-	hub.LastEventID()
+	return hub.LastEventID()
 }

--- a/dsn.go
+++ b/dsn.go
@@ -45,12 +45,7 @@ type Dsn struct {
 	projectID int
 }
 
-// TODO: Change it to `FromString` method on `Dsn` struct?
 func NewDsn(rawURL string) (*Dsn, error) {
-	if rawURL == "" {
-		return nil, nil
-	}
-
 	// Parse
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -62,17 +62,6 @@ func TestDsnDeserializeInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestDsnNoInput(t *testing.T) {
-	dsn, err := NewDsn("")
-
-	if dsn != nil {
-		t.Error("expected to return nil pointer to dsn")
-	}
-	if err != nil {
-		t.Error("expected to not return error")
-	}
-}
-
 func TestValidDsnInsecure(t *testing.T) {
 	url := "http://username@domain:8888/42"
 	dsn, err := NewDsn(url)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"sentry"
 	sentryIntegrations "sentry/integrations"
 	"strconv"
+	"time"
 )
 
 func prettyPrint(v interface{}) string {
@@ -24,9 +24,12 @@ func (t *DevNullTransport) Configure(options sentry.ClientOptions) {
 	fmt.Println("Headers:", dsn.RequestHeaders())
 	fmt.Println()
 }
-func (t *DevNullTransport) SendEvent(event *sentry.Event) (*http.Response, error) {
+func (t *DevNullTransport) SendEvent(event *sentry.Event) {
 	fmt.Println("Faked Transport")
-	return nil, nil
+}
+
+func (t *DevNullTransport) Flush(timeout time.Duration) bool {
+	return true
 }
 
 func recoverHandler() {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sentry"
-	sentryIntegrations "sentry/integrations"
 	"strconv"
 	"time"
+
+	"github.com/getsentry/sentry-go"
+	sentryintegrations "github.com/getsentry/sentry-go/integrations"
 )
 
 func prettyPrint(v interface{}) string {
@@ -141,7 +142,7 @@ func main() {
 		SampleRate: 1,
 		Transport:  new(DevNullTransport),
 		Integrations: []sentry.Integration{
-			new(sentryIntegrations.EnvironmentIntegration),
+			new(sentryintegrations.EnvironmentIntegration),
 		},
 	}); err != nil {
 		panic(err)

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -30,10 +30,13 @@ func (t *DevNullTransport) Configure(options sentry.ClientOptions) {
 	fmt.Println("Headers:", dsn.RequestHeaders())
 	fmt.Println()
 }
-func (t *DevNullTransport) SendEvent(event *sentry.Event) (*http.Response, error) {
+func (t *DevNullTransport) SendEvent(event *sentry.Event) {
 	fmt.Println("Faked Transport")
 	log.Println(prettyPrint(event))
-	return nil, nil
+}
+
+func (t *DevNullTransport) Flush(timeout time.Duration) bool {
+	return true
 }
 
 func customHandlerFunc(w http.ResponseWriter, r *http.Request) {

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"sentry"
-	sentryIntegrations "sentry/integrations"
 	"strconv"
 	"time"
+
+	"github.com/getsentry/sentry-go"
+	sentryintegrations "github.com/getsentry/sentry-go/integrations"
 )
 
 func prettyPrint(v interface{}) string {
@@ -111,7 +112,7 @@ func main() {
 		Transport: new(DevNullTransport),
 		Integrations: []sentry.Integration{
 			new(ExtractUser),
-			new(sentryIntegrations.RequestIntegration),
+			new(sentryintegrations.RequestIntegration),
 		},
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,4 @@
-module sentry
-
-go 1.12
+module github.com/getsentry/sentry-go
 
 require (
 	github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sentry
 go 1.12
 
 require (
+	github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713
 	github.com/go-errors/errors v1.0.1
 	github.com/pingcap/errors v0.11.1
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713 h1:UNOqI3EKhvbqV8f1Vm3NIwkrhq388sGCeAH2Op7w0rc=
+github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/pingcap/errors v0.11.1 h1:BXFZ6MdDd2U1uJUa2sRAWTmm+nieEzuyYM0R4aUTcC8=

--- a/hub.go
+++ b/hub.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"context"
+	"time"
 )
 
 // Default maximum number of breadcrumbs added to an event. Can be overwritten `maxBreadcrumbs` option.
@@ -173,8 +174,14 @@ func (hub *Hub) RecoverWithContext(ctx context.Context, err interface{}, hint *E
 	})
 }
 
-func (hub *Hub) Flush(timeout int) {
-	panic("Implement Flush redirect to the Client")
+func (hub *Hub) Flush(timeout time.Duration) bool {
+	client := hub.Client()
+
+	if client == nil {
+		return false
+	}
+
+	return client.Flush(timeout)
 }
 
 func (hub *Hub) GetIntegration(name string) Integration {

--- a/integrations/environment.go
+++ b/integrations/environment.go
@@ -1,8 +1,9 @@
-package sentry
+package sentryintegrations
 
 import (
 	"runtime"
-	"sentry"
+
+	"github.com/getsentry/sentry-go"
 )
 
 type EnvironmentIntegration struct{}

--- a/integrations/request.go
+++ b/integrations/request.go
@@ -1,9 +1,10 @@
-package sentry
+package sentryintegrations
 
 import (
 	"io/ioutil"
 	"net/http"
-	"sentry"
+
+	"github.com/getsentry/sentry-go"
 )
 
 type RequestIntegration struct{}

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -2,7 +2,7 @@ package sentry
 
 import (
 	"context"
-	"net/http"
+	"time"
 )
 
 type ScopeMock struct {
@@ -26,9 +26,11 @@ type TransportMock struct {
 }
 
 func (t *TransportMock) Configure(options ClientOptions) {}
-func (t *TransportMock) SendEvent(event *Event) (*http.Response, error) {
+func (t *TransportMock) SendEvent(event *Event) {
 	t.lastEvent = event
-	return nil, nil
+}
+func (t *TransportMock) Flush(timeout time.Duration) bool {
+	return true
 }
 
 type ClientMock struct {

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -12,7 +12,7 @@ func TestFunctionName(t *testing.T) {
 		pack string
 		name string
 	}{
-		{0, "sentry", "TestFunctionName"},
+		{0, "github.com/getsentry/sentry-go", "TestFunctionName"},
 		{1, "testing", "tRunner"},
 		{2, "runtime", "goexit"},
 		{100, "", ""},
@@ -46,7 +46,7 @@ func TestStacktraceFrame(t *testing.T) {
 	assertEqual(t, frame.Function, "Trace")
 	assertEqual(t, frame.Lineno, 12)
 	assertEqual(t, frame.InApp, true)
-	assertEqual(t, frame.Module, "sentry")
+	assertEqual(t, frame.Module, "github.com/getsentry/sentry-go")
 }
 
 func TestStacktraceFrameContext(t *testing.T) {

--- a/transport.go
+++ b/transport.go
@@ -2,43 +2,71 @@ package sentry
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/certifi/gocertifi"
 )
 
+const bufferSize = 5
+const defaultRetryAfter = time.Second * 60
+
 type Transport interface {
-	// Flush(timeout int) chan error
+	Flush(timeout time.Duration) bool
 	Configure(options ClientOptions)
-	SendEvent(event *Event) (*http.Response, error)
+	SendEvent(event *Event)
 }
 
 type HTTPTransport struct {
 	dsn       *Dsn
 	client    *http.Client
 	transport *http.Transport
+
+	buffer        chan *http.Request
+	disabledUntil time.Time
+
+	wg    sync.WaitGroup
+	start sync.Once
 }
 
 func (t *HTTPTransport) Configure(options ClientOptions) {
-	// TODO: Implement proxies/ca_certs here
-	dsn, _ := NewDsn(options.Dsn)
+	dsn, err := NewDsn(options.Dsn)
+	if err != nil {
+		debugger.Printf("%v\n", err)
+		return
+	}
 	t.dsn = dsn
-	t.transport = &http.Transport{}
+	t.buffer = make(chan *http.Request, bufferSize)
+
+	if options.HTTPTransport != nil {
+		t.transport = options.HTTPTransport
+	} else {
+		t.transport = &http.Transport{
+			Proxy:           t.getProxyConfig(options),
+			TLSClientConfig: t.getTLSConfig(options),
+		}
+	}
+
 	t.client = &http.Client{
 		Transport: t.transport,
 	}
+
+	t.start.Do(func() {
+		go t.worker()
+	})
 }
 
-func (t *HTTPTransport) SendEvent(event *Event) (*http.Response, error) {
-	if t.dsn == nil {
-		return nil, nil
+func (t *HTTPTransport) SendEvent(event *Event) {
+	if t.dsn == nil || time.Now().Before(t.disabledUntil) {
+		return
 	}
 
 	body, _ := json.Marshal(event)
-
-	dbg, _ := json.MarshalIndent(event, "", "  ")
-	fmt.Println(string(dbg))
 
 	request, _ := http.NewRequest(
 		http.MethodPost,
@@ -50,14 +78,104 @@ func (t *HTTPTransport) SendEvent(event *Event) (*http.Response, error) {
 		request.Header.Set(headerKey, headerValue)
 	}
 
-	response, err := t.client.Do(request)
+	debugger.Printf(
+		"Sending %s event [%s] to %s project: %d\n",
+		event.Level,
+		event.EventID,
+		t.dsn.host,
+		t.dsn.projectID,
+	)
 
-	if err != nil {
-		panic(err)
+	select {
+	case t.buffer <- request:
+		t.wg.Add(1)
+	default:
+		// worker would block, drop the packet
 	}
-	defer response.Body.Close()
-	body, _ = ioutil.ReadAll(response.Body)
-	fmt.Println(string(body))
+}
 
-	return response, err
+func (t *HTTPTransport) Flush(timeout time.Duration) bool {
+	c := make(chan struct{})
+
+	go func() {
+		t.wg.Wait()
+		close(c)
+	}()
+
+	select {
+	case <-c:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (t *HTTPTransport) getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error) {
+	if options.HTTPSProxy != "" {
+		return func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(options.HTTPSProxy)
+		}
+	} else if options.HTTPProxy != "" {
+		return func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(options.HTTPProxy)
+		}
+	}
+
+	return http.ProxyFromEnvironment
+}
+
+func (t *HTTPTransport) getTLSConfig(options ClientOptions) *tls.Config {
+	if options.CaCerts != nil {
+		return &tls.Config{
+			RootCAs: options.CaCerts,
+		}
+	}
+
+	rootCAs, err := gocertifi.CACerts()
+	if err != nil {
+		debugger.Printf("Coudnt load CA Certificates: %v\n", err)
+	}
+	return &tls.Config{
+		RootCAs: rootCAs,
+	}
+}
+
+func (t *HTTPTransport) worker() {
+	for request := range t.buffer {
+		if time.Now().Before(t.disabledUntil) {
+			t.wg.Done()
+			continue
+		}
+
+		response, err := t.client.Do(request)
+
+		if err != nil {
+			debugger.Printf("There was an issue with sending an event: %v", err)
+		}
+
+		if response != nil && response.StatusCode == http.StatusTooManyRequests {
+			t.disabledUntil = time.Now().Add(retryAfter(time.Now(), response))
+			debugger.Printf("Too many requests, backing off till: %s\n", t.disabledUntil)
+		}
+
+		t.wg.Done()
+	}
+}
+
+func retryAfter(now time.Time, r *http.Response) time.Duration {
+	retryAfterHeader := r.Header["Retry-After"]
+
+	if retryAfterHeader == nil {
+		return defaultRetryAfter
+	}
+
+	if date, err := time.Parse(time.RFC1123, retryAfterHeader[0]); err == nil {
+		return date.Sub(now)
+	}
+
+	if seconds, err := strconv.Atoi(retryAfterHeader[0]); err == nil {
+		return time.Second * time.Duration(seconds)
+	}
+
+	return defaultRetryAfter
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,40 @@
+package sentry
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRetryAfterNoHeader(t *testing.T) {
+	r := http.Response{}
+	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)
+}
+
+func TestRetryAfterIncorrectHeader(t *testing.T) {
+	r := http.Response{
+		Header: map[string][]string{
+			"Retry-After": {"x"},
+		},
+	}
+	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)
+}
+
+func TestRetryAfterDelayHeader(t *testing.T) {
+	r := http.Response{
+		Header: map[string][]string{
+			"Retry-After": {"1337"},
+		},
+	}
+	assertEqual(t, retryAfter(time.Now(), &r), time.Second*1337)
+}
+
+func TestRetryAfterDateHeader(t *testing.T) {
+	now, _ := time.Parse(time.RFC1123, "Wed, 21 Oct 2015 07:28:00 GMT")
+	r := http.Response{
+		Header: map[string][]string{
+			"Retry-After": {"Wed, 21 Oct 2015 07:28:13 GMT"},
+		},
+	}
+	assertEqual(t, retryAfter(now, &r), time.Second*13)
+}

--- a/util.go
+++ b/util.go
@@ -3,6 +3,8 @@ package sentry
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -14,4 +16,10 @@ func uuid() string {
 	id[8] &= 0x3F // clear variant
 	id[8] |= 0x80 // set to IETF variant
 	return hex.EncodeToString(id)
+}
+
+// nolint: deadcode
+func prettyPrint(data interface{}) {
+	dbg, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Println(string(dbg))
 }


### PR DESCRIPTION
What default transport should be able to do:
- DONE: queue events delivery
- DONE: drop events after queue is filled (30 requests)
- DONE: allow for knowing when everything was sent (`flush`)
- DONE: blocks the queue when server returns `429` using `Retry-After` header or 60sec default
- DONE: allow for configuring proxy and custom ssl certificated
- DONE: log to a debugger when server responds with error