### PR TITLE
build: Bump version when releasing with Craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,7 +1,7 @@
 github:
   owner: getsentry
   repo: sentry-go
-preReleaseCommand: ""
+preReleaseCommand: bash scripts/craft-pre-release.sh
 changelogPolicy: simple
 targets:
   - name: github

--- a/scripts/craft-pre-release.sh
+++ b/scripts/craft-pre-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eux
+
+SCRIPT_DIR="$( dirname "$0" )"
+cd $SCRIPT_DIR/..
+
+function replace() {
+    ! grep "$2" $3
+    perl -i -pe "s/$1/$2/g" $3
+    grep "$2" $3  # verify that replacement was successful
+}
+
+if [ "$#" -eq 1 ]; then
+    OLD_VERSION=""
+    NEW_VERSION="${1}"
+elif [ "$#" -eq 2 ]; then
+    OLD_VERSION="${1}"
+    NEW_VERSION="${2}"
+else
+    echo "Illegal number of parameters"
+    exit 1
+fi
+
+replace "const Version = \"[\w.-]+\"" "const Version = \"$NEW_VERSION\"" ./sentry.go

--- a/sentry.go
+++ b/sentry.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version Sentry-Go SDK Version
-const Version = "0.0.1-beta.3"
+const Version = "0.0.1"
 
 // Init initializes whole SDK by creating new `Client` and binding it to the current `Hub`
 func Init(options ClientOptions) error {

--- a/sentry.go
+++ b/sentry.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version Sentry-Go SDK Version
-const Version = "0.0.1"
+const Version = "0.1.0"
 
 // Init initializes whole SDK by creating new `Client` and binding it to the current `Hub`
 func Init(options ClientOptions) error {


### PR DESCRIPTION
Bumping that "Version" in `sentry.go` is probably a job for Craft.

Should also take care of https://github.com/getsentry/sentry-go/issues/17