### PR TITLE
fix: Check for initialized Client in AddBreadcrumbs

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -181,14 +181,22 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 // The total number of breadcrumbs that can be recorded are limited by the
 // configuration on the client.
 func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
-	options := hub.Client().Options()
-	maxBreadcrumbs := defaultMaxBreadcrumbs
+	client := hub.Client()
 
-	if options.MaxBreadcrumbs != 0 {
-		maxBreadcrumbs = options.MaxBreadcrumbs
+	// If there's no client, just store it on the scope straight away
+	if client == nil {
+		hub.Scope().AddBreadcrumb(breadcrumb, maxBreadcrumbs)
+		return
 	}
 
-	if maxBreadcrumbs < 0 {
+	options := client.Options()
+	max := defaultMaxBreadcrumbs
+
+	if options.MaxBreadcrumbs != 0 {
+		max = options.MaxBreadcrumbs
+	}
+
+	if max < 0 {
 		return
 	}
 
@@ -203,7 +211,6 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 		}
 	}
 
-	max := maxBreadcrumbs
 	if max > maxBreadcrumbs {
 		max = maxBreadcrumbs
 	}

--- a/hub_test.go
+++ b/hub_test.go
@@ -221,6 +221,31 @@ func TestAddBreadcrumbSkipAllBreadcrumbsIfMaxBreadcrumbsIsLessThanZero(t *testin
 	assertEqual(t, len(scope.breadcrumbs), 0)
 }
 
+func TestAddBreadcrumbShouldNeverExceedMaxBreadcrumbsConst(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.MaxBreadcrumbs = 1000
+
+	breadcrumb := &Breadcrumb{Message: "Breadcrumb"}
+
+	for i := 0; i < 111; i++ {
+		hub.AddBreadcrumb(breadcrumb, nil)
+	}
+
+	assertEqual(t, len(scope.breadcrumbs), 100)
+}
+
+func TestAddBreadcrumbShouldWorkWithoutClient(t *testing.T) {
+	scope := NewScope()
+	hub := NewHub(nil, scope)
+
+	breadcrumb := &Breadcrumb{Message: "Breadcrumb"}
+	for i := 0; i < 111; i++ {
+		hub.AddBreadcrumb(breadcrumb, nil)
+	}
+
+	assertEqual(t, len(scope.breadcrumbs), 100)
+}
+
 func TestAddBreadcrumbCallsBeforeBreadcrumbCallback(t *testing.T) {
 	hub, client, scope := setupHubTest()
 	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb {


### PR DESCRIPTION
Otherwise, we get a segfault at https://github.com/getsentry/sentry-go/blob/master/hub.go#L184 when Client is not initialized (e.g., empty DSN)