### PR TITLE
Allow empty DSN instead of returning an error

### DIFF
--- a/client.go
+++ b/client.go
@@ -120,13 +120,14 @@ func NewClient(options ClientOptions) (*Client, error) {
 		options.Environment = os.Getenv("SENTRY_ENVIRONMENT")
 	}
 
-	dsn, err := NewDsn(options.Dsn)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if dsn == nil {
+	var dsn *Dsn
+	if options.Dsn != "" {
+		var err error
+		dsn, err = NewDsn(options.Dsn)
+		if err != nil {
+			return nil, err
+		}
+	} else {
 		Logger.Println("Sentry client initialized with an empty DSN")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+func TestNewClientAllowsEmptyDSN(t *testing.T) {
+	transport := &TransportMock{}
+	client, err := NewClient(ClientOptions{
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("expected no error when creating client without a DNS but got %v", err)
+	}
+
+	client.CaptureException(errors.New("custom error"), nil, &ScopeMock{})
+	assertEqual(t, transport.lastEvent.Exception[0].Value, "custom error")
+}
+
 type customComplexError struct {
 	Message string
 }


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry-go/blob/e3426d1877ca5368ddc0bfc112368a0c293fad0e/client.go#L130, it looks like the intent is to allow an empty DSN (e.g. when the `SENTRY_DSN` env var is not set).

The current behavior when the DSN is empty is to return an error from `NewClient()`. This PR allows the DSN to be empy.