### PR TITLE
Add SetTransaction() to Scope

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -28,6 +28,7 @@ type Scope struct {
 	extra           map[string]interface{}
 	fingerprint     []string
 	level           Level
+	transaction     string
 	request         Request
 	eventProcessors []EventProcessor
 }
@@ -135,6 +136,11 @@ func (scope *Scope) SetLevel(level Level) {
 	scope.level = level
 }
 
+// SetTransaction sets new transaction name for the current transaction.
+func (scope *Scope) SetTransaction(transactionName string) {
+	scope.transaction = transactionName
+}
+
 // Clone returns a copy of the current scope with all data copied over.
 func (scope *Scope) Clone() *Scope {
 	clone := NewScope()
@@ -219,6 +225,10 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 
 	if scope.level != "" {
 		event.Level = scope.level
+	}
+
+	if scope.transaction != "" {
+		event.Transaction = scope.transaction
 	}
 
 	if (reflect.DeepEqual(event.Request, Request{})) {

--- a/scope_test.go
+++ b/scope_test.go
@@ -297,6 +297,21 @@ func TestScopeSetLevelOverrides(t *testing.T) {
 	assertEqual(t, scope.level, LevelFatal)
 }
 
+func TestScopeSetTransaction(t *testing.T) {
+	scope := NewScope()
+	scope.SetTransaction("abc")
+
+	assertEqual(t, scope.transaction, "abc")
+}
+
+func TestScopeSetTransactionOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetTransaction("abc")
+	scope.SetTransaction("def")
+
+	assertEqual(t, scope.transaction, "def")
+}
+
 func TestAddBreadcrumbAddsBreadcrumb(t *testing.T) {
 	scope := NewScope()
 	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "test"}, maxBreadcrumbs)


### PR DESCRIPTION
We noticed that according to the [unified spec](https://docs.sentry.io/development/sdk-dev/unified-api/#scope), there should be an `AddTransaction()` method that exists on the `Scope` object, which is used to create an event.  This currently does not exist in `sentry-go`.  This was a feature that we needed on our own project, so we went ahead and implemented it in `sentry-go`.

Bitcoin donations welcome: 38tt2b58t7TE9FS1BgjuZGYNUhmhGpwZ2D 😆