### PR TITLE
fix: Retry event marshalling without contextual data if the first pass fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Retry event marshalling without contextual data if the first pass fails
+
 ## v0.2.1
 
 - fix: Run `Contextify` integration on `Threads` as well

--- a/transport.go
+++ b/transport.go
@@ -64,6 +64,34 @@ func retryAfter(now time.Time, r *http.Response) time.Duration {
 	return defaultRetryAfter
 }
 
+func getRequestBodyFromEvent(event *Event) []byte {
+	body, err := json.Marshal(event)
+	if err == nil {
+		return body
+	}
+
+	partialMarshallMessage := "Original event couldn't be marshalled. Succeeded by stripping the data " +
+		"that uses interface{} type. Please verify that the data you attach to the scope is serializable."
+	// Try to serialize the event, with all the contextudal data that allows for interface{} stripped.
+	event.Breadcrumbs = nil
+	event.Contexts = nil
+	event.Extra = map[string]interface{}{
+		"info": partialMarshallMessage,
+	}
+	body, err = json.Marshal(event)
+	if err == nil {
+		Logger.Println(partialMarshallMessage)
+		return body
+	}
+
+	// This should _only_ happen when Event.Exception[0].Stacktrace.Frames[0].Vars is unserializable
+	// Which won't ever happen, as we don't use it now (although it's the part of public interface accepted by Sentry)
+	// Juuust in case something, somehow goes uterly wrong.
+	Logger.Println("Event couldn't be marshalled, even with stripped contextual data. Skipping delivery. " +
+		"Please notify the SDK owners with possibly broken payload.")
+	return nil
+}
+
 // ================================
 // HTTPTransport
 // ================================
@@ -131,7 +159,10 @@ func (t *HTTPTransport) SendEvent(event *Event) {
 		return
 	}
 
-	body, _ := json.Marshal(event)
+	body := getRequestBodyFromEvent(event)
+	if body == nil {
+		return
+	}
 
 	request, _ := http.NewRequest(
 		http.MethodPost,
@@ -257,7 +288,10 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		return
 	}
 
-	body, _ := json.Marshal(event)
+	body := getRequestBodyFromEvent(event)
+	if body == nil {
+		return
+	}
 
 	request, _ := http.NewRequest(
 		http.MethodPost,

--- a/transport_test.go
+++ b/transport_test.go
@@ -6,6 +6,120 @@ import (
 	"time"
 )
 
+type unserializableType struct {
+	UnsupportedField func()
+}
+
+const basicEvent = "{\"message\":\"mkey\",\"sdk\":{},\"user\":{},\"request\":{}}"
+const enhancedEvent = "{\"extra\":{\"info\":\"Original event couldn't be marshalled. Succeeded by stripping " +
+	"the data that uses interface{} type. Please verify that the data you attach to the scope is serializable.\"}," +
+	"\"message\":\"mkey\",\"sdk\":{},\"user\":{},\"request\":{}}"
+
+func TestGetRequestBodyFromEventValid(t *testing.T) {
+	body := getRequestBodyFromEvent(&Event{
+		Message: "mkey",
+	})
+
+	got := string(body)
+	want := basicEvent
+
+	if got != want {
+		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
+	}
+}
+
+func TestGetRequestBodyFromEventInvalidBreadcrumbsField(t *testing.T) {
+	body := getRequestBodyFromEvent(&Event{
+		Message: "mkey",
+		Breadcrumbs: []*Breadcrumb{{
+			Data: map[string]interface{}{
+				"wat": unserializableType{},
+			},
+		}},
+	})
+
+	got := string(body)
+	want := enhancedEvent
+
+	if got != want {
+		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
+	}
+}
+
+func TestGetRequestBodyFromEventInvalidExtraField(t *testing.T) {
+	body := getRequestBodyFromEvent(&Event{
+		Message: "mkey",
+		Extra: map[string]interface{}{
+			"wat": unserializableType{},
+		},
+	})
+
+	got := string(body)
+	want := enhancedEvent
+
+	if got != want {
+		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
+	}
+}
+
+func TestGetRequestBodyFromEventInvalidContextField(t *testing.T) {
+	body := getRequestBodyFromEvent(&Event{
+		Message: "mkey",
+		Contexts: map[string]interface{}{
+			"wat": unserializableType{},
+		},
+	})
+
+	got := string(body)
+	want := enhancedEvent
+
+	if got != want {
+		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
+	}
+}
+
+func TestGetRequestBodyFromEventMultipleInvalidFields(t *testing.T) {
+	body := getRequestBodyFromEvent(&Event{
+		Message: "mkey",
+		Breadcrumbs: []*Breadcrumb{{
+			Data: map[string]interface{}{
+				"wat": unserializableType{},
+			},
+		}},
+		Extra: map[string]interface{}{
+			"wat": unserializableType{},
+		},
+		Contexts: map[string]interface{}{
+			"wat": unserializableType{},
+		},
+	})
+
+	got := string(body)
+	want := enhancedEvent
+
+	if got != want {
+		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
+	}
+}
+
+func TestGetRequestBodyFromEventCompletelyInvalid(t *testing.T) {
+	body := getRequestBodyFromEvent(&Event{
+		Exception: []Exception{{
+			Stacktrace: &Stacktrace{
+				Frames: []Frame{{
+					Vars: map[string]interface{}{
+						"wat": unserializableType{},
+					},
+				}},
+			},
+		}},
+	})
+
+	if body != nil {
+		t.Error("expected body to be nil")
+	}
+}
+
 func TestRetryAfterNoHeader(t *testing.T) {
 	r := http.Response{}
 	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-go/issues/44