### PR TITLE
fix: Include url.Parse error in DsnParseError

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -52,7 +52,7 @@ func NewDsn(rawURL string) (*Dsn, error) {
 	// Parse
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, &DsnParseError{"invalid url"}
+		return nil, &DsnParseError{fmt.Sprintf("invalid url: %v", err)}
 	}
 
 	// Scheme


### PR DESCRIPTION
Go 1.11.13 and 1.12.8 received backported fixes for security issues with
url.Parse. One of the fixes includes stricter port validation.

With those minor versions of Go running in Travis,
TestInvalidDsnInvalidPort fails because url.Parse returns an error when
it previously didn't, thus NewDsn returns &DsnParseError{"invalid url"}
instead of &DsnParseError{"invalid port"}.

Including the error from url.Parse in the message both provides more
context for SDK users to understand why their DSN string was refused,
and fixes the test because "invalid port" is part of the now included
error message from url.Parse.

For reference, the backports are:

- https://github.com/golang/go/issues/33632
- https://github.com/golang/go/issues/33633