### PR TITLE
misc: Compile regexps only once

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -11,6 +11,11 @@ import (
 
 const unknown string = "unknown"
 
+var (
+	isTestFileRegexp    = regexp.MustCompile(`getsentry/sentry-go/.+_test.go`)
+	isExampleFileRegexp = regexp.MustCompile(`getsentry/sentry-go/example/`)
+)
+
 // The module download is split into two parts: downloading the go.mod and downloading the actual code.
 // If you have dependencies only needed for tests, then they will show up in your go.mod,
 // and go get will download their go.mods, but it will not download their code.
@@ -199,8 +204,6 @@ func extractFrames(pcs []uintptr) []Frame {
 }
 
 func filterFrames(frames []Frame) []Frame {
-	isTestFileRegexp := regexp.MustCompile(`getsentry/sentry-go/.+_test.go`)
-	isExampleFileRegexp := regexp.MustCompile(`getsentry/sentry-go/example/`)
 	filteredFrames := make([]Frame, 0, len(frames))
 
 	for _, frame := range frames {

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -34,6 +34,12 @@ func TestNewStacktrace(t *testing.T) {
 	assertEqual(t, stacktrace.Frames[1].Function, "Trace")
 }
 
+func BenchmarkNewStacktrace(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Trace()
+	}
+}
+
 func TestStacktraceFrame(t *testing.T) {
 	_, callerFile, _, _ := runtime.Caller(0)
 	dir, _ := filepath.Split(callerFile)


### PR DESCRIPTION
It is unnecessary to compile the same regexps over and over with every
call to `filterFrames`.

This improves the performance of `NewStacktrace()` reducing both CPU time
and memory allocation.

```
$ go1.11.13 test -run=- -count=5 -bench=. -benchmem | tee old.txt
$ # make changes ...
$ go1.11.13 test -run=- -count=5 -bench=. -benchmem | tee new.txt
$ benchstat old.txt new.txt
name             old time/op    new time/op    delta
NewStacktrace-8    54.0µs ± 0%    12.6µs ± 1%  -76.73%  (p=0.008 n=5+5)

name             old alloc/op   new alloc/op   delta
NewStacktrace-8    92.1kB ± 0%     7.3kB ± 0%  -92.08%  (p=0.008 n=5+5)

name             old allocs/op  new allocs/op  delta
NewStacktrace-8      92.0 ± 0%      15.0 ± 0%  -83.70%  (p=0.008 n=5+5)
```