### PR TITLE
Ensure go.mod is up-to-date via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
 
 env:
   - GO111MODULE=on
+  - GOFLAGS=-mod=readonly
 
 before_install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0


### PR DESCRIPTION
This prevents introducing new dependencies without a proper update to
go.mod, and also fails the Travis build in the presence of extraneous
dependencies in go.mod after e.g. an old dependency gets removed.

From `go help modules`:

> The -mod build flag provides additional control over updating and use of go.mod.
>
> If invoked with -mod=readonly, the go command is disallowed from the implicit
> automatic updating of go.mod described above. Instead, it fails when any changes
> to go.mod are needed. This setting is most useful to check that go.mod does
> not need updates, such as in a continuous integration and testing system.
> The "go get" command remains permitted to update go.mod even with -mod=readonly,
> and the "go mod" commands do not take the -mod flag (or any other build flags).