### PR TITLE
docs: Update links to event-playloads

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -23,7 +23,7 @@ const (
 	LevelFatal   Level = "fatal"
 )
 
-// https://docs.sentry.io/development/sdk-dev/interfaces/sdk/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/sdk/
 type SdkInfo struct {
 	Name         string       `json:"name,omitempty"`
 	Version      string       `json:"version,omitempty"`
@@ -41,7 +41,7 @@ type SdkPackage struct {
 // plus it could just be `map[string]interface{}` then
 type BreadcrumbHint map[string]interface{}
 
-// https://docs.sentry.io/development/sdk-dev/interfaces/breadcrumbs/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/
 type Breadcrumb struct {
 	Category  string                 `json:"category,omitempty"`
 	Data      map[string]interface{} `json:"data,omitempty"`
@@ -51,7 +51,7 @@ type Breadcrumb struct {
 	Type      string                 `json:"type,omitempty"`
 }
 
-// https://docs.sentry.io/development/sdk-dev/interfaces/user/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/user/
 type User struct {
 	Email     string `json:"email,omitempty"`
 	ID        string `json:"id,omitempty"`
@@ -59,7 +59,7 @@ type User struct {
 	Username  string `json:"username,omitempty"`
 }
 
-// https://docs.sentry.io/development/sdk-dev/interfaces/http/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/request/
 type Request struct {
 	URL         string            `json:"url,omitempty"`
 	Method      string            `json:"method,omitempty"`
@@ -113,7 +113,7 @@ func (r Request) FromHTTPRequest(request *http.Request) Request {
 	return r
 }
 
-// https://docs.sentry.io/development/sdk-dev/interfaces/exception/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/exception/
 type Exception struct {
 	Type          string      `json:"type,omitempty"`
 	Value         string      `json:"value,omitempty"`
@@ -124,7 +124,7 @@ type Exception struct {
 
 type EventID string
 
-// https://docs.sentry.io/development/sdk-dev/attributes/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/
 type Event struct {
 	Breadcrumbs []*Breadcrumb          `json:"breadcrumbs,omitempty"`
 	Contexts    map[string]interface{} `json:"contexts,omitempty"`

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -134,7 +134,7 @@ func extractPcs(method reflect.Value) []uintptr {
 	return pcs
 }
 
-// https://docs.sentry.io/development/sdk-dev/interfaces/stacktrace/
+// https://docs.sentry.io/development/sdk-dev/event-payloads/stacktrace/
 type Frame struct {
 	Function    string                 `json:"function,omitempty"`
 	Symbol      string                 `json:"symbol,omitempty"`


### PR DESCRIPTION
Each exposed struct has a link to the docs that lead to a 404.