### PR TITLE
fix: Correctly store last event id

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -37,7 +37,7 @@ var currentHub = NewHub(nil, NewScope()) // nolint: gochecknoglobals
 type Hub struct {
 	mu          sync.RWMutex
 	stack       *stack
-	lastEventID EventID
+	lastEventID *EventID
 }
 
 type layer struct {
@@ -81,7 +81,7 @@ func CurrentHub() *Hub {
 }
 
 // LastEventID returns an ID of last captured event for the current `Hub`.
-func (hub *Hub) LastEventID() EventID {
+func (hub *Hub) LastEventID() *EventID {
 	return hub.lastEventID
 }
 
@@ -210,7 +210,9 @@ func (hub *Hub) CaptureEvent(event *Event) *EventID {
 	if client == nil || scope == nil {
 		return nil
 	}
-	return client.CaptureEvent(event, nil, scope)
+	eventID := client.CaptureEvent(event, nil, scope)
+	hub.lastEventID = eventID
+	return eventID
 }
 
 // CaptureMessage calls the method of a same name on currently bound `Client` instance
@@ -221,7 +223,9 @@ func (hub *Hub) CaptureMessage(message string) *EventID {
 	if client == nil || scope == nil {
 		return nil
 	}
-	return client.CaptureMessage(message, nil, scope)
+	eventID := client.CaptureMessage(message, nil, scope)
+	hub.lastEventID = eventID
+	return eventID
 }
 
 // CaptureException calls the method of a same name on currently bound `Client` instance
@@ -232,7 +236,9 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 	if client == nil || scope == nil {
 		return nil
 	}
-	return client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
+	eventID := client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
+	hub.lastEventID = eventID
+	return eventID
 }
 
 // AddBreadcrumb records a new breadcrumb.

--- a/hub.go
+++ b/hub.go
@@ -37,7 +37,7 @@ var currentHub = NewHub(nil, NewScope()) // nolint: gochecknoglobals
 type Hub struct {
 	mu          sync.RWMutex
 	stack       *stack
-	lastEventID *EventID
+	lastEventID EventID
 }
 
 type layer struct {
@@ -81,7 +81,7 @@ func CurrentHub() *Hub {
 }
 
 // LastEventID returns an ID of last captured event for the current `Hub`.
-func (hub *Hub) LastEventID() *EventID {
+func (hub *Hub) LastEventID() EventID {
 	return hub.lastEventID
 }
 
@@ -211,7 +211,11 @@ func (hub *Hub) CaptureEvent(event *Event) *EventID {
 		return nil
 	}
 	eventID := client.CaptureEvent(event, nil, scope)
-	hub.lastEventID = eventID
+	if eventID != nil {
+		hub.lastEventID = *eventID
+	} else {
+		hub.lastEventID = ""
+	}
 	return eventID
 }
 
@@ -224,7 +228,11 @@ func (hub *Hub) CaptureMessage(message string) *EventID {
 		return nil
 	}
 	eventID := client.CaptureMessage(message, nil, scope)
-	hub.lastEventID = eventID
+	if eventID != nil {
+		hub.lastEventID = *eventID
+	} else {
+		hub.lastEventID = ""
+	}
 	return eventID
 }
 
@@ -237,7 +245,11 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 		return nil
 	}
 	eventID := client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
-	hub.lastEventID = eventID
+	if eventID != nil {
+		hub.lastEventID = *eventID
+	} else {
+		hub.lastEventID = ""
+	}
 	return eventID
 }
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -173,8 +173,21 @@ func TestConfigureScope(t *testing.T) {
 
 func TestLastEventID(t *testing.T) {
 	uuid := EventID(uuid())
-	hub := &Hub{lastEventID: uuid}
-	assertEqual(t, uuid, hub.LastEventID())
+	hub := &Hub{lastEventID: &uuid}
+	assertEqual(t, &uuid, hub.LastEventID())
+}
+
+func TestLastEventIDUpdatesAfterCaptures(t *testing.T) {
+	hub, _, _ := setupHubTest()
+
+	messageID := hub.CaptureMessage("wat")
+	assertEqual(t, messageID, hub.LastEventID())
+
+	errorID := hub.CaptureException(fmt.Errorf("wat"))
+	assertEqual(t, errorID, hub.LastEventID())
+
+	eventID := hub.CaptureEvent(&Event{Message: "wat"})
+	assertEqual(t, eventID, hub.LastEventID())
 }
 
 func TestLayerAccessingEmptyStack(t *testing.T) {

--- a/hub_test.go
+++ b/hub_test.go
@@ -173,21 +173,21 @@ func TestConfigureScope(t *testing.T) {
 
 func TestLastEventID(t *testing.T) {
 	uuid := EventID(uuid())
-	hub := &Hub{lastEventID: &uuid}
-	assertEqual(t, &uuid, hub.LastEventID())
+	hub := &Hub{lastEventID: uuid}
+	assertEqual(t, uuid, hub.LastEventID())
 }
 
 func TestLastEventIDUpdatesAfterCaptures(t *testing.T) {
 	hub, _, _ := setupHubTest()
 
 	messageID := hub.CaptureMessage("wat")
-	assertEqual(t, messageID, hub.LastEventID())
+	assertEqual(t, *messageID, hub.LastEventID())
 
 	errorID := hub.CaptureException(fmt.Errorf("wat"))
-	assertEqual(t, errorID, hub.LastEventID())
+	assertEqual(t, *errorID, hub.LastEventID())
 
 	eventID := hub.CaptureEvent(&Event{Message: "wat"})
-	assertEqual(t, eventID, hub.LastEventID())
+	assertEqual(t, *eventID, hub.LastEventID())
 }
 
 func TestLayerAccessingEmptyStack(t *testing.T) {

--- a/sentry.go
+++ b/sentry.go
@@ -116,7 +116,7 @@ func Flush(timeout time.Duration) bool {
 }
 
 // LastEventID returns an ID of last captured event.
-func LastEventID() EventID {
+func LastEventID() *EventID {
 	hub := CurrentHub()
 	return hub.LastEventID()
 }

--- a/sentry.go
+++ b/sentry.go
@@ -116,7 +116,7 @@ func Flush(timeout time.Duration) bool {
 }
 
 // LastEventID returns an ID of last captured event.
-func LastEventID() *EventID {
+func LastEventID() EventID {
 	hub := CurrentHub()
 	return hub.LastEventID()
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-go/issues/98

I know it requires a change in `Hub` struct and `LastEventID` signature, but this method was never implemented in the first place and we are still in `0.x` so I think it should be fine.