### PR TITLE
Add support for path prefixes in the DSN

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -149,6 +149,9 @@ func (dsn Dsn) StoreAPIURL() *url.URL {
 	if dsn.port != dsn.scheme.defaultPort() {
 		rawURL += fmt.Sprintf(":%d", dsn.port)
 	}
+	if dsn.path != "" {
+		rawURL += dsn.path
+	}
 	rawURL += fmt.Sprintf("/api/%d/store/", dsn.projectID)
 	parsedURL, _ := url.Parse(rawURL)
 	return parsedURL

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -84,6 +84,16 @@ func TestValidDsnNoPort(t *testing.T) {
 	assertEqual(t, "http://domain/api/42/store/", dsn.StoreAPIURL().String())
 }
 
+func TestValidDsnPrefixed(t *testing.T) {
+	url := "http://username@domain/prefixed/42"
+	dsn, err := NewDsn(url)
+
+	if err != nil {
+		t.Error("expected dsn to be correctly created")
+	}
+	assertEqual(t, "http://domain/prefixed/api/42/store/", dsn.StoreAPIURL().String())
+}
+
 func TestValidDsnInsecureNoPort(t *testing.T) {
 	url := "https://username@domain/42"
 	dsn, err := NewDsn(url)


### PR DESCRIPTION
Port of a [feature from the JavaScript SDK](https://github.com/getsentry/sentry-javascript/blob/645ff532941d9a23bb6531c6305e99544b356502/packages/core/src/api.ts#L48) which supports DSNs with a
custom path prefix (e.g. http://user@host/prefixed/42).