### PR TITLE
build: Reset go.mod version to 1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.13
+go 1.11
 
 require (
 	github.com/ajg/form v1.5.1 // indirect


### PR DESCRIPTION
Currently the go tool use the Go version defined in go.mod to check for
uses of features that did not exist prior to the specified version.

Additionally, when a build fails, that version may end up in the error
message.

To prevent confusion for SDK users, set the version to the oldest Go
release supported by sentry-go.

Fixes #83 