### PR TITLE
test: Overhaul DSN tests

### DIFF
--- a/dsn_test.go
+++ b/dsn_test.go
@@ -3,36 +3,115 @@ package sentry
 import (
 	"encoding/json"
 	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestDsnParsing(t *testing.T) {
-	url := "https://username:password@domain:8888/foo/bar/23"
-	dsn, err := NewDsn(url)
-	if err != nil {
-		t.Error("expected dsn to be correctly created")
-	}
-	assertEqual(t, schemeHTTPS, dsn.scheme)
-	assertEqual(t, dsn.publicKey, "username")
-	assertEqual(t, dsn.secretKey, "password")
-	assertEqual(t, dsn.host, "domain")
-	assertEqual(t, dsn.path, "/foo/bar")
-	assertEqual(t, dsn.String(), url)
-	assertEqual(t, dsn.port, 8888)
-	assertEqual(t, dsn.projectID, 23)
+type DsnTest struct {
+	in  string
+	dsn *Dsn   // expected value after parsing
+	url string // expected Store API URL
 }
 
-func TestDsnDefaultPort(t *testing.T) {
-	dsn, _ := NewDsn("https://u@d:1337/23")
-	assertEqual(t, dsn.port, 1337)
-	dsn, _ = NewDsn("https://u@d/23")
-	assertEqual(t, dsn.port, 443)
-	dsn, _ = NewDsn("http://u@d/23")
-	assertEqual(t, dsn.port, 80)
+//nolint: gochecknoglobals
+var dsnTests = map[string]DsnTest{
+	"AllFields": {
+		in: "https://public:secret@domain:8888/foo/bar/42",
+		dsn: &Dsn{
+			scheme:    schemeHTTPS,
+			publicKey: "public",
+			secretKey: "secret",
+			host:      "domain",
+			port:      8888,
+			path:      "/foo/bar",
+			projectID: 42,
+		},
+		url: "https://domain:8888/foo/bar/api/42/store/",
+	},
+	"MinimalSecure": {
+		in: "https://public@domain/42",
+		dsn: &Dsn{
+			scheme:    schemeHTTPS,
+			publicKey: "public",
+			host:      "domain",
+			port:      443,
+			projectID: 42,
+		},
+		url: "https://domain/api/42/store/",
+	},
+	"MinimalInsecure": {
+		in: "http://public@domain/42",
+		dsn: &Dsn{
+			scheme:    schemeHTTP,
+			publicKey: "public",
+			host:      "domain",
+			port:      80,
+			projectID: 42,
+		},
+		url: "http://domain/api/42/store/",
+	},
+}
+
+//nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
+func TestNewDsn(t *testing.T) {
+	for name, tt := range dsnTests {
+		t.Run(name, func(t *testing.T) {
+			dsn, err := NewDsn(tt.in)
+			if err != nil {
+				t.Fatalf("NewDsn() error: %q", err)
+			}
+			// Internal fields
+			if diff := cmp.Diff(tt.dsn, dsn, cmp.AllowUnexported(Dsn{})); diff != "" {
+				t.Errorf("NewDsn() mismatch (-want +got):\n%s", diff)
+			}
+			// Store API URL
+			url := dsn.StoreAPIURL().String()
+			if diff := cmp.Diff(tt.url, url); diff != "" {
+				t.Errorf("dsn.StoreAPIURL() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type invalidDsnTest struct {
+	in  string
+	err string // expected substring of the error
+}
+
+//nolint: gochecknoglobals
+var invalidDsnTests = map[string]invalidDsnTest{
+	"NoScheme":     {"public:secret@:8888/42", "invalid scheme"},
+	"NoPublicKey":  {"https://:secret@domain:8888/42", "empty username"},
+	"NoHost":       {"https://public:secret@:8888/42", "empty host"},
+	"NoProjectID":  {"https://public:secret@domain:8888/", "empty project id"},
+	"BadURL":       {"!@#$%^&*()", "invalid url"},
+	"BadScheme":    {"ftp://public:secret@domain:8888/1", "invalid scheme"},
+	"BadProjectID": {"https://public:secret@domain:8888/wbvdf7^W#$", "invalid project id"},
+	"BadPort":      {"https://public:secret@domain:wat/42", "invalid port"},
+}
+
+//nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
+func TestNewDsnInvalidInput(t *testing.T) {
+	for name, tt := range invalidDsnTests {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewDsn(tt.in)
+			if err == nil {
+				t.Fatalf("got nil, want error with %q", tt.err)
+			}
+			if _, ok := err.(*DsnParseError); !ok {
+				t.Errorf("got %T, want %T", err, (*DsnParseError)(nil))
+			}
+			if !strings.Contains(err.Error(), tt.err) {
+				t.Errorf("%q does not contain %q", err.Error(), tt.err)
+			}
+		})
+	}
 }
 
 func TestDsnSerializeDeserialize(t *testing.T) {
-	url := "https://username:password@domain:8888/foo/bar/23"
+	url := "https://public:secret@domain:8888/foo/bar/42"
 	dsn, dsnErr := NewDsn(url)
 	serialized, _ := json.Marshal(dsn)
 	var deserialized Dsn
@@ -44,15 +123,15 @@ func TestDsnSerializeDeserialize(t *testing.T) {
 	if dsnErr != nil {
 		t.Error("expected NewDsn to not return error")
 	}
-	assertEqual(t, "\"https://username:password@domain:8888/foo/bar/23\"", string(serialized))
+	assertEqual(t, `"https://public:secret@domain:8888/foo/bar/42"`, string(serialized))
 	assertEqual(t, url, deserialized.String())
 }
 
 func TestDsnDeserializeInvalidJSON(t *testing.T) {
 	var invalidJSON Dsn
-	invalidJSONErr := json.Unmarshal([]byte("\"whoops"), &invalidJSON)
+	invalidJSONErr := json.Unmarshal([]byte(`"whoops`), &invalidJSON)
 	var invalidDsn Dsn
-	invalidDsnErr := json.Unmarshal([]byte("\"http://wat\""), &invalidDsn)
+	invalidDsnErr := json.Unmarshal([]byte(`"http://wat"`), &invalidDsn)
 
 	if invalidJSONErr == nil {
 		t.Error("expected dsn unmarshal to return error")
@@ -62,137 +141,15 @@ func TestDsnDeserializeInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestValidDsnInsecure(t *testing.T) {
-	url := "http://username@domain:8888/42"
+func TestRequestHeadersWithoutSecretKey(t *testing.T) {
+	url := "https://public@domain/42"
 	dsn, err := NewDsn(url)
-
 	if err != nil {
-		t.Error("expected dsn to be correctly created")
+		t.Fatal(err)
 	}
-	assertEqual(t, url, dsn.String())
-}
-
-func TestValidDsnNoPort(t *testing.T) {
-	url := "http://username@domain/42"
-	dsn, err := NewDsn(url)
-
-	if err != nil {
-		t.Error("expected dsn to be correctly created")
-	}
-	assertEqual(t, 80, dsn.port)
-	assertEqual(t, url, dsn.String())
-	assertEqual(t, "http://domain/api/42/store/", dsn.StoreAPIURL().String())
-}
-
-func TestValidDsnPrefixed(t *testing.T) {
-	url := "http://username@domain/prefixed/42"
-	dsn, err := NewDsn(url)
-
-	if err != nil {
-		t.Error("expected dsn to be correctly created")
-	}
-	assertEqual(t, "http://domain/prefixed/api/42/store/", dsn.StoreAPIURL().String())
-}
-
-func TestValidDsnInsecureNoPort(t *testing.T) {
-	url := "https://username@domain/42"
-	dsn, err := NewDsn(url)
-
-	if err != nil {
-		t.Error("expected dsn to be correctly created")
-	}
-	assertEqual(t, 443, dsn.port)
-	assertEqual(t, url, dsn.String())
-	assertEqual(t, "https://domain/api/42/store/", dsn.StoreAPIURL().String())
-}
-
-func TestValidDsnNoPassword(t *testing.T) {
-	url := "https://username@domain:8888/42"
-	dsn, err := NewDsn(url)
-
-	if err != nil {
-		t.Error("expected dsn to be correctly created")
-	}
-	assertEqual(t, url, dsn.String())
-	assertEqual(t, "https://domain:8888/api/42/store/", dsn.StoreAPIURL().String())
-}
-
-func TestInvalidDsnInvalidUrl(t *testing.T) {
-	_, err := NewDsn("!@#$%^&*()")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "invalid url")
-}
-
-func TestInvalidDsnInvalidScheme(t *testing.T) {
-	_, err := NewDsn("ftp://username:password@domain:8888/1")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "invalid scheme")
-}
-
-func TestInvalidDsnNoUsername(t *testing.T) {
-	_, err := NewDsn("https://:password@domain:8888/23")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "empty username")
-}
-
-func TestInvalidDsnNoHost(t *testing.T) {
-	_, err := NewDsn("https://username:password@:8888/42")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "empty host")
-}
-
-func TestInvalidDsnInvalidPort(t *testing.T) {
-	_, err := NewDsn("https://username:password@domain:wat/42")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "invalid port")
-}
-
-func TestInvalidDsnNoProjectId(t *testing.T) {
-	_, err := NewDsn("https://username:password@domain:8888/")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "empty project id")
-}
-
-func TestInvalidDsnInvalidProjectId(t *testing.T) {
-	_, err := NewDsn("https://username:password@domain:8888/wbvdf7^W#$")
-	_, ok := err.(*DsnParseError)
-
-	if ok != true {
-		t.Error("expected error to be of type DsnParseError")
-	}
-	assertStringContains(t, err.Error(), "invalid project id")
-}
-
-func TestRequestHeadersWithoutPassword(t *testing.T) {
-	url := "https://username@domain:8888/23"
-	dsn, _ := NewDsn(url)
 	headers := dsn.RequestHeaders()
 	authRegexp := regexp.MustCompile("^Sentry sentry_version=7, sentry_timestamp=\\d+, " +
-		"sentry_client=sentry.go/.+, sentry_key=username$")
+		"sentry_client=sentry.go/.+, sentry_key=public$")
 
 	if len(headers) != 2 {
 		t.Error("expected request to have 2 headers")
@@ -203,12 +160,15 @@ func TestRequestHeadersWithoutPassword(t *testing.T) {
 	}
 }
 
-func TestRequestHeadersWithPassword(t *testing.T) {
-	url := "https://username:secret@domain:8888/23"
-	dsn, _ := NewDsn(url)
+func TestRequestHeadersWithSecretKey(t *testing.T) {
+	url := "https://public:secret@domain/42"
+	dsn, err := NewDsn(url)
+	if err != nil {
+		t.Fatal(err)
+	}
 	headers := dsn.RequestHeaders()
 	authRegexp := regexp.MustCompile("^Sentry sentry_version=7, sentry_timestamp=\\d+, " +
-		"sentry_client=sentry.go/.+, sentry_key=username, sentry_secret=secret$")
+		"sentry_client=sentry.go/.+, sentry_key=public, sentry_secret=secret$")
 
 	if len(headers) != 2 {
 		t.Error("expected request to have 2 headers")

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -82,14 +82,20 @@ type invalidDsnTest struct {
 
 //nolint: gochecknoglobals
 var invalidDsnTests = map[string]invalidDsnTest{
-	"NoScheme":     {"public:secret@:8888/42", "invalid scheme"},
-	"NoPublicKey":  {"https://:secret@domain:8888/42", "empty username"},
-	"NoHost":       {"https://public:secret@:8888/42", "empty host"},
-	"NoProjectID":  {"https://public:secret@domain:8888/", "empty project id"},
-	"BadURL":       {"!@#$%^&*()", "invalid url"},
-	"BadScheme":    {"ftp://public:secret@domain:8888/1", "invalid scheme"},
-	"BadProjectID": {"https://public:secret@domain:8888/wbvdf7^W#$", "invalid project id"},
-	"BadPort":      {"https://public:secret@domain:wat/42", "invalid port"},
+	"Empty":     {"", "invalid scheme"},
+	"NoScheme1": {"public:secret@:8888/42", "invalid scheme"},
+	// FIXME: NoScheme2's error message is inconsistent with NoScheme1; consider
+	// avoiding leaking errors from url.Parse.
+	"NoScheme2":     {"://public:secret@:8888/42", "missing protocol scheme"},
+	"NoPublicKey":   {"https://:secret@domain:8888/42", "empty username"},
+	"NoHost":        {"https://public:secret@:8888/42", "empty host"},
+	"NoProjectID1":  {"https://public:secret@domain:8888/", "empty project id"},
+	"NoProjectID2":  {"https://public:secret@domain:8888", "empty project id"},
+	"BadURL":        {"!@#$%^&*()", "invalid url"},
+	"BadScheme":     {"ftp://public:secret@domain:8888/1", "invalid scheme"},
+	"BadProjectID":  {"https://public:secret@domain:8888/wbvdf7^W#$", "invalid project id"},
+	"BadPort":       {"https://public:secret@domain:wat/42", "invalid port"},
+	"TrailingSlash": {"https://public:secret@domain:8888/42/", "invalid project id"},
 }
 
 //nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.4.0
 	github.com/go-errors/errors v1.0.1
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
+	github.com/google/go-cmp v0.3.1
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=


### PR DESCRIPTION
- Use cmp.Diff to compare values and print easy to read diffs on error.
- Use table tests to consistently check the same things for multiple
inputs. Previously, some tests omitted parts that were covered by
others.
- Use consistent names and values matching DSN concepts. Helps with
reading and understanding tests.
- Use raw strings to avoid escaping quotes.
- Do not ignore errors from NewDsn.