### PR TITLE
ref: extract magic number into a constant

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -159,8 +159,8 @@ func (dsn Dsn) StoreAPIURL() *url.URL {
 
 // RequestHeaders returns all the necessary headers that have to be used in the transport.
 func (dsn Dsn) RequestHeaders() map[string]string {
-	auth := fmt.Sprintf("Sentry sentry_version=%d, sentry_timestamp=%d, "+
-		"sentry_client=sentry.go/%s, sentry_key=%s", 7, time.Now().Unix(), Version, dsn.publicKey)
+	auth := fmt.Sprintf("Sentry sentry_version=%s, sentry_timestamp=%d, "+
+		"sentry_client=sentry.go/%s, sentry_key=%s", apiVersion, time.Now().Unix(), Version, dsn.publicKey)
 
 	if dsn.secretKey != "" {
 		auth = fmt.Sprintf("%s, sentry_secret=%s", auth, dsn.secretKey)

--- a/sentry.go
+++ b/sentry.go
@@ -5,8 +5,12 @@ import (
 	"time"
 )
 
-// Version Sentry-Go SDK Version
+// Version is the version of the sentry-go SDK.
 const Version = "0.3.1"
+
+// apiVersion is the minimum version of the Sentry API compatible with the
+// sentry-go SDK.
+const apiVersion = "7"
 
 // Init initializes whole SDK by creating new `Client` and binding it to the current `Hub`
 func Init(options ClientOptions) error {


### PR DESCRIPTION
Document what "7" means with an (unexported) constant.

Though unexported, the constant is of type string to accommodate possible future values that would not be a good fit for an int/number, e.g. "8.0".