### PR TITLE
style: Use '//nolint' when disabling linters

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 
 // Logger is an instance of log.Logger that is use to provide debug information about running Sentry Client
 // can be enabled by either using `Logger.SetOutput` directly or with `Debug` client option
-var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags) // nolint: gochecknoglobals
+var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags) //nolint: gochecknoglobals
 
 type EventProcessor func(event *Event, hint *EventHint) *Event
 
@@ -25,7 +25,7 @@ type EventModifier interface {
 	ApplyToEvent(event *Event, hint *EventHint) *Event
 }
 
-var globalEventProcessors []EventProcessor // nolint: gochecknoglobals
+var globalEventProcessors []EventProcessor //nolint: gochecknoglobals
 
 func AddGlobalEventProcessor(processor EventProcessor) {
 	globalEventProcessors = append(globalEventProcessors, processor)

--- a/hub.go
+++ b/hub.go
@@ -22,7 +22,7 @@ const defaultMaxBreadcrumbs = 30
 const maxBreadcrumbs = 100
 
 // Initial instance of the Hub that has no `Client` bound and an empty `Scope`
-var currentHub = NewHub(nil, NewScope()) // nolint: gochecknoglobals
+var currentHub = NewHub(nil, NewScope()) //nolint: gochecknoglobals
 
 // Hub is the central object that can manages scopes and clients.
 //

--- a/sourcereader_test.go
+++ b/sourcereader_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var input = [][]byte{
 	[]byte("line 1"),
 	[]byte("line 2"),

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -11,7 +11,7 @@ import (
 
 const unknown string = "unknown"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var (
 	isTestFileRegexp    = regexp.MustCompile(`getsentry/sentry-go/.+_test.go`)
 	isExampleFileRegexp = regexp.MustCompile(`getsentry/sentry-go/example/`)

--- a/util.go
+++ b/util.go
@@ -27,7 +27,7 @@ func fileExists(fileName string) bool {
 	return true
 }
 
-// nolint: deadcode, unused
+//nolint: deadcode, unused
 func prettyPrint(data interface{}) {
 	dbg, _ := json.MarshalIndent(data, "", "  ")
 	fmt.Println(string(dbg))


### PR DESCRIPTION
From https://github.com/golangci/golangci-lint#nolint
> Use //nolint instead of // nolint because machine-readable comments
> should have no space by Go convention.