### PR TITLE
ci(travis): Bump golangci-lint version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.19.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
 
 script:
-  - golangci-lint run
+  - golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
   - go build
   - go test
   - go test -race

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - GO111MODULE=on GOFLAGS=-mod=readonly
 
 before_install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.19.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
 
 script:
   - golangci-lint run


### PR DESCRIPTION
The current recommended installation steps use githubusercontent.com
instead of goreleaser.com.

Additionally, pin to a specific tagged version of the install script to
ensure reproducible installations of the tool.

Use latest available version 1.21.0.