### PR TITLE
ci(travis): Test more env and Go combinations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,33 @@
 sudo: false
 
 language: go
+
 go:
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - master
 
 env:
   - GO111MODULE=on GOFLAGS=-mod=readonly
+  - GO111MODULE=off
+
+jobs:
+  include:
+    - name: "Module support outside of GOPATH"
+      go: 1.13.x
+      before_script: >-
+        mv $GOPATH/src/github.com/getsentry/sentry-go ~/sentry-go &&
+        cd ~/sentry-go &&
+        export GOPATH= &&
+        go env GOPATH
+      script: >-
+        go test &&
+        go test -race
+  allow_failures:
+    - go: master
+    - name: "Module support outside of GOPATH"
+  fast_finish: true
 
 before_install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.19.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1


### PR DESCRIPTION
- Test against go@master to help us verify if the SDK will work with a
new Go release before the release is shipped. Failed builds are allowed,
i.e., they do not block PRs.

- Test with GO111MODULE=off and GO111MODULE=on, as our users could be
using Go Modules or not.

- Test code outside of GOPATH. It should be okay to work on sentry-go
either inside or outside of GOPATH (Module mode). *Temporarily* marked
to allow failures. This reproduces #100 in our CI environment.

Build matrix increases from 3 jobs to 2*4+1 = 9 jobs.