### PR TITLE
fix(stacktrace): Filter out internal SDK methods

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -206,7 +206,8 @@ func filterFrames(frames []Frame) []Frame {
 			continue
 		}
 		// sentry internal frames
-		if frame.Module == "github.com/getsentry/sentry-go" {
+		if frame.Module == "github.com/getsentry/sentry-go" ||
+			strings.HasPrefix(frame.Module, "github.com/getsentry/sentry-go.") {
 			continue
 		}
 		filteredFrames = append(filteredFrames, frame)

--- a/stacktrace_external_test.go
+++ b/stacktrace_external_test.go
@@ -104,6 +104,9 @@ func TestNewStacktrace(t *testing.T) {
 				},
 			},
 		}},
+		"StacktraceTestHelper": {sentry.StacktraceTestHelper{}.NewStacktrace, &sentry.Stacktrace{
+			Frames: []sentry.Frame{},
+		}},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -9,6 +9,12 @@ func NewStacktraceForTest() *Stacktrace {
 	return NewStacktrace()
 }
 
+type StacktraceTestHelper struct{}
+
+func (StacktraceTestHelper) NewStacktrace() *Stacktrace {
+	return NewStacktrace()
+}
+
 func TestFunctionName(t *testing.T) {
 	for _, test := range []struct {
 		skip int


### PR DESCRIPTION
The frame.Module field in its current form may contain entries like:
github.com/getsentry/sentry-go.(*Hub)
github.com/getsentry/sentry-go.(*Client)
github.com/getsentry/sentry-go.(*Client)

Taking those into account now.

Fixes up #123.