### PR TITLE
ci: Require go.mod to be tidy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
         run: go build ./...
       - name: Vet
         run: go vet ./...
+      - name: Check go.mod Tidiness
+        run: go mod tidy && git diff --exit-code
+        if: ${{ matrix.go == '1.16' }}
       - name: Test
         run: go test ./...
       - name: Test (race)


### PR DESCRIPTION
This helps us prevent accidentally having an inconsistent go.mod file
after changes to dependencies.