### PR TITLE
Fix TestConcurrentHubClone

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,7 @@ issues:
   exclude:
     - "not declared by package utf8"
     - "unicode/utf8/utf8.go"
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - prealloc

--- a/hub_test.go
+++ b/hub_test.go
@@ -355,7 +355,6 @@ func TestConcurrentHubClone(t *testing.T) {
 		// Mutate hub in the main goroutine.
 		hub.PushScope()
 		hub.PopScope()
-		hub.BindClient(nil)
 		hub.BindClient(client)
 		// Clone scope in a new Goroutine as documented in
 		// https://docs.sentry.io/platforms/go/goroutines/.


### PR DESCRIPTION
Temporarily binding the hub client to nil introduces the (unintended)
possibility of dropping events, as Hub.CaptureMessage and related
methods bail when their client is nil.

It was possible to reproduce the issue by running the tests many times
in a row with a command like:

go test -race -count 500 -failfast -run TestConcurrentHubClone

Fixes #132