### PR TITLE
fix: HTTPTransport.Flush panic and data race

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -1,7 +1,12 @@
 package sentry
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -151,4 +156,137 @@ func TestRetryAfterDateHeader(t *testing.T) {
 		},
 	}
 	assertEqual(t, retryAfter(now, &r), time.Second*13)
+}
+
+// A testHTTPServer counts events sent to it. It requires a call to Unblock
+// before incrementing its internal counter and sending a response to the HTTP
+// client. This allows for coordinating the execution flow when needed.
+type testHTTPServer struct {
+	*httptest.Server
+	// eventCounter counts the number of events processed by the server.
+	eventCounter *uint64
+	// ch is used to block/unblock the server on demand.
+	ch chan bool
+}
+
+func newTestHTTPServer(t *testing.T) *testHTTPServer {
+	ch := make(chan bool)
+	eventCounter := new(uint64)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		var event struct {
+			EventID string `json:"event_id"`
+		}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Block until signal to continue.
+		<-ch
+		count := atomic.AddUint64(eventCounter, 1)
+		t.Logf("[SERVER] {%.4s} event received (#%d)", event.EventID, count)
+	}
+	return &testHTTPServer{
+		Server:       httptest.NewTLSServer(http.HandlerFunc(handler)),
+		eventCounter: eventCounter,
+		ch:           ch,
+	}
+}
+
+func (ts *testHTTPServer) EventCount() uint64 {
+	return atomic.LoadUint64(ts.eventCounter)
+}
+
+func (ts *testHTTPServer) Unblock() {
+	ts.ch <- true
+}
+
+func TestHTTPTransport(t *testing.T) {
+	server := newTestHTTPServer(t)
+	defer server.Close()
+
+	transport := NewHTTPTransport()
+	transport.Configure(ClientOptions{
+		Dsn:        fmt.Sprintf("https://test@%s/1", server.Listener.Addr()),
+		HTTPClient: server.Client(),
+	})
+
+	// Helpers
+
+	transportSendTestEvent := func(t *testing.T) (id string) {
+		t.Helper()
+
+		e := NewEvent()
+		id = uuid()
+		e.EventID = EventID(id)
+
+		transport.SendEvent(e)
+		t.Logf("[CLIENT] {%.4s} event sent", e.EventID)
+		return id
+	}
+
+	transportMustFlush := func(t *testing.T, id string) {
+		t.Helper()
+
+		ok := transport.Flush(100 * time.Millisecond)
+		if !ok {
+			t.Fatalf("[CLIENT] {%.4s} Flush() timed out", id)
+		}
+	}
+
+	serverEventCountMustBe := func(t *testing.T, n uint64) {
+		t.Helper()
+
+		count := server.EventCount()
+		if count != n {
+			t.Fatalf("[SERVER] event count = %d, want %d", count, n)
+		}
+	}
+
+	// Actual tests
+
+	testSendSingleEvent := func(t *testing.T) {
+		// Sending a single event should increase the server event count by
+		// exactly one.
+
+		initialCount := server.EventCount()
+		id := transportSendTestEvent(t)
+
+		// Server is blocked waiting for us, right now count must not have
+		// changed yet.
+		serverEventCountMustBe(t, initialCount)
+
+		// After unblocking the server, Flush must guarantee that the server
+		// event count increased by one.
+		server.Unblock()
+		transportMustFlush(t, id)
+		serverEventCountMustBe(t, initialCount+1)
+	}
+	t.Run("SendSingleEvent", testSendSingleEvent)
+
+	t.Run("FlushMultipleTimes", func(t *testing.T) {
+		// Flushing multiple times should not increase the server event count.
+
+		initialCount := server.EventCount()
+		for i := 0; i < 10; i++ {
+			transportMustFlush(t, fmt.Sprintf("loop%d", i))
+		}
+		serverEventCountMustBe(t, initialCount)
+	})
+
+	t.Run("ConcurrentSendAndFlush", func(t *testing.T) {
+		// It should be safe to send events and flush concurrently.
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			testSendSingleEvent(t)
+			wg.Done()
+		}()
+		go func() {
+			transportMustFlush(t, "from goroutine")
+			wg.Done()
+		}()
+		wg.Wait()
+	})
 }


### PR DESCRIPTION
Rewrite HTTPTransport internals to remove a data race and occasional
panics.

Prior to this, HTTPTransport used a `sync.WaitGroup` to track how many
in-flight requests existed, and `Flush` waited until the observed number
of in-flight requests reached zero.

Unsynchronized access to the WaitGroup lead to panics (reuse before
wg.Wait returns) and data races (undefined order of wg.Add and wg.Wait
calls). See https://github.com/getsentry/sentry-go/issues/103#issuecomment-574376825, https://github.com/getsentry/sentry-go/issues/103#issuecomment-574883037 and  https://github.com/getsentry/sentry-go/issues/103#issuecomment-574885317.

The new implementation changes the `Flush` behavior to wait until the
current in-flight requests are processed, inline with other SDKs and the
Unified API.

Fixes #103.
