### PR TITLE
ci: enable linters explicitly

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,38 @@
 linters:
-  enable-all: true
-  disable:
-    - megacheck
-    - stylecheck
-    - funlen
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - prealloc
+    - scopelint
+    - unconvert
+    - unparam
 run:
   skip-dirs:
     - echo
@@ -16,3 +45,6 @@ issues:
     - path: _test\.go
       linters:
         - prealloc
+    - path: errors_test\.go
+      linters:
+        - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,12 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
     - bodyclose
+    - deadcode
     - depguard
     - dogsled
     - dupl
+    - errcheck
     - gochecknoglobals
     - gochecknoinits
     - goconst
@@ -24,6 +16,9 @@ linters:
     - goimports
     - golint
     - gosec
+    - gosimple
+    - govet
+    - ineffassign
     - interfacer
     - lll
     - maligned
@@ -31,8 +26,13 @@ linters:
     - nakedret
     - prealloc
     - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
     - unconvert
     - unparam
+    - unused
+    - varcheck
 run:
   skip-dirs:
     - echo

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -20,14 +19,6 @@ func assertNotEqual(t *testing.T, got, want interface{}, userMessage ...interfac
 
 	if reflect.DeepEqual(got, want) {
 		logFailedAssertion(t, formatUnequalValues(got, want), userMessage...)
-	}
-}
-
-func assertStringContains(t *testing.T, input, substr string) {
-	t.Helper()
-
-	if !strings.Contains(input, substr) {
-		logFailedAssertion(t, fmt.Sprintf("expected '%s' to contain '%s'", input, substr))
 	}
 }
 


### PR DESCRIPTION
Dropped `enable-all` and enabled all linters that are running right now explicitly.

fixes #142