### PR TITLE
ci: Bump golangci-lint to v1.27.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
   fast_finish: true
 
 before_install:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
   # Fetch origin/master. This is required for `git merge-base` when testing a
   # branch, since Travis clones only the target branch.
   - git fetch origin master:remotes/origin/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
   fast_finish: true
 
 before_install:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
   # Fetch origin/master. This is required for `git merge-base` when testing a
   # branch, since Travis clones only the target branch.
   - git fetch origin master:remotes/origin/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
   fast_finish: true
 
 before_install:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.19.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
   # Fetch origin/master. This is required for `git merge-base` when testing a
   # branch, since Travis clones only the target branch.
   - git fetch origin master:remotes/origin/master

--- a/scope_test.go
+++ b/scope_test.go
@@ -586,9 +586,10 @@ func TestEventProcessorsModifiesEvent(t *testing.T) {
 
 	if processedEvent == nil {
 		t.Error("event should not be dropped")
+	} else {
+		assertEqual(t, LevelFatal, processedEvent.Level)
+		assertEqual(t, []string{"wat"}, processedEvent.Fingerprint)
 	}
-	assertEqual(t, LevelFatal, processedEvent.Level)
-	assertEqual(t, []string{"wat"}, processedEvent.Fingerprint)
 }
 
 func TestEventProcessorsCanDropEvent(t *testing.T) {


### PR DESCRIPTION
While doing #144, realized it was behind a couple of versions so bumped.

