### PR TITLE
ci: Update craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,10 +1,14 @@
+minVersion: '0.9.0'
 github:
   owner: getsentry
   repo: sentry-go
 preReleaseCommand: bash scripts/craft-pre-release.sh
 changelogPolicy: simple
+statusProvider:
+    name: github
 targets:
   - name: github
+    includeNames: /none/
     tagPrefix: v
   - name: registry
     type: sdk


### PR DESCRIPTION
The new statusProvider config option was added in craft@0.9.0 and
allows us to remove a dependency on zeus.ci for build status checks.

The includeNames option skips artifact fetching. Reference:
https://github.com/getsentry/craft/blob/59486ba128c3aa24e87e585a6a0b87667fc5b4c0/src/targets/base.ts#L67