### PR TITLE
Add badges to GoDoc and go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [![Build Status](https://travis-ci.com/getsentry/sentry-go.svg?branch=master)](https://travis-ci.com/getsentry/sentry-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/getsentry/sentry-go)](https://goreportcard.com/report/github.com/getsentry/sentry-go)
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/Ww9hbqr)
+[![GoDoc](https://godoc.org/github.com/getsentry/sentry-go?status.svg)](https://godoc.org/github.com/getsentry/sentry-go)
+[![go.dev](https://img.shields.io/badge/go.dev-pkg-007d9c.svg?style=flat)](https://pkg.go.dev/github.com/getsentry/sentry-go)
 
 `sentry-go` provides a Sentry client implementation for the Go programming language. This is the next line of the Go SDK for [Sentry](https://sentry.io/), intended to replace the `raven-go` package.
 
@@ -95,7 +97,8 @@ For more detailed information about how to get the most out of `sentry-go` there
 
 - [Bug Tracker](https://github.com/getsentry/sentry-go/issues)
 - [GitHub Project](https://github.com/getsentry/sentry-go)
-- [Godocs](https://godoc.org/github.com/getsentry/sentry-go)
+- [GoDoc](https://godoc.org/github.com/getsentry/sentry-go)
+- [go.dev](https://pkg.go.dev/github.com/getsentry/sentry-go)
 - [@getsentry](https://twitter.com/getsentry) on Twitter for updates
 
 ## License


### PR DESCRIPTION
GoDoc has the latest docs (master), go.dev has docs for all released
versions.