### PR TITLE
Update release steps

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -5,7 +5,10 @@ github:
 preReleaseCommand: bash scripts/craft-pre-release.sh
 changelogPolicy: simple
 statusProvider:
-    name: github
+  name: github
+  config:
+    contexts:
+      - Travis CI - Branch
 targets:
   - name: github
     includeNames: /none/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,5 @@ $ golangci-lint run
 
     ```console
     $ craft prepare X.X.X
-    $ craft publish X.X.X --skip-status-check
+    $ craft publish X.X.X
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,19 @@ $ golangci-lint run
 
 ## Release
 
-1. Update changelog with new version in `vX.X.X` format title and list of changes
-2. Commit with `misc: vX.X.X changelog` commit message and push to `master`
-3. Let `craft` do the rest
+1. Update `CHANGELOG.md` with new version in `vX.X.X` format title and list of changes.
 
-```console
-$ craft prepare X.X.X
-$ craft publish X.X.X --skip-status-check
-```
+    The command below can be used to get a list of changes since the last tag, with the format used in `CHANGELOG.md`:
+
+    ```console
+    $ git log --no-merges --format=%s $(git describe --abbrev=0).. | sed 's/^/- /'
+    ```
+
+2. Commit with `misc: vX.X.X changelog` commit message and push to `master`.
+
+3. Let `craft` do the rest:
+
+    ```console
+    $ craft prepare X.X.X
+    $ craft publish X.X.X --skip-status-check
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The public-facing channels for support and development of Sentry SDKs can be fou
 
 ## Testing
 
-```bash
+```console
 $ go test
 ```
 
@@ -12,24 +12,24 @@ $ go test
 
 Use: https://github.com/cespare/reflex
 
-```bash
+```console
 $ reflex -g '*.go' -d "none" -- sh -c 'printf "\n"; go test'
 ```
 
 ### With data race detection
 
-```bash
+```console
 $ go test -race
 ```
 
 ### Coverage
-```bash
+```console
 $ go test -race -coverprofile=coverage.txt -covermode=atomic && go tool cover -html coverage.txt
 ```
 
 ## Linting
 
-```bash
+```console
 $ golangci-lint run
 ```
 
@@ -39,7 +39,7 @@ $ golangci-lint run
 2. Commit with `misc: vX.X.X changelog` commit message and push to `master`
 3. Let `craft` do the rest
 
-```bash
+```console
 $ craft prepare X.X.X
 $ craft publish X.X.X --skip-status-check
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ though support for this configuration is best-effort.
 
 `sentry-go` can be installed like any other Go library through `go get`:
 
-```bash
+```console
 $ go get github.com/getsentry/sentry-go
 ```
 
@@ -43,7 +43,7 @@ Or, if you are already using
 [Go Modules](https://github.com/golang/go/wiki/Modules), you may specify a
 version number as well:
 
-```bash
+```console
 $ go get github.com/getsentry/sentry-go@latest
 ```
 


### PR DESCRIPTION
- Show how to prepare the changelog (at least how to get started)
- Remove bad flag to `craft`
- Update markdown block language to highlight contents as shell session
- Explicitly configure `craft` to check commit status using Travis