### PR TITLE
Attached new logger instance to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-// Logger is in instance of log.Logger and can be used directly to log anything manually
+// Logger is an instance of log.Logger and can be used directly to log using Sentry.Logger
 var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags) //nolint: gochecknoglobals
 
 type EventProcessor func(event *Event, hint *EventHint) (*Event, error)

--- a/example/multiclient/main.go
+++ b/example/multiclient/main.go
@@ -17,7 +17,7 @@ func (pi *pickleIntegration) SetupOnce(client *sentry.Client) {
 	client.AddEventProcessor(pi.processor)
 }
 
-func (pi *pickleIntegration) processor(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+func (pi *pickleIntegration) processor(event *sentry.Event, hint *sentry.EventHint, logger *log.Logger) *sentry.Event {
 	event.Message = fmt.Sprintf("PickleRick Says: %s", event.Message)
 	return event
 }

--- a/example/with_extra/main.go
+++ b/example/with_extra/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -50,7 +51,7 @@ func (ee ExtractExtra) Name() string {
 }
 
 func (ee ExtractExtra) SetupOnce(client *sentry.Client) {
-	client.AddEventProcessor(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	client.AddEventProcessor(func(event *sentry.Event, hint *sentry.EventHint, logger *log.Logger) *sentry.Event {
 		if ex, ok := hint.OriginalException.(CustomComplexError); ok {
 			for key, val := range ex.GimmeMoreData() {
 				event.Extra[key] = val
@@ -94,7 +95,7 @@ func main() {
 	// applied to all events - if used with ConfigureScope or per
 	// event/block if used with WithScope):
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
-		scope.AddEventProcessor(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		scope.AddEventProcessor(func(event *sentry.Event, hint *sentry.EventHint, logger *log.Logger) *sentry.Event {
 			if ex, ok := hint.OriginalException.(CustomComplexError); ok {
 				for key, val := range ex.GimmeMoreData() {
 					event.Extra[key] = val

--- a/hub.go
+++ b/hub.go
@@ -283,7 +283,7 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 			h = hint
 		}
 		if breadcrumb = options.BeforeBreadcrumb(breadcrumb, h); breadcrumb == nil {
-			Logger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
+			client.Logger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
 			return
 		}
 	}

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -148,23 +148,23 @@ func TestIgnoreErrorsIntegration(t *testing.T) {
 		}},
 	}
 
-	if event, _ := iei.processor(dropped, &EventHint{}); event != nil {
+	if event := iei.processor(dropped, &EventHint{}, Logger); event != nil {
 		t.Error("Event should be dropped")
 	}
 
-	if event, _ := iei.processor(alsoDropped, &EventHint{}); event != nil {
+	if event := iei.processor(alsoDropped, &EventHint{}, Logger); event != nil {
 		t.Error("Event should be dropped")
 	}
 
-	if event, _ := iei.processor(thisDroppedAsWell, &EventHint{}); event != nil {
+	if event := iei.processor(thisDroppedAsWell, &EventHint{}, Logger); event != nil {
 		t.Error("Event should be dropped")
 	}
 
-	if event, _ := iei.processor(notDropped, &EventHint{}); event == nil {
+	if event := iei.processor(notDropped, &EventHint{}, Logger); event == nil {
 		t.Error("Event should not be dropped")
 	}
 
-	if event, _ := iei.processor(alsoNotDropped, &EventHint{}); event == nil {
+	if event := iei.processor(alsoNotDropped, &EventHint{}, Logger); event == nil {
 		t.Error("Event should not be dropped")
 	}
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -148,23 +148,23 @@ func TestIgnoreErrorsIntegration(t *testing.T) {
 		}},
 	}
 
-	if iei.processor(dropped, &EventHint{}) != nil {
+	if event, _ := iei.processor(dropped, &EventHint{}); event != nil {
 		t.Error("Event should be dropped")
 	}
 
-	if iei.processor(alsoDropped, &EventHint{}) != nil {
+	if event, _ := iei.processor(alsoDropped, &EventHint{}); event != nil {
 		t.Error("Event should be dropped")
 	}
 
-	if iei.processor(thisDroppedAsWell, &EventHint{}) != nil {
+	if event, _ := iei.processor(thisDroppedAsWell, &EventHint{}); event != nil {
 		t.Error("Event should be dropped")
 	}
 
-	if iei.processor(notDropped, &EventHint{}) == nil {
+	if event, _ := iei.processor(notDropped, &EventHint{}); event == nil {
 		t.Error("Event should not be dropped")
 	}
 
-	if iei.processor(alsoNotDropped, &EventHint{}) == nil {
+	if event, _ := iei.processor(alsoNotDropped, &EventHint{}); event == nil {
 		t.Error("Event should not be dropped")
 	}
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -14,11 +14,11 @@ func (scope *ScopeMock) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
 	scope.breadcrumb = breadcrumb
 }
 
-func (scope *ScopeMock) ApplyToEvent(event *Event, hint *EventHint) *Event {
+func (scope *ScopeMock) ApplyToEvent(event *Event, hint *EventHint) (*Event, error) {
 	if scope.shouldDropEvent {
-		return nil
+		return nil, nil
 	}
-	return event
+	return event, nil
 }
 
 type TransportMock struct {

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"log"
 	"sync"
 	"time"
 )
@@ -14,11 +15,11 @@ func (scope *ScopeMock) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
 	scope.breadcrumb = breadcrumb
 }
 
-func (scope *ScopeMock) ApplyToEvent(event *Event, hint *EventHint) (*Event, error) {
+func (scope *ScopeMock) ApplyToEvent(event *Event, hint *EventHint, logger *log.Logger) *Event {
 	if scope.shouldDropEvent {
-		return nil, nil
+		return nil
 	}
-	return event, nil
+	return event
 }
 
 type TransportMock struct {

--- a/scope_test.go
+++ b/scope_test.go
@@ -508,7 +508,7 @@ func TestApplyToEventWithCorrectScopeAndEvent(t *testing.T) {
 	scope := fillScopeWithData(NewScope())
 	event := fillEventWithData(NewEvent())
 
-	processedEvent := scope.ApplyToEvent(event, nil)
+	processedEvent, _ := scope.ApplyToEvent(event, nil)
 
 	assertEqual(t, len(processedEvent.Breadcrumbs), 2, "should merge breadcrumbs")
 	assertEqual(t, len(processedEvent.Tags), 2, "should merge tags")
@@ -525,7 +525,7 @@ func TestApplyToEventUsingEmptyScope(t *testing.T) {
 	scope := NewScope()
 	event := fillEventWithData(NewEvent())
 
-	processedEvent := scope.ApplyToEvent(event, nil)
+	processedEvent, _ := scope.ApplyToEvent(event, nil)
 
 	assertEqual(t, len(processedEvent.Breadcrumbs), 1, "should use event breadcrumbs")
 	assertEqual(t, len(processedEvent.Tags), 1, "should use event tags")
@@ -542,7 +542,7 @@ func TestApplyToEventUsingEmptyEvent(t *testing.T) {
 	scope := fillScopeWithData(NewScope())
 	event := NewEvent()
 
-	processedEvent := scope.ApplyToEvent(event, nil)
+	processedEvent, _ := scope.ApplyToEvent(event, nil)
 
 	assertEqual(t, len(processedEvent.Breadcrumbs), 1, "should use scope breadcrumbs")
 	assertEqual(t, len(processedEvent.Tags), 1, "should use scope tags")
@@ -559,16 +559,16 @@ func TestEventProcessorsModifiesEvent(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()
 	scope.eventProcessors = []EventProcessor{
-		func(event *Event, hint *EventHint) *Event {
+		func(event *Event, hint *EventHint) (*Event, error) {
 			event.Level = LevelFatal
-			return event
+			return event, nil
 		},
-		func(event *Event, hint *EventHint) *Event {
+		func(event *Event, hint *EventHint) (*Event, error) {
 			event.Fingerprint = []string{"wat"}
-			return event
+			return event, nil
 		},
 	}
-	processedEvent := scope.ApplyToEvent(event, nil)
+	processedEvent, _ := scope.ApplyToEvent(event, nil)
 
 	if processedEvent == nil {
 		t.Error("event should not be dropped")
@@ -581,11 +581,11 @@ func TestEventProcessorsCanDropEvent(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()
 	scope.eventProcessors = []EventProcessor{
-		func(event *Event, hint *EventHint) *Event {
-			return nil
+		func(event *Event, hint *EventHint) (*Event, error) {
+			return nil, nil
 		},
 	}
-	processedEvent := scope.ApplyToEvent(event, nil)
+	processedEvent, _ := scope.ApplyToEvent(event, nil)
 
 	if processedEvent != nil {
 		t.Error("event should be dropped")
@@ -595,16 +595,16 @@ func TestEventProcessorsCanDropEvent(t *testing.T) {
 func TestEventProcessorsAddEventProcessor(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()
-	processedEvent := scope.ApplyToEvent(event, nil)
+	processedEvent, _ := scope.ApplyToEvent(event, nil)
 
 	if processedEvent == nil {
 		t.Error("event should not be dropped")
 	}
 
-	scope.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
-		return nil
+	scope.AddEventProcessor(func(event *Event, hint *EventHint) (*Event, error) {
+		return nil, nil
 	})
-	processedEvent = scope.ApplyToEvent(event, nil)
+	processedEvent, _ = scope.ApplyToEvent(event, nil)
 
 	if processedEvent != nil {
 		t.Error("event should be dropped")


### PR DESCRIPTION
New logger instance attached to client creation. Tests are tweaked to accommodate new changes but no new tests are written for error checks. I am not sure whether we want to do it or not.

FYI: I have still kept Global logger to be used directly, however, the mutation would still exist with this.