### PR TITLE
Add tests for net/http and fasthttp integrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ jobs:
         export GOPATH= &&
         go env GOPATH
       script: >-
-        go test &&
-        go test -race
+        go test ./... &&
+        go test ./... -race
   allow_failures:
     - go: master
   fast_finish: true
@@ -34,9 +34,9 @@ before_install:
 
 script:
   - golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
-  - go build
-  - go test
-  - go test -race
+  - go build ./...
+  - go test ./...
+  - go test ./... -race
 
 notifications:
   webhooks:


### PR DESCRIPTION
Tests should allow us to make changes to `sentry-go` with some confidence that integrations still work.

Targeting `net/http` and `fasthttp` because other integrations (`echo`, `gin`, `iris`, `martini`, `negroni`) are similar to `net/http`, so we cover most of the surface area.

The tests cover 3 scenarios:
- Capturing panics
- Capturing message with request body
- Capturing message without request body

The tests in `sentryhttp` and `sentryfasthttp` are pretty similar, however need to account for differences in `net/http` and `fasthttp`.

Updates #97.