### PR TITLE
feat: Limit reading bytes from request bodies

### DIFF
--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -56,7 +56,7 @@ func New(options Options) echo.MiddlewareFunc {
 func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		hub := sentry.CurrentHub().Clone()
-		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(ctx.Request()))
+		hub.Scope().SetRequest(ctx.Request())
 		ctx.Set(valuesKey, hub)
 		defer h.recoverWithSentry(hub, ctx.Request())
 		return next(ctx)

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -58,7 +58,7 @@ func New(options Options) gin.HandlerFunc {
 
 func (h *handler) handle(ctx *gin.Context) {
 	hub := sentry.CurrentHub().Clone()
-	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(ctx.Request))
+	hub.Scope().SetRequest(ctx.Request)
 	ctx.Set(valuesKey, hub)
 	defer h.recoverWithSentry(hub, ctx.Request)
 	ctx.Next()

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -52,7 +52,7 @@ func New(options Options) *Handler {
 func (h *Handler) Handle(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		hub := sentry.CurrentHub().Clone()
-		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+		hub.Scope().SetRequest(r)
 		ctx := sentry.SetHubOnContext(
 			r.Context(),
 			hub,
@@ -66,7 +66,7 @@ func (h *Handler) Handle(handler http.Handler) http.Handler {
 func (h *Handler) HandleFunc(handler http.HandlerFunc) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		hub := sentry.CurrentHub().Clone()
-		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+		hub.Scope().SetRequest(r)
 		ctx := sentry.SetHubOnContext(
 			r.Context(),
 			hub,

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -1,28 +1,31 @@
 package sentry
 
 import (
-	"bytes"
-	"io/ioutil"
-	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestRequestFromHTTPRequest(t *testing.T) {
-
-	var testPayload = `{"test_data": true}`
-
-	t.Run("reading_body", func(t *testing.T) {
-		payload := bytes.NewBufferString(testPayload)
-		req, err := http.NewRequest("POST", "/test/", payload)
-		assertEqual(t, err, nil)
-		assertNotEqual(t, req, nil)
-		sentryRequest := Request{}
-		sentryRequest = sentryRequest.FromHTTPRequest(req)
-		assertEqual(t, sentryRequest.Data, testPayload)
-
-		// Re-reading original *http.Request.Body
-		reqBody, err := ioutil.ReadAll(req.Body)
-		assertEqual(t, err, nil)
-		assertEqual(t, string(reqBody), testPayload)
-	})
+func TestNewRequest(t *testing.T) {
+	const payload = `{"test_data": true}`
+	got := NewRequest(httptest.NewRequest("POST", "/test/?q=sentry", strings.NewReader(payload)))
+	want := &Request{
+		URL:         "http://example.com/test/",
+		Method:      "POST",
+		Data:        "",
+		QueryString: "q=sentry",
+		Cookies:     "",
+		Headers: map[string]string{
+			"Host": "example.com",
+		},
+		Env: map[string]string{
+			"REMOTE_ADDR": "192.0.2.1",
+			"REMOTE_PORT": "1234",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Request mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -57,7 +57,7 @@ func New(options Options) iris.Handler {
 
 func (h *handler) handle(ctx iris.Context) {
 	hub := sentry.CurrentHub().Clone()
-	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(ctx.Request()))
+	hub.Scope().SetRequest(ctx.Request())
 	ctx.Values().Set(valuesKey, hub)
 	defer h.recoverWithSentry(hub, ctx.Request())
 	ctx.Next()

--- a/martini/sentrymartini.go
+++ b/martini/sentrymartini.go
@@ -53,7 +53,7 @@ func New(options Options) martini.Handler {
 
 func (h *handler) handle(rw http.ResponseWriter, r *http.Request, ctx martini.Context) {
 	hub := sentry.CurrentHub().Clone()
-	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+	hub.Scope().SetRequest(r)
 	ctx.Map(hub)
 	defer h.recoverWithSentry(hub, r)
 	ctx.Next()

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -53,7 +53,7 @@ func New(options Options) negroni.Handler {
 
 func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	hub := sentry.CurrentHub().Clone()
-	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+	hub.Scope().SetRequest(r)
 	ctx := sentry.SetHubOnContext(
 		context.WithValue(r.Context(), sentry.RequestContextKey, r),
 		hub,
@@ -82,7 +82,7 @@ func (h *handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
 func PanicHandlerFunc(info *negroni.PanicInformation) {
 	hub := sentry.CurrentHub().Clone()
 	hub.WithScope(func(scope *sentry.Scope) {
-		scope.SetRequest(sentry.Request{}.FromHTTPRequest(info.Request))
+		scope.SetRequest(info.Request)
 		hub.RecoverWithContext(
 			context.WithValue(context.Background(), sentry.RequestContextKey, info.Request),
 			info.RecoveredPanic,

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -2,6 +2,7 @@ package sentry_test
 
 import (
 	"errors"
+	"net/http/httptest"
 	"sync"
 	"testing"
 
@@ -55,7 +56,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.SetFingerprint([]string{"foo"})
 	scope.AddBreadcrumb(&sentry.Breadcrumb{Timestamp: 1337, Message: "foo"}, 100)
 	scope.SetUser(sentry.User{ID: "foo"})
-	scope.SetRequest(sentry.Request{URL: "foo"})
+	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
 
 	sentry.CaptureException(errors.New(string(x)))
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -15,10 +15,10 @@ type unserializableType struct {
 	UnsupportedField func()
 }
 
-const basicEvent = "{\"message\":\"mkey\",\"sdk\":{},\"user\":{},\"request\":{}}"
+const basicEvent = "{\"message\":\"mkey\",\"sdk\":{},\"user\":{}}"
 const enhancedEvent = "{\"extra\":{\"info\":\"Original event couldn't be marshalled. Succeeded by stripping " +
 	"the data that uses interface{} type. Please verify that the data you attach to the scope is serializable.\"}," +
-	"\"message\":\"mkey\",\"sdk\":{},\"user\":{},\"request\":{}}"
+	"\"message\":\"mkey\",\"sdk\":{},\"user\":{}}"
 
 func TestGetRequestBodyFromEventValid(t *testing.T) {
 	body := getRequestBodyFromEvent(&Event{


### PR DESCRIPTION
This change both limits the number of bytes that the SDK attempts to
read and buffer in memory, as well as delays as much work as possible.

It requires breaking changes to the exported API.

Notes on API changes:

```diff
- Request.FromHTTPRequest
+ NewRequest
```

  The difference is that NewRequest does not read the request body.
  FromHTTPRequest was called from HTTP middleware in integrations in the
  beginning of the request handling flow. Attempting to read the whole
  body there is often wasteful, since most requests should not result in
  reporting an error to Sentry.

  With this change, Scope.SetRequest keeps a lazy buffer that clones a
  limited portion of the request body only if it is read by the user.

```diff
- Scope.SetRequest(Request)
+ Scope.SetRequest(*http.Request)
```

  For most integrations (fasthttp being the only exception), this means
  less work needs to be done when handling a request. Converting from
  http.Request to sentry.Request is only done when there is an error to
  be reported.
  It also means we can keep a reference to the request body without
  reading all bytes upfront.

```diff
- Event.Request type Request
+ Event.Request type *Request
```
  Avoids copying of possibly large struct.

---

Closes #96.
Closes #166.