### PR TITLE
ci: Test against Go 1.14, drop 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
   - master
 
 env:
@@ -13,7 +13,7 @@ env:
 jobs:
   include:
     - name: "Module support outside of GOPATH"
-      go: 1.13.x
+      go: stable
       before_script: >-
         mv $GOPATH/src/github.com/getsentry/sentry-go ~/sentry-go &&
         cd ~/sentry-go &&


### PR DESCRIPTION
Go 1.14 has been released, so update the versions we test against.

Testing of Module mode outside of GOPATH can use the latest stable
release, thus not requiring a config update with each release of Go 1.x.