### PR TITLE
Add Exception.ThreadID field

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -112,6 +112,7 @@ type Exception struct {
 	Type          string      `json:"type,omitempty"`
 	Value         string      `json:"value,omitempty"`
 	Module        string      `json:"module,omitempty"`
+	ThreadID      string      `json:"thread_id,omitempty"`
 	Stacktrace    *Stacktrace `json:"stacktrace,omitempty"`
 	RawStacktrace *Stacktrace `json:"raw_stacktrace,omitempty"`
 }


### PR DESCRIPTION
Doc says that crashed thread should not have stacktrace, but instead, the `thread_id` attribute should be set on the exception https://docs.sentry.io/development/sdk-dev/event-payloads/exception/