### PR TITLE
Getting os version and kernel_version for unix os

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
+	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d
 )
 
 replace github.com/ugorji/go v1.1.4 => github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
+golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20181221001348-537d06c36207/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/integrations.go
+++ b/integrations.go
@@ -185,10 +185,7 @@ func (ei *environmentIntegration) processor(event *Event, hint *EventHint) *Even
 		"num_cpu": runtime.NumCPU(),
 	}
 
-	event.Contexts["os"] = map[string]interface{}{
-		"name": runtime.GOOS,
-	}
-
+	event.Contexts["os"] = osContext()
 	event.Contexts["runtime"] = map[string]interface{}{
 		"name":           "go",
 		"version":        runtime.Version(),

--- a/os_context_unix.go
+++ b/os_context_unix.go
@@ -1,0 +1,25 @@
+//+build !windows
+
+package sentry
+
+import (
+	"bytes"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func osContext() map[string]interface{} {
+	ctx := map[string]interface{}{
+		"name": runtime.GOOS,
+	}
+
+	var name unix.Utsname
+	if err := unix.Uname(&name); err != nil {
+		return ctx
+	}
+
+	ctx["version"] = string(name.Release[:bytes.IndexByte(name.Release[:], 0)])
+	ctx["kernel_version"] = string(name.Version[:bytes.IndexByte(name.Version[:], 0)])
+	return ctx
+}

--- a/os_context_windows.go
+++ b/os_context_windows.go
@@ -1,0 +1,11 @@
+//+build windows
+
+package sentry
+
+import "runtime"
+
+func osContext() map[string]interface{} {
+	return map[string]interface{}{
+		"name": runtime.GOOS,
+	}
+}


### PR DESCRIPTION
This changes getting version and kernel_version by using uname
from golang/x/sys/unix package.

NOTE: windows not support in this changes.

Fixes #187