### PR TITLE
fix: Report usage error including stack trace

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,14 @@ import (
 	"time"
 )
 
+// usageError is used to report to Sentry an SDK usage error.
+//
+// It is not exported because it is never returned by any function or method in
+// the exported API.
+type usageError struct {
+	error
+}
+
 // Logger is an instance of log.Logger that is use to provide debug information about running Sentry Client
 // can be enabled by either using `Logger.SetOutput` directly or with `Debug` client option
 var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags) //nolint: gochecknoglobals
@@ -299,10 +307,7 @@ func (client *Client) eventFromMessage(message string, level Level) *Event {
 
 func (client *Client) eventFromException(exception error, level Level) *Event {
 	if exception == nil {
-		event := NewEvent()
-		event.Level = level
-		event.Message = fmt.Sprintf("Called %s with nil value", callerFunctionName())
-		return event
+		exception = usageError{fmt.Errorf("%s called with nil error", callerFunctionName())}
 	}
 
 	stacktrace := ExtractStacktrace(exception)


### PR DESCRIPTION
Prior to this, calling `CaptureException`, `Recover` or `RecoverWithContext` with a `nil` error would send a message event to Sentry without a stack trace.

Looking at the Sentry issues list, and issue detail, all you see is "Called CaptureException with nil value" without a clue of what caused it.

This change turns that message into a `sentry.usageError` (new type) with a stack trace, making it easier to understand what is wrong and fix user code.


## BEFORE

No stacktrace nor any clue where the incorrect call to `CaptureException` is.

![image](https://user-images.githubusercontent.com/88819/78385829-c9602e00-75dc-11ea-9a8e-04a6c0267556.png)
![image](https://user-images.githubusercontent.com/88819/78385851-d250ff80-75dc-11ea-8f12-bb4956541c1f.png)


## AFTER


Usage error with description and file name and line number information, plus source code context when available.

![image](https://user-images.githubusercontent.com/88819/78386035-21973000-75dd-11ea-9d86-1ee829b49a6d.png)
![image](https://user-images.githubusercontent.com/88819/78386064-2f4cb580-75dd-11ea-9b23-8e864c8e758a.png)

Without source context:

![image](https://user-images.githubusercontent.com/88819/78386346-b13cde80-75dd-11ea-832e-76d9576449ef.png)
