### PR TITLE
fix: Use time.Time for timestamps

### DIFF
--- a/client.go
+++ b/client.go
@@ -374,8 +374,8 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		event.EventID = EventID(uuid())
 	}
 
-	if event.Timestamp == 0 {
-		event.Timestamp = time.Now().Unix()
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
 	}
 
 	if event.Level == "" {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,37 @@
+package sentry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	tests := []struct {
+		in  interface{}
+		out string
+	}{
+		// TODO: eliminate empty struct fields from serialization of empty event.
+		// Only *Event implements json.Marshaler.
+		// {Event{}, `{"sdk":{},"user":{}}`},
+		{&Event{}, `{"sdk":{},"user":{}}`},
+		// Only *Breadcrumb implements json.Marshaler.
+		// {Breadcrumb{}, `{}`},
+		{&Breadcrumb{}, `{}`},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			want := tt.out
+			b, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(b)
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("JSON serialization mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -62,8 +62,8 @@ func NewScope() *Scope {
 // AddBreadcrumb adds new breadcrumb to the current scope
 // and optionally throws the old one if limit is reached.
 func (scope *Scope) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
-	if breadcrumb.Timestamp == 0 {
-		breadcrumb.Timestamp = time.Now().Unix()
+	if breadcrumb.Timestamp.IsZero() {
+		breadcrumb.Timestamp = time.Now().UTC()
 	}
 
 	scope.mu.Lock()

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -54,7 +54,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.SetLevel(sentry.LevelDebug)
 	scope.SetTransaction("foo")
 	scope.SetFingerprint([]string{"foo"})
-	scope.AddBreadcrumb(&sentry.Breadcrumb{Timestamp: 1337, Message: "foo"}, 100)
+	scope.AddBreadcrumb(&sentry.Breadcrumb{Message: "foo"}, 100)
 	scope.SetUser(sentry.User{ID: "foo"})
 	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
 


### PR DESCRIPTION
This gives us more flexibility to represent and manipulate time values,
as well as allow us to report values with sub-second resolution.

Fixes #190.