### PR TITLE
fix: check for dropped event

### DIFF
--- a/client.go
+++ b/client.go
@@ -415,6 +415,9 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 
 	if scope != nil {
 		event = scope.ApplyToEvent(event, hint)
+		if event == nil {
+			return nil
+		}
 	}
 
 	for _, processor := range client.eventProcessors {

--- a/client_test.go
+++ b/client_test.go
@@ -156,6 +156,13 @@ func TestApplyToScopeCanDropEvent(t *testing.T) {
 	client, scope, transport := setupClientTest()
 	scope.shouldDropEvent = true
 
+	client.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+		if event == nil {
+			t.Errorf("EventProcessor received nil Event")
+		}
+		return event
+	})
+
 	client.CaptureMessage("Foo", nil, scope)
 
 	if transport.lastEvent != nil {


### PR DESCRIPTION
`scope.ApplyToEvent` may return nil, but is not checked in `prepareEvent`.