### PR TITLE
Read module dependencies from debug.BuildInfo instead of go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.11
+go 1.12
 
 require (
 	github.com/ajg/form v1.5.1 // indirect

--- a/integrations.go
+++ b/integrations.go
@@ -39,7 +39,7 @@ func (mi *modulesIntegration) processor(event *Event, hint *EventHint) *Event {
 func extractModules() map[string]string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		Logger.Printf("ModuleIntegration wasn't able to extract modules because this binary doesn't use go module mode.")
+		Logger.Printf("The Modules integration is not available in binaries built without module support.")
 		return nil
 	}
 	modules := map[string]string{

--- a/integrations.go
+++ b/integrations.go
@@ -31,7 +31,7 @@ func (mi *modulesIntegration) processor(event *Event, hint *EventHint) *Event {
 		mi.once.Do(func() {
 			info, ok := debug.ReadBuildInfo()
 			if !ok {
-				Logger.Printf("The Modules integration is not available in binaries built without module support.")
+				Logger.Print("The Modules integration is not available in binaries built without module support.")
 				return
 			}
 			mi.modules = extractModules(info)

--- a/integrations.go
+++ b/integrations.go
@@ -42,7 +42,9 @@ func extractModules() map[string]string {
 		Logger.Printf("ModuleIntegration wasn't able to extract modules because this binary doesn't use go module mode.")
 		return nil
 	}
-	modules := make(map[string]string)
+	modules := map[string]string{
+		info.Main.Path: info.Main.Version,
+	}
 	for _, dep := range info.Deps {
 		ver := dep.Version
 		if dep.Replace != nil {

--- a/integrations.go
+++ b/integrations.go
@@ -48,9 +48,9 @@ func extractModules(info *debug.BuildInfo) map[string]string {
 	for _, dep := range info.Deps {
 		ver := dep.Version
 		if dep.Replace != nil {
-			ver += fmt.Sprintf(" => %s %s", dep.Replace.Path, dep.Version)
+			ver += fmt.Sprintf(" => %s %s", dep.Replace.Path, dep.Replace.Version)
 		}
-		modules[dep.Path] = ver
+		modules[dep.Path] = strings.TrimSuffix(ver, " ")
 	}
 	return modules
 }

--- a/integrations.go
+++ b/integrations.go
@@ -29,19 +29,19 @@ func (mi *modulesIntegration) SetupOnce(client *Client) {
 func (mi *modulesIntegration) processor(event *Event, hint *EventHint) *Event {
 	if len(event.Modules) == 0 {
 		mi.once.Do(func() {
-			mi.modules = extractModules()
+			info, ok := debug.ReadBuildInfo()
+			if !ok {
+				Logger.Printf("The Modules integration is not available in binaries built without module support.")
+				return
+			}
+			mi.modules = extractModules(info)
 		})
 	}
 	event.Modules = mi.modules
 	return event
 }
 
-func extractModules() map[string]string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		Logger.Printf("The Modules integration is not available in binaries built without module support.")
-		return nil
-	}
+func extractModules(info *debug.BuildInfo) map[string]string {
 	modules := map[string]string{
 		info.Main.Path: info.Main.Version,
 	}

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"runtime/debug"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTransformStringsIntoRegexps(t *testing.T) {
@@ -242,9 +244,9 @@ func TestContextifyFramesNonexistingFilesShouldNotDropFrames(t *testing.T) {
 
 func TestExtractModules(t *testing.T) {
 	tests := []struct {
-		name     string
-		info     *debug.BuildInfo
-		expected map[string]string
+		name string
+		info *debug.BuildInfo
+		want map[string]string
 	}{
 		{
 			name: "no require modules",
@@ -255,7 +257,7 @@ func TestExtractModules(t *testing.T) {
 				},
 				Deps: []*debug.Module{},
 			},
-			expected: map[string]string{
+			want: map[string]string{
 				"my/module": "(devel)",
 			},
 		},
@@ -277,7 +279,7 @@ func TestExtractModules(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{
+			want: map[string]string{
 				"my/module":                      "(devel)",
 				"github.com/getsentry/sentry-go": "v0.5.1",
 				"github.com/gin-gonic/gin":       "v1.4.0",
@@ -300,7 +302,7 @@ func TestExtractModules(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{
+			want: map[string]string{
 				"my/module":                      "(devel)",
 				"github.com/getsentry/sentry-go": "v0.5.1 => pkg/sentry",
 			},
@@ -323,7 +325,7 @@ func TestExtractModules(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{
+			want: map[string]string{
 				"my/module":            "(devel)",
 				"github.com/ugorji/go": "v1.1.4 => github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43",
 			},
@@ -333,7 +335,10 @@ func TestExtractModules(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			assertEqual(t, extractModules(tt.info), tt.expected)
+			got := extractModules(tt.info)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("modules info mismatch (-want +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -242,10 +242,12 @@ func TestContextifyFramesNonexistingFilesShouldNotDropFrames(t *testing.T) {
 
 func TestExtractModules(t *testing.T) {
 	tests := []struct {
+		name     string
 		info     *debug.BuildInfo
 		expected map[string]string
 	}{
 		{
+			name: "no require modules",
 			info: &debug.BuildInfo{
 				Main: debug.Module{
 					Path:    "my/module",
@@ -258,6 +260,7 @@ func TestExtractModules(t *testing.T) {
 			},
 		},
 		{
+			name: "have require modules",
 			info: &debug.BuildInfo{
 				Main: debug.Module{
 					Path:    "my/module",
@@ -268,14 +271,20 @@ func TestExtractModules(t *testing.T) {
 						Path:    "github.com/getsentry/sentry-go",
 						Version: "v0.5.1",
 					},
+					{
+						Path:    "github.com/gin-gonic/gin",
+						Version: "v1.4.0",
+					},
 				},
 			},
 			expected: map[string]string{
 				"my/module":                      "(devel)",
 				"github.com/getsentry/sentry-go": "v0.5.1",
+				"github.com/gin-gonic/gin":       "v1.4.0",
 			},
 		},
 		{
+			name: "replace module with local module",
 			info: &debug.BuildInfo{
 				Main: debug.Module{
 					Path:    "my/module",
@@ -297,6 +306,7 @@ func TestExtractModules(t *testing.T) {
 			},
 		},
 		{
+			name: "replace module with another remote module",
 			info: &debug.BuildInfo{
 				Main: debug.Module{
 					Path:    "my/module",
@@ -322,6 +332,8 @@ func TestExtractModules(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		assertEqual(t, tt.expected, extractModules(tt.info))
+		t.Run(tt.name, func(t *testing.T) {
+			assertEqual(t, tt.expected, extractModules(tt.info))
+		})
 	}
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -333,7 +333,7 @@ func TestExtractModules(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			assertEqual(t, tt.expected, extractModules(tt.info))
+			assertEqual(t, extractModules(tt.info), tt.expected)
 		})
 	}
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -3,6 +3,7 @@ package sentry
 import (
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"testing"
 )
 
@@ -237,4 +238,24 @@ func TestContextifyFramesNonexistingFilesShouldNotDropFrames(t *testing.T) {
 
 	contextifiedFrames := cfi.contextify(frames)
 	assertEqual(t, len(contextifiedFrames), len(frames))
+}
+
+func TestExtractModules(t *testing.T) {
+	expected := map[string]string{
+		"my/module":                      "(devel)",
+		"github.com/getsentry/sentry-go": "v0.5.1",
+	}
+	modules := extractModules(&debug.BuildInfo{
+		Main: debug.Module{
+			Path:    "my/module",
+			Version: "(devel)",
+		},
+		Deps: []*debug.Module{
+			{
+				Path:    "github.com/getsentry/sentry-go",
+				Version: "v0.5.1",
+			},
+		},
+	})
+	assertEqual(t, expected, modules)
 }


### PR DESCRIPTION
This changes getting modules from `runtime/debug` instead of getting it from `go.mod` or `vendor/modules.txt`.

![Screen Shot 2563-04-15 at 00 22 05](https://user-images.githubusercontent.com/484530/79254957-b9373100-7eaf-11ea-95e5-d006590cbd58.png)

Fixes #184