### PR TITLE
Use http.RoundTripper in place of *http.Transport

### DIFF
--- a/client.go
+++ b/client.go
@@ -87,7 +87,7 @@ type ClientOptions struct {
 	HTTPClient *http.Client
 	// An optional pointer to `http.Transport` that will be used with a default HTTPTransport.
 	// Using your own transport will make HTTPProxy, HTTPSProxy and CaCerts options ignored.
-	HTTPTransport *http.Transport
+	HTTPTransport http.RoundTripper
 	// An optional HTTP proxy to use.
 	// This will default to the `http_proxy` environment variable.
 	// or `https_proxy` if that one exists.

--- a/transport.go
+++ b/transport.go
@@ -107,7 +107,7 @@ type batch struct {
 type HTTPTransport struct {
 	dsn       *Dsn
 	client    *http.Client
-	transport *http.Transport
+	transport http.RoundTripper
 
 	// buffer is a channel of batches. Calling Flush terminates work on the
 	// current in-flight items and starts a new batch for subsequent events.
@@ -336,7 +336,7 @@ func (t *HTTPTransport) worker() {
 type HTTPSyncTransport struct {
 	dsn           *Dsn
 	client        *http.Client
-	transport     *http.Transport
+	transport     http.RoundTripper
 	disabledUntil time.Time
 
 	// HTTP Client request timeout. Defaults to 30 seconds.


### PR DESCRIPTION
Fixes #204 