### PR TITLE
feat: Support chained errors using Unwrap()

### DIFF
--- a/client.go
+++ b/client.go
@@ -328,9 +328,12 @@ func (client *Client) eventFromException(exception error, level Level) *Event {
 			Type:       reflect.TypeOf(err).String(),
 			Stacktrace: ExtractStacktrace(err),
 		})
-		if previous, ok := err.(interface{ Cause() error }); ok {
+		switch previous := err.(type) {
+		case interface{ Unwrap() error }:
+			err = previous.Unwrap()
+		case interface{ Cause() error }:
 			err = previous.Cause()
-		} else {
+		default:
 			err = nil
 		}
 	}


### PR DESCRIPTION
Unwrap was introduced in Go 1.13.

Fixes #137.