### PR TITLE
Allow custom stacktrace extraction

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -42,9 +42,14 @@ func NewStacktrace() *Stacktrace {
 	return &stacktrace
 }
 
-// ExtractStacktrace creates a new `Stacktrace` based on the given `error` object.
-// TODO: Make it configurable so that anyone can provide their own implementation?
-// Use of reflection allows us to not have a hard dependency on any given package, so we don't have to import it
+// ExtractStacktrace creates a new `Stacktrace` based on the given `error`
+// object. In the case of wrapped errors, the last/outter-most
+// stack trace is returned. If you need different behavior, you
+// may provide your own StacktraceExtractor function in the client
+// options.
+//
+// Use of reflection allows us to not have a hard dependency on any given
+// package, so we don't have to import it.
 func ExtractStacktrace(err error) *Stacktrace {
 	method := extractReflectedStacktraceMethod(err)
 


### PR DESCRIPTION
This PR makes it possible to use a custom stack-trace extractor function.  There was a TODO comment suggesting this as a possible feature, and I've found we need this feature, so I added it.

I look forward to any feedback.