### PR TITLE
Update echo middleware to get Hub instance from context

### DIFF
--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -55,7 +55,12 @@ func New(options Options) echo.MiddlewareFunc {
 
 func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		hub := sentry.CurrentHub().Clone()
+		var hub *sentry.Hub
+		if sentry.HasHubOnContext(ctx.Request().Context()) {
+			hub = sentry.GetHubFromContext(ctx.Request().Context())
+		} else {
+			hub = sentry.CurrentHub().Clone()
+		}
 		hub.Scope().SetRequest(ctx.Request())
 		ctx.Set(valuesKey, hub)
 		defer h.recoverWithSentry(hub, ctx.Request())


### PR DESCRIPTION
Modified to support getting `sentry.Hub` instance from parent Context to include extra fields defined in the parent context.

Background -- we use sentry with echo web framework in a AWS lambda environment behind AWS API Gateway. We have top-level sentry instance defined with extra fields. 

The purpose of this change is to use the existing hub on context by default.