### PR TITLE
Fix event init in eventFromException

### DIFF
--- a/client.go
+++ b/client.go
@@ -320,7 +320,8 @@ func (client *Client) eventFromException(exception error, level Level) *Event {
 		err = usageError{fmt.Errorf("%s called with nil error", callerFunctionName())}
 	}
 
-	event := &Event{Level: level}
+	event := NewEvent()
+	event.Level = level
 
 	for i := 0; i < maxErrorDepth && err != nil; i++ {
 		event.Exception = append(event.Exception, Exception{


### PR DESCRIPTION
In #185 the `event := NewEvent()` was changed to `event := &Event{Level: level}`. and caused this problem:`panic: assignment to entry in nil map` when you try to set value to `event.Extra`.
Extra useage example: https://github.com/getsentry/sentry-go/blob/master/example/with_extra/main.go#L56
