### PR TITLE
Make Hub and Scope nil safe

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -82,6 +82,9 @@ func CurrentHub() *Hub {
 
 // LastEventID returns an ID of last captured event for the current `Hub`.
 func (hub *Hub) LastEventID() EventID {
+	if hub == nil {
+		return ""
+	}
 	return hub.lastEventID
 }
 
@@ -105,6 +108,9 @@ func (hub *Hub) stackTop() *layer {
 
 // Clone returns a copy of the current Hub with top-most scope and client copied over.
 func (hub *Hub) Clone() *Hub {
+	if hub == nil {
+		return nil
+	}
 	top := hub.stackTop()
 	if top == nil {
 		return nil
@@ -118,6 +124,9 @@ func (hub *Hub) Clone() *Hub {
 
 // Scope returns top-level `Scope` of the current `Hub` or `nil` if no `Scope` is bound.
 func (hub *Hub) Scope() *Scope {
+	if hub == nil {
+		return nil
+	}
 	top := hub.stackTop()
 	if top == nil {
 		return nil
@@ -127,6 +136,9 @@ func (hub *Hub) Scope() *Scope {
 
 // Scope returns top-level `Client` of the current `Hub` or `nil` if no `Client` is bound.
 func (hub *Hub) Client() *Client {
+	if hub == nil {
+		return nil
+	}
 	top := hub.stackTop()
 	if top == nil {
 		return nil
@@ -136,6 +148,9 @@ func (hub *Hub) Client() *Client {
 
 // PushScope pushes a new scope for the current `Hub` and reuses previously bound `Client`.
 func (hub *Hub) PushScope() *Scope {
+	if hub == nil {
+		return nil
+	}
 	top := hub.stackTop()
 
 	var client *Client
@@ -163,6 +178,9 @@ func (hub *Hub) PushScope() *Scope {
 
 // PushScope pops the most recent scope for the current `Hub`.
 func (hub *Hub) PopScope() {
+	if hub == nil {
+		return
+	}
 	hub.mu.Lock()
 	defer hub.mu.Unlock()
 
@@ -175,6 +193,9 @@ func (hub *Hub) PopScope() {
 
 // BindClient binds a new `Client` for the current `Hub`.
 func (hub *Hub) BindClient(client *Client) {
+	if hub == nil {
+		return
+	}
 	top := hub.stackTop()
 	if top != nil {
 		top.SetClient(client)
@@ -206,6 +227,9 @@ func (hub *Hub) ConfigureScope(f func(scope *Scope)) {
 // passing it a top-level `Scope`.
 // Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
 func (hub *Hub) CaptureEvent(event *Event) *EventID {
+	if hub == nil {
+		return nil
+	}
 	client, scope := hub.Client(), hub.Scope()
 	if client == nil || scope == nil {
 		return nil
@@ -223,6 +247,9 @@ func (hub *Hub) CaptureEvent(event *Event) *EventID {
 // passing it a top-level `Scope`.
 // Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
 func (hub *Hub) CaptureMessage(message string) *EventID {
+	if hub == nil {
+		return nil
+	}
 	client, scope := hub.Client(), hub.Scope()
 	if client == nil || scope == nil {
 		return nil
@@ -240,6 +267,9 @@ func (hub *Hub) CaptureMessage(message string) *EventID {
 // passing it a top-level `Scope`.
 // Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
 func (hub *Hub) CaptureException(exception error) *EventID {
+	if hub == nil {
+		return nil
+	}
 	client, scope := hub.Client(), hub.Scope()
 	if client == nil || scope == nil {
 		return nil
@@ -258,6 +288,9 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 // The total number of breadcrumbs that can be recorded are limited by the
 // configuration on the client.
 func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
+	if hub == nil {
+		return
+	}
 	client := hub.Client()
 
 	// If there's no client, just store it on the scope straight away

--- a/scope.go
+++ b/scope.go
@@ -62,6 +62,9 @@ func NewScope() *Scope {
 // AddBreadcrumb adds new breadcrumb to the current scope
 // and optionally throws the old one if limit is reached.
 func (scope *Scope) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
+	if scope == nil {
+		return
+	}
 	if breadcrumb.Timestamp.IsZero() {
 		breadcrumb.Timestamp = time.Now().UTC()
 	}
@@ -79,6 +82,9 @@ func (scope *Scope) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
 
 // ClearBreadcrumbs clears all breadcrumbs from the current scope.
 func (scope *Scope) ClearBreadcrumbs() {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -87,6 +93,9 @@ func (scope *Scope) ClearBreadcrumbs() {
 
 // SetUser sets the user for the current scope.
 func (scope *Scope) SetUser(user User) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -95,6 +104,9 @@ func (scope *Scope) SetUser(user User) {
 
 // SetRequest sets the request for the current scope.
 func (scope *Scope) SetRequest(r *http.Request) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -126,6 +138,9 @@ func (scope *Scope) SetRequest(r *http.Request) {
 // in memory. Typically, the request body is buffered lazily from the
 // Request.Body from SetRequest.
 func (scope *Scope) SetRequestBody(b []byte) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -186,6 +201,9 @@ type readCloser struct {
 
 // SetTag adds a tag to the current scope.
 func (scope *Scope) SetTag(key, value string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -194,6 +212,9 @@ func (scope *Scope) SetTag(key, value string) {
 
 // SetTags assigns multiple tags to the current scope.
 func (scope *Scope) SetTags(tags map[string]string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -204,6 +225,9 @@ func (scope *Scope) SetTags(tags map[string]string) {
 
 // RemoveTag removes a tag from the current scope.
 func (scope *Scope) RemoveTag(key string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -212,6 +236,9 @@ func (scope *Scope) RemoveTag(key string) {
 
 // SetContext adds a context to the current scope.
 func (scope *Scope) SetContext(key string, value interface{}) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -220,6 +247,9 @@ func (scope *Scope) SetContext(key string, value interface{}) {
 
 // SetContexts assigns multiple contexts to the current scope.
 func (scope *Scope) SetContexts(contexts map[string]interface{}) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -230,6 +260,9 @@ func (scope *Scope) SetContexts(contexts map[string]interface{}) {
 
 // RemoveContext removes a context from the current scope.
 func (scope *Scope) RemoveContext(key string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -238,6 +271,9 @@ func (scope *Scope) RemoveContext(key string) {
 
 // SetExtra adds an extra to the current scope.
 func (scope *Scope) SetExtra(key string, value interface{}) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -246,6 +282,9 @@ func (scope *Scope) SetExtra(key string, value interface{}) {
 
 // SetExtras assigns multiple extras to the current scope.
 func (scope *Scope) SetExtras(extra map[string]interface{}) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -256,6 +295,9 @@ func (scope *Scope) SetExtras(extra map[string]interface{}) {
 
 // RemoveExtra removes a extra from the current scope.
 func (scope *Scope) RemoveExtra(key string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -264,6 +306,9 @@ func (scope *Scope) RemoveExtra(key string) {
 
 // SetFingerprint sets new fingerprint for the current scope.
 func (scope *Scope) SetFingerprint(fingerprint []string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -272,6 +317,9 @@ func (scope *Scope) SetFingerprint(fingerprint []string) {
 
 // SetLevel sets new level for the current scope.
 func (scope *Scope) SetLevel(level Level) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -280,6 +328,9 @@ func (scope *Scope) SetLevel(level Level) {
 
 // SetTransaction sets new transaction name for the current transaction.
 func (scope *Scope) SetTransaction(transactionName string) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -288,6 +339,9 @@ func (scope *Scope) SetTransaction(transactionName string) {
 
 // Clone returns a copy of the current scope with all data copied over.
 func (scope *Scope) Clone() *Scope {
+	if scope == nil {
+		return nil
+	}
 	scope.mu.RLock()
 	defer scope.mu.RUnlock()
 
@@ -315,11 +369,17 @@ func (scope *Scope) Clone() *Scope {
 
 // Clear removes the data from the current scope. Not safe for concurrent use.
 func (scope *Scope) Clear() {
+	if scope == nil {
+		return
+	}
 	*scope = *NewScope()
 }
 
 // AddEventProcessor adds an event processor to the current scope.
 func (scope *Scope) AddEventProcessor(processor EventProcessor) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -328,6 +388,9 @@ func (scope *Scope) AddEventProcessor(processor EventProcessor) {
 
 // ApplyToEvent takes the data from the current scope and attaches it to the event.
 func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
+	if scope == nil {
+		return nil
+	}
 	scope.mu.RLock()
 	defer scope.mu.RUnlock()
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -624,3 +624,35 @@ func TestEventProcessorsAddEventProcessor(t *testing.T) {
 		t.Error("event should be dropped")
 	}
 }
+
+func TestNilScope(t *testing.T) {
+	var scope *Scope
+
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: time.Now(), Message: "test"}, maxBreadcrumbs)
+	scope.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+		return nil
+	})
+	if event := scope.ApplyToEvent(fillEventWithData(NewEvent()), nil); event != nil {
+		t.Error(event)
+	}
+	scope.Clear()
+	scope.ClearBreadcrumbs()
+	if s := scope.Clone(); s != nil {
+		t.Error(s)
+	}
+	scope.RemoveContext("key")
+	scope.RemoveExtra("key")
+	scope.RemoveTag("key")
+	scope.SetContext("zip", "zap")
+	scope.SetContexts(map[string]interface{}{"zip": "zap"})
+	scope.SetExtra("zip", "zap")
+	scope.SetExtras(map[string]interface{}{"zip": "zap"})
+	scope.SetFingerprint([]string{"fingerprint"})
+	scope.SetLevel(LevelInfo)
+	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
+	scope.SetRequestBody([]byte("this is the body"))
+	scope.SetTag("zip", "zap")
+	scope.SetTags(map[string]string{"zip": "zap"})
+	scope.SetTransaction("transactionName")
+	scope.SetUser(User{ID: "foo"})
+}


### PR DESCRIPTION
Hi!

This PR makes the `*Hub` and `*Scope` methods safe to call with a nil receiver.

This is useful since it makes instrumentation easier:  The consumer doesn't need to worry about doing nil checks when using `GetHubFromContext`:
```go
func myFunc(ctx context.Context) {
	hub := sentry.GetHubFromContext(ctx)
	hub.CaptureMessage("zip zap")
}
```

This is particularly useful in unit test situations where the context (or something else that contains the hub) is not fully populated.  Consumers can still check `hub != nil` if they want to know if the hub is there and the error will be recored.

Thank you for your consideration!
