### PR TITLE
fix: Stop test early on bad condition

### DIFF
--- a/scope_test.go
+++ b/scope_test.go
@@ -585,7 +585,7 @@ func TestEventProcessorsModifiesEvent(t *testing.T) {
 	processedEvent := scope.ApplyToEvent(event, nil)
 
 	if processedEvent == nil {
-		t.Error("event should not be dropped")
+		t.Fatal("event should not be dropped")
 	}
 	assertEqual(t, LevelFatal, processedEvent.Level)
 	assertEqual(t, []string{"wat"}, processedEvent.Fingerprint)


### PR DESCRIPTION
If processedEvent is nil, it is a runtime panic to access any of its fields.