### PR TITLE
feat: Add option to compress requests with gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "I am running away from my responsibilities. And it feels good." – Michael Scott, Season 4, "Money"
+- feat: Add option to compress requests with gzip (#231)
 
 ## v0.6.1
 

--- a/client.go
+++ b/client.go
@@ -48,6 +48,15 @@ func AddGlobalEventProcessor(processor EventProcessor) {
 	globalEventProcessors = append(globalEventProcessors, processor)
 }
 
+// Encoding represents encoding types for a request body
+type Encoding string
+
+// Enum representing possible encoding types
+const (
+	JSON Encoding = "json"
+	GZIP Encoding = "gzip"
+)
+
 // Integration allows for registering a functions that modify or discard captured events.
 type Integration interface {
 	Name() string
@@ -91,6 +100,10 @@ type ClientOptions struct {
 	Environment string
 	// Maximum number of breadcrumbs.
 	MaxBreadcrumbs int
+	// Decides how request body is encoded
+	// Current options are json and gzip
+	// Defaults to json
+	Encoding Encoding
 	// An optional pointer to `http.Client` that will be used with a default HTTPTransport.
 	// Using your own client will make HTTPTransport, HTTPProxy, HTTPSProxy and CaCerts options ignored.
 	HTTPClient *http.Client
@@ -139,6 +152,10 @@ func NewClient(options ClientOptions) (*Client, error) {
 
 	if options.Environment == "" {
 		options.Environment = os.Getenv("SENTRY_ENVIRONMENT")
+	}
+
+	if options.Encoding == "" {
+		options.Encoding = JSON
 	}
 
 	var dsn *Dsn


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-go/issues/230

## Motivation

The `store` endpoint has [support](https://develop.sentry.dev/sdk/store/#request-compression) for gzipped compressed request bodies. We should implement this functionality for the SDK.

## Implementation

I create a `Encoding` config option, that currently has two options, `json` (our current implementation) and `gzip` (the new addition from this PR). This config option is read by the transport to decide how to encode the request body. This option defaults to `json` (and if incorrectly set, will just use `json` anyway).

## Testing
I wrote a unit test for the function that encodes the request body.

