### PR TITLE
ref: Simplify MarshalJSON implementations

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -67,11 +67,7 @@ func (b *Breadcrumb) MarshalJSON() ([]byte, error) {
 			alias: (*alias)(b),
 		})
 	}
-	return json.Marshal(&struct {
-		*alias
-	}{
-		alias: (*alias)(b),
-	})
+	return json.Marshal((*alias)(b))
 }
 
 // https://docs.sentry.io/development/sdk-dev/event-payloads/user/
@@ -184,11 +180,7 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 			alias: (*alias)(e),
 		})
 	}
-	return json.Marshal(&struct {
-		*alias
-	}{
-		alias: (*alias)(e),
-	})
+	return json.Marshal((*alias)(e))
 }
 
 func NewEvent() *Event {


### PR DESCRIPTION
There is no need to embed the alias type in a struct when the aliased
type is already a struct itself and there are no new/shadowed fields.

A type conversion does the job of triggering the default json.Marshal
behavior.