### PR TITLE
feat: Add transactions to sync transport

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -416,16 +416,10 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		return
 	}
 
-	body := getRequestBodyFromEvent(event)
-	if body == nil {
+	request, err := getRequestFromEvent(event, t.dsn)
+	if err != nil {
 		return
 	}
-
-	request, _ := http.NewRequest(
-		http.MethodPost,
-		t.dsn.StoreAPIURL().String(),
-		bytes.NewBuffer(body),
-	)
 
 	for headerKey, headerValue := range t.dsn.RequestHeaders() {
 		request.Header.Set(headerKey, headerValue)


### PR DESCRIPTION
PR Addressing https://github.com/getsentry/sentry-go/pull/235#discussion_r434773906

We previously merged in new `Transaction` interfaces, and support for using the `envelopes` endpoint, but we only updated the async transport.

This PR updates `HTTPSyncTransport` to use `getRequestFromEvent`.