### PR TITLE
fix: clone request body to new scope

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -309,6 +309,7 @@ func (scope *Scope) Clone() *Scope {
 	clone.level = scope.level
 	clone.transaction = scope.transaction
 	clone.request = scope.request
+	clone.requestBody = scope.requestBody
 
 	return clone
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -368,9 +368,11 @@ func TestAddBreadcrumbAddsTimestamp(t *testing.T) {
 func TestScopeBasicInheritance(t *testing.T) {
 	scope := NewScope()
 	scope.SetExtra("a", 1)
+	scope.SetRequestBody([]byte("requestbody"))
 	clone := scope.Clone()
 
 	assertEqual(t, scope.extra, clone.extra)
+	assertEqual(t, scope.requestBody, clone.requestBody)
 }
 
 func TestScopeParentChangedInheritance(t *testing.T) {


### PR DESCRIPTION
### The problem

I applied sentryecho middleware to my echo application, when capturing exception in `withScope`, the request body was not recorded.

### Fix
Assign clone's request body to original scope