### PR TITLE
doc: Add comments to all exported types and methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ Hey, thank you if you're reading this, we welcome your contribution!
 Please help us save time when reviewing your PR by following this simple
 process:
 
-1. Is your PR a simple typo fix? Read no further, __click that green "Create
-   pull request" button__!
+1. Is your PR a simple typo fix? Read no further, **click that green "Create
+   pull request" button**!
 
 2. For more complex PRs that involve behavior changes or new APIs, please
-   consider [opening an __issue__][new-issue] describing the problem you're
+   consider [opening an **issue**][new-issue] describing the problem you're
    trying to solve if there's not one already.
 
    A PR is often one specific solution to a problem and sometimes talking about
@@ -27,7 +27,7 @@ process:
 5. We have [guidelines for PR submitters][pr-guide]. A short summary:
 
    - Good PR descriptions are very helpful and most of the time they include
-     __why__ something is done and why done in this particular way. Also list
+     **why** something is done and why done in this particular way. Also list
      other possible solutions that were considered and discarded.
    - Be your own first reviewer. Make sure your code compiles and passes the
      existing tests.
@@ -35,6 +35,10 @@ process:
 [new-issue]: https://github.com/getsentry/sentry-go/issues/new/choose
 [commit-guide]: https://develop.sentry.dev/code-review/#commit-guidelines
 [pr-guide]: https://develop.sentry.dev/code-review/#guidelines-for-submitters
+
+Please also read through our [SDK Development docs](https://develop.sentry.dev/sdk/).
+It contains information about SDK features, expected payloads and best practices for
+contributing to Sentry SDKs.
 
 ## Community
 
@@ -61,6 +65,7 @@ $ go test -race
 ```
 
 ### Coverage
+
 ```console
 $ go test -race -coverprofile=coverage.txt -covermode=atomic && go tool cover -html coverage.txt
 ```
@@ -75,17 +80,17 @@ $ golangci-lint run
 
 1. Update `CHANGELOG.md` with new version in `vX.X.X` format title and list of changes.
 
-    The command below can be used to get a list of changes since the last tag, with the format used in `CHANGELOG.md`:
+   The command below can be used to get a list of changes since the last tag, with the format used in `CHANGELOG.md`:
 
-    ```console
-    $ git log --no-merges --format=%s $(git describe --abbrev=0).. | sed 's/^/- /'
-    ```
+   ```console
+   $ git log --no-merges --format=%s $(git describe --abbrev=0).. | sed 's/^/- /'
+   ```
 
 2. Commit with `misc: vX.X.X changelog` commit message and push to `master`.
 
 3. Let [`craft`](https://github.com/getsentry/craft) do the rest:
 
-    ```console
-    $ craft prepare X.X.X
-    $ craft publish X.X.X
-    ```
+   ```console
+   $ craft prepare X.X.X
+   $ craft publish X.X.X
+   ```

--- a/client.go
+++ b/client.go
@@ -36,14 +36,22 @@ type usageError struct {
 // can be enabled by either using `Logger.SetOutput` directly or with `Debug` client option
 var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags) //nolint: gochecknoglobals
 
+// EventProcessor is a function that processes an event.
+// Event processors are used to change an event before it is sent to Sentry.
 type EventProcessor func(event *Event, hint *EventHint) *Event
 
+// EventModifier is the interface that wraps the ApplyToEvent method.
+//
+// ApplyToEvent changes an event based on external data and/or
+// an event hint.
 type EventModifier interface {
 	ApplyToEvent(event *Event, hint *EventHint) *Event
 }
 
 var globalEventProcessors []EventProcessor //nolint: gochecknoglobals
 
+// AddGlobalEventProcessor adds a EventProcessor to the global list of
+// event processors.
 func AddGlobalEventProcessor(processor EventProcessor) {
 	globalEventProcessors = append(globalEventProcessors, processor)
 }
@@ -252,7 +260,7 @@ func (client *Client) Recover(err interface{}, hint *EventHint, scope EventModif
 	return nil
 }
 
-// Recover captures a panic and passes relevant context object.
+// RecoverWithContext captures a panic and passes relevant context object.
 // Returns `EventID` if successfully, or `nil` if there's no error to recover from.
 func (client *Client) RecoverWithContext(
 	ctx context.Context,

--- a/dsn.go
+++ b/dsn.go
@@ -27,6 +27,8 @@ func (scheme scheme) defaultPort() int {
 	}
 }
 
+// DsnParseError represents an error that occurs if a Sentry
+// DSN cannot be parsed.
 type DsnParseError struct {
 	Message string
 }
@@ -182,10 +184,12 @@ func (dsn Dsn) RequestHeaders() map[string]string {
 	}
 }
 
+// MarshalJSON converts the Dsn struct to JSON.
 func (dsn Dsn) MarshalJSON() ([]byte, error) {
 	return json.Marshal(dsn.String())
 }
 
+// UnmarshalJSON converts JSON data to the Dsn struct.
 func (dsn *Dsn) UnmarshalJSON(data []byte) error {
 	var str string
 	_ = json.Unmarshal(data, &str)

--- a/hub.go
+++ b/hub.go
@@ -125,7 +125,7 @@ func (hub *Hub) Scope() *Scope {
 	return top.scope
 }
 
-// Scope returns top-level `Client` of the current `Hub` or `nil` if no `Client` is bound.
+// Client returns top-level `Client` of the current `Hub` or `nil` if no `Client` is bound.
 func (hub *Hub) Client() *Client {
 	top := hub.stackTop()
 	if top == nil {
@@ -161,7 +161,7 @@ func (hub *Hub) PushScope() *Scope {
 	return scope
 }
 
-// PushScope pops the most recent scope for the current `Hub`.
+// PopScope pops the most recent scope for the current `Hub`.
 func (hub *Hub) PopScope() {
 	hub.mu.Lock()
 	defer hub.mu.Unlock()

--- a/interfaces.go
+++ b/interfaces.go
@@ -29,8 +29,6 @@ const (
 )
 
 // SdkInfo contains all metadata about about the SDK being used
-//
-// https://develop.sentry.dev/sdk/event-payloads/sdk/
 type SdkInfo struct {
 	Name         string       `json:"name,omitempty"`
 	Version      string       `json:"version,omitempty"`
@@ -52,8 +50,6 @@ type BreadcrumbHint map[string]interface{}
 
 // Breadcrumb specifies an application event that occurred before a Sentry event.
 // An event may contain one or more breadcrumbs.
-//
-// https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
 type Breadcrumb struct {
 	Category  string                 `json:"category,omitempty"`
 	Data      map[string]interface{} `json:"data,omitempty"`
@@ -85,8 +81,6 @@ func (b *Breadcrumb) MarshalJSON() ([]byte, error) {
 // User describes a user associated to an Event. You should provide
 // atleast an id (a unique identifier for a user) or an ip address
 // if this struct is used.
-//
-// https://develop.sentry.dev/sdk/event-payloads/user/
 type User struct {
 	Email     string `json:"email,omitempty"`
 	ID        string `json:"id,omitempty"`
@@ -95,8 +89,6 @@ type User struct {
 }
 
 // Request contains information on a HTTP request related to the event.
-//
-// https://develop.sentry.dev/sdk/event-payloads/request/
 type Request struct {
 	URL         string            `json:"url,omitempty"`
 	Method      string            `json:"method,omitempty"`
@@ -146,8 +138,6 @@ func NewRequest(r *http.Request) *Request {
 }
 
 // Exception specifies an error or exception that occurred
-//
-// https://develop.sentry.dev/sdk/event-payloads/exception/
 type Exception struct {
 	Type          string      `json:"type,omitempty"`
 	Value         string      `json:"value,omitempty"`
@@ -162,8 +152,6 @@ type Exception struct {
 type EventID string
 
 // Event is the fundamental data structure that is sent to Sentry.
-//
-// https://develop.sentry.dev/sdk/event-payloads/
 type Event struct {
 	Breadcrumbs []*Breadcrumb          `json:"breadcrumbs,omitempty"`
 	Contexts    map[string]interface{} `json:"contexts,omitempty"`
@@ -249,8 +237,6 @@ func NewEvent() *Event {
 }
 
 // Thread specifies threads that were running at the time of an event
-//
-// https://develop.sentry.dev/sdk/event-payloads/threads/
 type Thread struct {
 	ID            string      `json:"id,omitempty"`
 	Name          string      `json:"name,omitempty"`
@@ -285,7 +271,6 @@ type TraceContext struct {
 // Span describes a timed unit of work in a trace.
 //
 // Experimental: This is part of a beta feature of the SDK.
-// https://develop.sentry.dev/sdk/event-payloads/span/
 type Span struct {
 	TraceID        string            `json:"trace_id"`
 	SpanID         string            `json:"span_id"`

--- a/interfaces.go
+++ b/interfaces.go
@@ -50,7 +50,7 @@ type SdkPackage struct {
 // plus it could just be `map[string]interface{}` then
 type BreadcrumbHint map[string]interface{}
 
-// Breadcrumb specifies an application event that occured before a Sentry event.
+// Breadcrumb specifies an application event that occurred before a Sentry event.
 // An event may contain one or more breadcrumbs.
 //
 // https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
@@ -145,7 +145,7 @@ func NewRequest(r *http.Request) *Request {
 	}
 }
 
-// Exception specifies an error or exception that occured
+// Exception specifies an error or exception that occurred
 //
 // https://develop.sentry.dev/sdk/event-payloads/exception/
 type Exception struct {

--- a/scope.go
+++ b/scope.go
@@ -47,6 +47,7 @@ type Scope struct {
 	eventProcessors []EventProcessor
 }
 
+// NewScope creates a new Scope
 func NewScope() *Scope {
 	scope := Scope{
 		breadcrumbs: make([]*Breadcrumb, 0),

--- a/sentry.go
+++ b/sentry.go
@@ -63,7 +63,7 @@ func Recover() *EventID {
 	return nil
 }
 
-// Recover captures a panic and passes relevant context object.
+// RecoverWithContext captures a panic and passes relevant context object.
 func RecoverWithContext(ctx context.Context) *EventID {
 	if err := recover(); err != nil {
 		var hub *Hub

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -18,6 +18,8 @@ const unknown string = "unknown"
 // https://github.com/golang/go/issues/26913#issuecomment-411976222
 
 // Stacktrace holds information about the frames of the stack.
+//
+// https://develop.sentry.dev/sdk/event-payloads/stacktrace/
 type Stacktrace struct {
 	Frames        []Frame `json:"frames,omitempty"`
 	FramesOmitted []uint  `json:"frames_omitted,omitempty"`
@@ -127,7 +129,8 @@ func extractPcs(method reflect.Value) []uintptr {
 	return pcs
 }
 
-// https://docs.sentry.io/development/sdk-dev/event-payloads/stacktrace/
+// Frame represents a function call and it's metadata. Frames are associated
+// with a Stacktrace.
 type Frame struct {
 	Function    string                 `json:"function,omitempty"`
 	Symbol      string                 `json:"symbol,omitempty"`

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -18,8 +18,6 @@ const unknown string = "unknown"
 // https://github.com/golang/go/issues/26913#issuecomment-411976222
 
 // Stacktrace holds information about the frames of the stack.
-//
-// https://develop.sentry.dev/sdk/event-payloads/stacktrace/
 type Stacktrace struct {
 	Frames        []Frame `json:"frames,omitempty"`
 	FramesOmitted []uint  `json:"frames_omitted,omitempty"`


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-go/issues/239

This PR adds comments to all Exported Types and Methods. It also links to the relevant SDK documentation where possible.

There are no code changes, only comments.