### PR TITLE
fix: wg.Done() must be outside RecoverRepanic

### DIFF
--- a/example/recover-repanic/main.go
+++ b/example/recover-repanic/main.go
@@ -70,6 +70,12 @@ func main() {
 
 // RecoverRepanic calls f and, in case of a runtime panic, reports the panic to
 // Sentry and repanics.
+//
+// Note that if RecoverRepanic is called from multiple goroutines and they panic
+// concurrently, then the repanic initiated from RecoverRepanic, unless handled
+// further down the call stack, will cause the program to crash without waiting
+// for other goroutines to finish their work. That means that most likely only
+// the first panic will be successfully reported to Sentry.
 func RecoverRepanic(f func()) {
 	// Clone the current hub so that modifications of the scope are visible only
 	// within this function.


### PR DESCRIPTION
This is a small change to the example for correctness.
The concurrency issue is subtle, but here is an attempt to explain it.

Keep in mind that:
- deferred calls happen in reverse order.
- to recover from panics in f, RecoverRepanic must defer a func call
before calling f.

If defer wg.Done() is part of f, the argument passed to RecoverRepanic,
it means it will be called before any deferred functions setup by
RecoverRepanic itself. If all goroutines started in the loop would call
wg.Done() before an event is reported to Sentry, the main goroutine
blocked on wg.Wait() would unblock and reach the end of func main,
terminating the execution of the program, consequently dropping any
other pending work in other goroutines, reporting to Sentry included.

---

I had this change locally and forgot to include in #241, my bad.