### PR TITLE
Tweak golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,9 +34,6 @@ linters:
     - unused
     - varcheck
 issues:
-  exclude:
-    - "not declared by package utf8"
-    - "unicode/utf8/utf8.go"
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - unparam
     - unused
     - varcheck
+    - whitespace
 issues:
   exclude-rules:
     - path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,10 +33,6 @@ linters:
     - unparam
     - unused
     - varcheck
-run:
-  skip-dirs:
-    - echo
-    - example/echo
 issues:
   exclude:
     - "not declared by package utf8"


### PR DESCRIPTION
- Add `whitespace` linter to check for unnecessary newlines at the start and end of functions, if, for, etc.
- Remove unnecessary exclude rules.