### PR TITLE
fix: Dubious conversion from int to string in test

### DIFF
--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -1,7 +1,7 @@
 package sentry_test
 
 import (
-	"errors"
+	"fmt"
 	"net/http/httptest"
 	"sync"
 	"testing"
@@ -58,7 +58,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.SetUser(sentry.User{ID: "foo"})
 	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
 
-	sentry.CaptureException(errors.New(string(x)))
+	sentry.CaptureException(fmt.Errorf("error %d", x))
 
 	scope.ClearBreadcrumbs()
 	scope.Clone()


### PR DESCRIPTION
This fixes a go vet check enabled by default in Go 1.15 and run as part of go test.

Does not affect any SDK functionality.

---

See https://travis-ci.com/github/getsentry/sentry-go/jobs/350136321#L407

![image](https://user-images.githubusercontent.com/88819/85010437-4d4ba000-b160-11ea-8e1a-f91bdb8e4ab3.png)
