### PR TITLE
Avoid expensive operations in CaptureEvent hot path

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,14 @@ import (
 // stack trace is often the most useful information.
 const maxErrorDepth = 10
 
+// hostname is the host name reported by the kernel. It is precomputed once to
+// avoid syscalls when capturing events.
+//
+// The error is ignored because retrieving the host name is best-effort. If the
+// error is non-nil, there is nothing to do other than retrying. We choose not
+// to retry for now.
+var hostname, _ = os.Hostname()
+
 // usageError is used to report to Sentry an SDK usage error.
 //
 // It is not exported because it is never returned by any function or method in
@@ -423,7 +431,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 	if event.ServerName == "" {
 		if client.Options().ServerName != "" {
 			event.ServerName = client.Options().ServerName
-		} else if hostname, err := os.Hostname(); err == nil {
+		} else {
 			event.ServerName = hostname
 		}
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -381,3 +381,15 @@ func TestSampleRate(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkProcessEvent(b *testing.B) {
+	c, err := NewClient(ClientOptions{
+		SampleRate: 0.25,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		c.processEvent(&Event{}, nil, nil)
+	}
+}


### PR DESCRIPTION
The original motivation was noticing that calling `rand.New` in `Client.processEvent` was odd.

Writing a small benchmark reviewed that calling `os.Hostname()` for every event was also wasteful.

This PR addresses only those two points and is not meant as a comprehensive optimization effort.

The two changes combined result in this [`benchstat`](//golang.org/x/perf/cmd/benchstat) output:

## go version go1.14.3 darwin/amd64

```
name             old time/op    new time/op    delta
ProcessEvent-16    10.3µs ±15%     0.8µs ± 3%  -92.11%  (p=0.000 n=8+7)

name             old alloc/op   new alloc/op   delta
ProcessEvent-16    6.45kB ± 1%    1.02kB ± 0%  -84.14%  (p=0.000 n=8+8)

name             old allocs/op  new allocs/op  delta
ProcessEvent-16      8.25 ± 9%      6.00 ± 0%  -27.27%  (p=0.000 n=8+8)
```

## go version go1.14.4 linux/amd64

```
name            old time/op    new time/op    delta
ProcessEvent-8    10.9µs ± 0%     1.1µs ± 2%  -89.49%  (p=0.001 n=7+7)

name            old alloc/op   new alloc/op   delta
ProcessEvent-8    6.41kB ± 0%    1.02kB ± 0%  -84.02%  (p=0.000 n=8+8)

name            old allocs/op  new allocs/op  delta
ProcessEvent-8      7.50 ± 7%      6.00 ± 0%  -20.00%  (p=0.000 n=8+8)
```