### PR TITLE
feat: use Hub from request context when available

### DIFF
--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -55,10 +55,8 @@ func New(options Options) echo.MiddlewareFunc {
 
 func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		var hub *sentry.Hub
-		if sentry.HasHubOnContext(ctx.Request().Context()) {
-			hub = sentry.GetHubFromContext(ctx.Request().Context())
-		} else {
+		hub := sentry.GetHubFromContext(ctx.Request().Context())
+		if hub == nil {
 			hub = sentry.CurrentHub().Clone()
 		}
 		hub.Scope().SetRequest(ctx.Request())

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -63,6 +63,10 @@ func New(options Options) *Handler {
 // Handle wraps fasthttp.RequestHandler and recovers from caught panics.
 func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
+		// Unlike for other integrations, we don't support getting an existing
+		// hub from the current request context because fasthttp doesn't use the
+		// standard net/http.Request and because fasthttp.RequestCtx implements
+		// context.Context but requires string keys.
 		hub := sentry.CurrentHub().Clone()
 		scope := hub.Scope()
 		scope.SetRequest(convert(ctx))

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -57,7 +57,10 @@ func New(options Options) gin.HandlerFunc {
 }
 
 func (h *handler) handle(ctx *gin.Context) {
-	hub := sentry.CurrentHub().Clone()
+	hub := sentry.GetHubFromContext(ctx.Request.Context())
+	if hub == nil {
+		hub = sentry.CurrentHub().Clone()
+	}
 	hub.Scope().SetRequest(ctx.Request)
 	ctx.Set(valuesKey, hub)
 	defer h.recoverWithSentry(hub, ctx.Request)

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -56,7 +56,10 @@ func New(options Options) iris.Handler {
 }
 
 func (h *handler) handle(ctx iris.Context) {
-	hub := sentry.CurrentHub().Clone()
+	hub := sentry.GetHubFromContext(ctx.Request().Context())
+	if hub == nil {
+		hub = sentry.CurrentHub().Clone()
+	}
 	hub.Scope().SetRequest(ctx.Request())
 	ctx.Values().Set(valuesKey, hub)
 	defer h.recoverWithSentry(hub, ctx.Request())

--- a/martini/sentrymartini.go
+++ b/martini/sentrymartini.go
@@ -52,7 +52,10 @@ func New(options Options) martini.Handler {
 }
 
 func (h *handler) handle(rw http.ResponseWriter, r *http.Request, ctx martini.Context) {
-	hub := sentry.CurrentHub().Clone()
+	hub := sentry.GetHubFromContext(r.Context())
+	if hub == nil {
+		hub = sentry.CurrentHub().Clone()
+	}
 	hub.Scope().SetRequest(r)
 	ctx.Map(hub)
 	defer h.recoverWithSentry(hub, r)

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -52,10 +52,14 @@ func New(options Options) negroni.Handler {
 }
 
 func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	hub := sentry.CurrentHub().Clone()
+	ctx := r.Context()
+	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub().Clone()
+	}
 	hub.Scope().SetRequest(r)
-	ctx := sentry.SetHubOnContext(
-		context.WithValue(r.Context(), sentry.RequestContextKey, r),
+	ctx = sentry.SetHubOnContext(
+		context.WithValue(ctx, sentry.RequestContextKey, r),
 		hub,
 	)
 	defer h.recoverWithSentry(hub, r)


### PR DESCRIPTION
This allows users to setup a request-scoped Hub with relevant data in a middleware that runs before the web frameworks we integrate with.

A typical case is AWS Lambda + Web Framework. See https://github.com/getsentry/sentry-go/pull/217#issuecomment-635730182 for an example.

This is a follow-up on #217.