### PR TITLE
docs: Deprecate AddGlobalEventProcessor

### DIFF
--- a/client.go
+++ b/client.go
@@ -87,6 +87,8 @@ var globalEventProcessors []EventProcessor
 
 // AddGlobalEventProcessor adds processor to the global list of event
 // processors. Global event processors apply to all events.
+//
+// Deprecated: Use Scope.AddEventProcessor or Client.AddEventProcessor instead.
 func AddGlobalEventProcessor(processor EventProcessor) {
 	globalEventProcessors = append(globalEventProcessors, processor)
 }


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-go/issues/147.

Since the next release will be the first to include a doc comment for `AddGlobalEventProcessor`, let's mark it as deprecated as a first step and perhaps remove it in a future release.