### PR TITLE
feat: Send debug logging to stderr by default

### DIFF
--- a/client.go
+++ b/client.go
@@ -169,7 +169,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 	if options.Debug {
 		debugWriter := options.DebugWriter
 		if debugWriter == nil {
-			debugWriter = os.Stdout
+			debugWriter = os.Stderr
 		}
 		Logger.SetOutput(debugWriter)
 	}


### PR DESCRIPTION
The [standard logger from Go's log package writes to stderr by default](https://github.com/golang/go/blob/0951939fd9e4a6bc83f23c42e8ddff02b29c997e/src/log/log.go#L76) and that is [the more conventional tradition](https://unix.stackexchange.com/a/331808).

This makes it so that enabling debug output without defining an output stream will use stderr instead of stdout. Users can then filter stderr to inspect SDK debug messages.

Fixes #154.