### PR TITLE
feat: Report bad usage of CaptureMessage and CaptureEvent

### DIFF
--- a/client.go
+++ b/client.go
@@ -346,6 +346,10 @@ func (client *Client) Flush(timeout time.Duration) bool {
 }
 
 func (client *Client) eventFromMessage(message string, level Level) *Event {
+	if message == "" {
+		err := usageError{fmt.Errorf("%s called with empty message", callerFunctionName())}
+		return client.eventFromException(err, level)
+	}
 	event := NewEvent()
 	event.Level = level
 	event.Message = message
@@ -409,6 +413,11 @@ func reverse(a []Exception) {
 }
 
 func (client *Client) processEvent(event *Event, hint *EventHint, scope EventModifier) *EventID {
+	if event == nil {
+		err := usageError{fmt.Errorf("%s called with nil event", callerFunctionName())}
+		return client.CaptureException(err, hint, scope)
+	}
+
 	options := client.Options()
 
 	// TODO: Reconsider if its worth going away from default implementation


### PR DESCRIPTION
Calling `CaptureException` with a nil error reports a usage error to Sentry.

Before this change, `CaptureMessage("")` resulted in an event in Sentry called `'<unlabeled event>'`. `CaptureEvent(nil)` resulted in a run-time panic.

This change makes `CaptureMessage` and `CaptureEvent` behave similar to `CaptureException`, reporting an usage error to help users spot and fix instrumentation mistakes.

Fixes #202.

## Before

![image](https://user-images.githubusercontent.com/88819/87965817-a9d21000-cabc-11ea-82b7-e0d395d6232d.png)
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1330ee0]

goroutine 1 [running]:
github.com/getsentry/sentry-go.(*Client).prepareEvent(0xc00013a500, 0x0, 0x0, 0x147cc80, 0xc000156000, 0xc000014401)
       client.go:399 +0x50
github.com/getsentry/sentry-go.(*Client).processEvent(0xc00013a500, 0x0, 0x0, 0x147cc80, 0xc000156000, 0x0)
        client.go:378 +0x237
github.com/getsentry/sentry-go.(*Client).CaptureEvent(...)
        client.go:230
github.com/getsentry/sentry-go.(*Hub).CaptureEvent(0xc000109050, 0x0, 0x3)
        hub.go:213 +0xa9
github.com/getsentry/sentry-go.CaptureEvent(...)
        sentry.go:54
```

## After

![image](https://user-images.githubusercontent.com/88819/88025366-76cb6300-cb34-11ea-9bbc-ec446c75ea37.png)
![image](https://user-images.githubusercontent.com/88819/87965952-d6862780-cabc-11ea-9d07-e92c3a6cea28.png)

Plus each event include a stack trace.