### PR TITLE
ci: Test against go1.15, drop go1.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
   - 1.14.x
+  - 1.15.x
   - master
 
 env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.12
+go 1.13
 
 require (
 	github.com/ajg/form v1.5.1 // indirect


### PR DESCRIPTION
With the [release of go1.15](https://golang.org/doc/go1.15), update the list of supported versions.