### PR TITLE
fix: Remove RawStacktrace

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -139,12 +139,11 @@ func NewRequest(r *http.Request) *Request {
 
 // Exception specifies an error that occurred.
 type Exception struct {
-	Type          string      `json:"type,omitempty"`
-	Value         string      `json:"value,omitempty"`
-	Module        string      `json:"module,omitempty"`
-	ThreadID      string      `json:"thread_id,omitempty"`
-	Stacktrace    *Stacktrace `json:"stacktrace,omitempty"`
-	RawStacktrace *Stacktrace `json:"raw_stacktrace,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	Value      string      `json:"value,omitempty"`
+	Module     string      `json:"module,omitempty"`
+	ThreadID   string      `json:"thread_id,omitempty"`
+	Stacktrace *Stacktrace `json:"stacktrace,omitempty"`
 }
 
 // EventID is a hexadecimal string representing a unique uuid4 for an Event.
@@ -238,12 +237,11 @@ func NewEvent() *Event {
 
 // Thread specifies threads that were running at the time of an event.
 type Thread struct {
-	ID            string      `json:"id,omitempty"`
-	Name          string      `json:"name,omitempty"`
-	Stacktrace    *Stacktrace `json:"stacktrace,omitempty"`
-	RawStacktrace *Stacktrace `json:"raw_stacktrace,omitempty"`
-	Crashed       bool        `json:"crashed,omitempty"`
-	Current       bool        `json:"current,omitempty"`
+	ID         string      `json:"id,omitempty"`
+	Name       string      `json:"name,omitempty"`
+	Stacktrace *Stacktrace `json:"stacktrace,omitempty"`
+	Crashed    bool        `json:"crashed,omitempty"`
+	Current    bool        `json:"current,omitempty"`
 }
 
 // EventHint contains information that can be associated with an Event.


### PR DESCRIPTION
Neither Exception.RawStacktrace nor Thread.RawStacktrace are part of the protocol, they are internal fields used in Relay. Clients should not send that and it has no effect on data displayed in Sentry.

This is a breaking change to the published API, but one that fixes a bug -- those fields should not be used.

See:

https://github.com/getsentry/relay/blob/95d85eb662c0b7fa463de595cc6cdd0d8578ed5b/relay-general/src/protocol/exception.rs#L56-L57
https://github.com/getsentry/relay/blob/95d85eb662c0b7fa463de595cc6cdd0d8578ed5b/relay-general/src/protocol/thread.rs#L114-L115

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
