### PR TITLE
doc: Clarify SampleRate documentation

### DIFF
--- a/client.go
+++ b/client.go
@@ -110,7 +110,9 @@ type ClientOptions struct {
 	// Configures whether SDK should generate and attach stacktraces to pure
 	// capture message calls.
 	AttachStacktrace bool
-	// The sample rate for event submission (0.0 - 1.0, defaults to 1.0).
+	// The sample rate for event submission in the range [0.0, 1.0]. By default,
+	// all events are sent. Thus, as a historical special case, the sample rate
+	// 0.0 is treated as if it was 1.0.
 	SampleRate float64
 	// List of regexp strings that will be used to match against event's message
 	// and if applicable, caught errors type and value.


### PR DESCRIPTION
Trying to write down what the current behavior is. This is going to be weird when `TracesSampleRate` will default to zero.

Alternatively, we could solve this with the functional options pattern overcoming the default value not matching the Go zero value for the type, but that would require a breaking API change right at `sentry.Init` 🤔 

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
