### PR TITLE
ref: Remove unnecessary explicit type conversion

### DIFF
--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -59,7 +59,7 @@ func (h *Handler) HandleFunc(handler http.HandlerFunc) http.HandlerFunc {
 }
 
 func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		hub := sentry.GetHubFromContext(ctx)
 		if hub == nil {
@@ -68,8 +68,8 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 		hub.Scope().SetRequest(r)
 		ctx = sentry.SetHubOnContext(ctx, hub)
 		defer h.recoverWithSentry(hub, r)
-		handler.ServeHTTP(rw, r.WithContext(ctx))
-	})
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	}
 }
 
 func (h *Handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {


### PR DESCRIPTION
The conversion is implied by the result type.

(As we go through it, rename the ResponseWriter parameter to the more
commonly used name 'w'.)

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
