### PR TITLE
doc: Remove deprecation of sentryhttp.HandleFunc

### DIFF
--- a/example/http/main.go
+++ b/example/http/main.go
@@ -56,11 +56,14 @@ func run() error {
 	})
 
 	http.Handle("/", sentryHandler.Handle(&handler{}))
-	http.HandleFunc("/foo", sentryHandler.HandleFunc(
+	http.Handle("/foo", sentryHandler.Handle(
 		enhanceSentryEvent(func(w http.ResponseWriter, r *http.Request) {
 			panic("y tho")
 		}),
 	))
+	http.Handle("/bar", sentryHandler.HandleFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
 
 	log.Print("Listening and serving HTTP on :3000")
 	return http.ListenAndServe(":3000", nil)

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -60,7 +60,13 @@ func (h *Handler) Handle(handler http.Handler) http.Handler {
 	return h.handle(handler)
 }
 
-// Deprecated: Use the Handle method instead.
+// HandleFunc is like Handle, but with a handler function parameter for cases
+// where that is convenient. In particular, use it to wrap a handler function
+// literal.
+//
+//  http.Handle(pattern, h.HandleFunc(func (w http.ResponseWriter, r *http.Request) {
+//      // handler code here
+//  }))
 func (h *Handler) HandleFunc(handler http.HandlerFunc) http.HandlerFunc {
 	return h.handle(handler)
 }


### PR DESCRIPTION
Reverts the deprecation note added in
36c74322d86a295bf2cde8854576e42a77526bb3.

While sketching out tracing support for the sentryhttp package, I
realized that the deprecation was not necessary, since
sentryhttp.HandleFunc is particularly useful in one situation, and now
we have a more explicit example of that usage.

Typically, user code has either an http.Handler (http.HandlerFunc
implements http.Handler) or a function literal of type
func(http.ResponseWriter, *http.Request) to pass as argument.

Because sentryhttp.Handle already takes an http.Handler parameter, what
is left for sentryhttp.HandleFunc to be useful at is taking in a handler
function literal, implicitly converting it to an http.HandlerFunc so
that users don't have to write the explicit conversion, saving a bit of
noise.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
