### PR TITLE
fix: avoid unnecessary allocation in client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -438,11 +438,10 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 
 	// As per spec, transactions do not go through BeforeSend.
 	if event.Type != transactionType && options.BeforeSend != nil {
-		h := &EventHint{}
-		if hint != nil {
-			h = hint
+		if hint == nil {
+			hint = &EventHint{}
 		}
-		if event = options.BeforeSend(event, h); event == nil {
+		if event = options.BeforeSend(event, hint); event == nil {
 			Logger.Println("Event dropped due to BeforeSend callback.")
 			return nil
 		}


### PR DESCRIPTION
This is a simple fix that avoids allocating an event hint if one was provided to CaptureEvent