### PR TITLE
fix: only use a single location per frame from xerrors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,5 @@ require (
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )


### PR DESCRIPTION
if you look at https://github.com/golang/xerrors/blob/master/frame.go#L31
you'll notice that while xerrors.Frame does store 3 PCs, it is only because
of what runtime.CallersFrames requires. location() only returns a single
func/file/line. So in that spirit and for what xerror users are likely
looking for in sentry, this change makes a non duplicated stack. In other
words what %+v will print for an error that has wraps underneath, will
also be what sentry shows.

Fixes #306
Related to issue #246
