### PR TITLE
ref: Use crypto/rand.Read, not crypto/rand.Reader

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,13 +5,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 )
 
 func uuid() string {
 	id := make([]byte, 16)
-	_, _ = io.ReadFull(rand.Reader, id)
+	// Prefer rand.Read over rand.Reader, see https://go-review.googlesource.com/c/go/+/272326/.
+	_, _ = rand.Read(id)
 	id[6] &= 0x0F // clear version
 	id[6] |= 0x40 // set version to 4 (random uuid)
 	id[8] &= 0x3F // clear variant


### PR DESCRIPTION
This is to make use of a (future) protection against rogue code that
changes the value of rand.Reader.

The distinction may only be relevant in Go 1.17 onwards, while Go 1.16
is not released yet. The change has a chance of being backported to
1.16.x, though.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
