### PR TITLE
doc: Point users to preferable or more commonly used APIs

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -48,8 +48,9 @@ type Dsn struct {
 	projectID int
 }
 
-// NewDsn creates an instance of Dsn by parsing provided url in a string format.
-// If Dsn is not set the client is effectively disabled.
+// NewDsn creates a Dsn by parsing rawURL. Most users will never call this
+// function directly. It is provided for use in custom Transport
+// implementations.
 func NewDsn(rawURL string) (*Dsn, error) {
 	// Parse
 	parsedURL, err := url.Parse(rawURL)


### PR DESCRIPTION
While not extensive, the clarifications are meant to help people with
inline hints when they use the SDK in their favorite editor.

Changing a client's transport in unsupported because setting
Client.Transport does not configure the transport. While users could
theoretically call Transport.Configure themselves, the next problem is
that typically a single client is used by multiple hubs on concurrent
goroutines, and directly changing the transport without proper
syncronization is a data race.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
