### PR TITLE
ci: Update install steps to make GO111MODULE=off work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,15 @@ before_install:
   # branch, since Travis clones only the target branch.
   - git fetch origin master:remotes/origin/master
 
+install: |
+  if [[ $GO111MODULE == off ]]; then
+    # Iris is not supported in legacy GOPATH mode. We delete the source code
+    # because otherwise lint, build, and test steps would fail.
+    rm -vrf ./iris/ ./example/iris/
+    go get -v -t ./...
+  fi
+  # go get is not required in Module mode
+
 script:
   - golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
   - go build ./...


### PR DESCRIPTION
This makes the Travis builds on the legacy GOPATH mode succeed.

![image](https://user-images.githubusercontent.com/88819/100448835-37e58500-30b3-11eb-9107-6efaba5d7edf.png)

They were failing because Iris imports `github.com/russross/blackfriday/v2` which cannot be installed in GOPATH mode.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
