### PR TITLE
feat: Add helper to debug outgoing HTTP requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/getsentry/sentry-go/internal/debug"
 )
 
 // maxErrorDepth is the maximum number of errors reported in a chain of errors.
@@ -199,6 +201,13 @@ func NewClient(options ClientOptions) (*Client, error) {
 
 	if options.Environment == "" {
 		options.Environment = os.Getenv("SENTRY_ENVIRONMENT")
+	}
+
+	if env := os.Getenv("SENTRYGODEBUG"); env == "dumphttp=1" {
+		options.HTTPTransport = &debug.Transport{
+			RoundTripper: http.DefaultTransport,
+			Output:       os.Stderr,
+		}
 	}
 
 	var dsn *Dsn

--- a/internal/debug/transport.go
+++ b/internal/debug/transport.go
@@ -1,0 +1,45 @@
+package debug
+
+import (
+	"io"
+	"net/http"
+	"net/http/httputil"
+)
+
+// Transport implements http.RoundTripper and can be used to wrap other HTTP
+// transports to dump request and responses for debugging.
+type Transport struct {
+	http.RoundTripper
+	Output io.Writer
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	b, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+	_, err = t.Output.Write(ensureTrailingNewline(b))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.RoundTripper.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	b, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		return nil, err
+	}
+	_, err = t.Output.Write(ensureTrailingNewline(b))
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func ensureTrailingNewline(b []byte) []byte {
+	if len(b) > 0 && b[len(b)-1] != '\n' {
+		b = append(b, '\n')
+	}
+	return b
+}


### PR DESCRIPTION
Not a supported feature, but useful nonetheless.

Similar to GODEBUG, SENTRYGODEBUG is a comma-separated list of key=value
pairs, though the only recognizable pair right now is dumphttp=1 to dump
HTTP requests and responses to stderr.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
