### PR TITLE
Run Travis & GH actions CI side by side

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,15 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
+      - name: Get golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
       - name: Fetch origin/master
         # Fetch origin/master. This is required for `git merge-base` when testing a
         # branch, since Github clones only the target branch.
         run: 
           git fetch origin master:remotes/origin/master
-      - name: Get golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       - name: Linting
         run: |
-          golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,53 +27,35 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
+          # Getting all history enables using `git merge-base origin/master HEAD`
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
-      - name: Remove if Go Module mode
+      - name: Remove if Go Module mode disabled
+        if: matrix.go111module == 'off'
         run: |
-          if [[ $GO111MODULE == off ]]; then
-            # Iris is not supported in legacy GOPATH mode. We delete the source code
-            # because otherwise lint, build, and test steps would fail.
-            rm -vrf ./iris/ ./example/iris/
-            # go get is not required in Module mode
-            GOFLAGS="-mod=readonly" go get -v -t ./...
-          fi
+          # Iris does not supported in legacy GOPATH mode. We delete the source code
+          # because otherwise lint, build, and test steps would fail.
+          rm -vrf ./iris/ ./example/iris/
+          # go get is not required in Module mode
+          go get -v -t ./...
       - name: Build
         run: go build ./...
       - name: Tests
         run: |
           go test ./...
           go test ./... -race
-  golang-lint:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    strategy:
-      matrix:
-        go-version: ["1.15", "1.14", "1.13"]
-    env:
-        GOPATH: ${{ github.workspace }}
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
-          # Getting all history enables using `git merge-base origin/master HEAD`
-          fetch-depth: 0
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version}}
-      - name: Lint
+      - name: Run linting if Go Module is on
+        if: matrix.go111module == 'on'
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
           git fetch origin master:remotes/origin/master
           git merge-base origin/master HEAD
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+
   golang-outside-gopath:
-    name: module support outside gopath
+    name: Module support outside GOPATH
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
         GOPATH: ${{ github.workspace }}
     defaults:
       run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+        working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+          path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        go-version: ["1.15", "1.14", "1.13"]
+        go-version: ["master", "1.15", "1.14", "1.13"]
         go111module: ["on", "off"]
         include:
           # includes goflags when go111module is on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.15", "1.14", "1.13"]
-        go111module: ["on", "off"]
+        go111module: ["on"] # XXX: Temp change
         include:
           # includes goflags when go111module is on
           - go111module: "on"
@@ -21,6 +21,55 @@ jobs:
     env:
       GO111MODULE: ${{ matrix.go111module }}
       GOPATH: ${{ github.workspace }}
+    # Required for building with GOPATH
+    # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Relative path under Github workspace
+          path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
+          # Getting all history enables using `git merge-base origin/master HEAD`
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version}}
+      - name: Remove if Go Module mode disabled
+        if: matrix.go111module == 'off'
+        run: |
+          # Iris does not supported in legacy GOPATH mode. We delete the source code
+          # because otherwise lint, build, and test steps would fail.
+          rm -vrf ./iris/ ./example/iris/
+          # go get is not required in Module mode
+          go get -v -t ./...
+      - name: Build
+        run: go build ./...
+      - name: Tests
+        run: |
+          go test ./...
+          go test ./... -race
+      - name: Run linting if Go Module is on
+        if: matrix.go111module == 'on'
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          git fetch origin master:remotes/origin/master
+          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+  
+  golang-module-off:
+    name: tests-module-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        go-version: ["1.15", "1.14", "1.13"]
+        go111module: ["off"]
+    env:
+      GO111MODULE: ${{ matrix.go111module }}
+      # Only difference with job above
+      # GOPATH: ${{ github.workspace }}
+    # XXX: The defaults hack is intended to be used
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        go-version: ["master", "1.15", "1.14", "1.13"]
+        go-version: ["1.15", "1.14", "1.13"]
         go111module: ["on", "off"]
         include:
           # includes goflags when go111module is on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,14 @@ jobs:
     # XXX: The defaults hack is intended to be used
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
+    # defaults:
+    #   run:
+    #     working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
           # Relative path under Github workspace
-          path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
+          # path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         # go-version: ["1.13", "1.14", "1.15"]
         # TODO: Focus on a specific vector of the matrix
         go-version: ["1.15"]
-        go111module: ["on"]
+        go111module: ["on", "off"]
     env:
       GO111MODULE: ${{ matrix.go111module }}
       GOFLAGS: "-mod=readonly"
@@ -47,34 +47,39 @@ jobs:
         run: |
           go test ./...
           go test ./... -race
-  golang-lint:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    env:
-        GOPATH: ${{ github.workspace }}
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-      - name: Get golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
-      - name: Fetch origin/master
-        # Fetch origin/master. This is required for `git merge-base` when testing a
-        # branch, since Github clones only the target branch.
-        run: 
-          git fetch origin master:remotes/origin/master
       - name: Linting
         run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
+          git fetch origin master:remotes/origin/master
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+  # golang-lint:
+  #   name: lint
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 5
+  #   env:
+  #       GOPATH: ${{ github.workspace }}
+  #   defaults:
+  #     run:
+  #       working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+  #         # We must fetch at least the immediate parents so that if this is
+  #         # a pull request then we can checkout the head.
+  #         fetch-depth: 2
+  #     - uses: actions/setup-go@v2
+  #       with:
+  #         go-version: 1.15
+  #     - name: Get golangci-lint
+  #       run: |
+  #         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
+  #     - name: Fetch origin/master
+  #       # Fetch origin/master. This is required for `git merge-base` when testing a
+  #       # branch, since Github clones only the target branch.
+  #       run: 
+  #         git fetch origin master:remotes/origin/master
+  #     - name: Linting
+  #       run: |
+  #         $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: go-workflow
 on:
   push:
+    branches:
+      - master
   pull_request:
 jobs:
   golang-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           # because otherwise lint, build, and test steps would fail.
           rm -vrf ./iris/ ./example/iris/
           # go get is not required in Module mode
-          go get -v -t ./...
+          GOPATH=$GITHUB_WORKSPACE go get -v -t ./...
       # Required for building with GOPATH
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
       - name: Set GOPATH for Module mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
       GITHUB_REPO: ${{ github.repository }}
     defaults:
       run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+        working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+          path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.15", "1.14", "1.13"]
-        go111module: ["on"] # XXX: Temp change
+        go111module: ["on", "off"]
         include:
           # includes goflags when go111module is on
           - go111module: "on"
@@ -21,55 +21,6 @@ jobs:
     env:
       GO111MODULE: ${{ matrix.go111module }}
       GOPATH: ${{ github.workspace }}
-    # Required for building with GOPATH
-    # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Relative path under Github workspace
-          path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
-          # Getting all history enables using `git merge-base origin/master HEAD`
-          fetch-depth: 0
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version}}
-      - name: Remove if Go Module mode disabled
-        if: matrix.go111module == 'off'
-        run: |
-          # Iris does not supported in legacy GOPATH mode. We delete the source code
-          # because otherwise lint, build, and test steps would fail.
-          rm -vrf ./iris/ ./example/iris/
-          # go get is not required in Module mode
-          go get -v -t ./...
-      - name: Build
-        run: go build ./...
-      - name: Tests
-        run: |
-          go test ./...
-          go test ./... -race
-      - name: Run linting if Go Module is on
-        if: matrix.go111module == 'on'
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          git fetch origin master:remotes/origin/master
-          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
-  
-  golang-module-off:
-    name: tests-module-off
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    strategy:
-      matrix:
-        go-version: ["1.15", "1.14", "1.13"]
-        go111module: ["off"]
-    env:
-      GO111MODULE: ${{ matrix.go111module }}
-      # Only difference with job above
-      # GOPATH: ${{ github.workspace }}
-    # XXX: The defaults hack is intended to be used
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
-          # Let's see if it does a normal checkout or what!
+          # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
@@ -66,14 +66,7 @@ jobs:
       - name: Lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          # git remote -v
-          # git fetch origin master:remotes/origin/master
-          # git fetch https://github.com/getsentry/sentry-go.git master:remotes/upstream/master
-          env | sort
-          echo GITHUB_REF
-          echo GITHUB_HEAD_REF
-          echo GITHUB_BASE_REF
-          export SHA=`git merge-base origin/master HEAD`
-          echo $SHA
+          git fetch origin master:remotes/origin/master
+          git merge-base origin/master HEAD
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           if [[ $GO111MODULE == off ]]; then
             # XXX: Do we need this variable for the next steps in the workflow?
-            echo 'GOFLAGS="-mod=readonly"' >> $GITHUB_ENV
+            echo 'GOFLAGS=' >> $GITHUB_ENV
             # Iris is not supported in legacy GOPATH mode. We delete the source code
             # because otherwise lint, build, and test steps would fail.
             rm -vrf ./iris/ ./example/iris/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
           go-version: ${{ matrix.go-version}}
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          git remote -v
           git fetch origin master:remotes/origin/master
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         # TODO: We will need to figure out how to test against `master`
         go-version: ["1.13", "1.14", "1.15"]
-        # TODO: Add back "off"
-        go111module: ["on"]
+        # TODO: Add back "on"
+        go111module: ["off"]
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -56,4 +56,4 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without
           # patch version: we always use the latest patch version.
-          version: v1.27.0
+          version: v1.28.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,10 @@ jobs:
       - name: Lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          git remote -v
+          # git remote -v
           # git fetch origin master:remotes/origin/master
-          git fetch https://github.com/getsentry/sentry-go.git master:remotes/upstream/master
-          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base upstream/master HEAD)
+          # git fetch https://github.com/getsentry/sentry-go.git master:remotes/upstream/master
+          export SHA=`git merge-base origin/master HEAD`
+          echo $SHA
+          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without
           # patch version: we always use the latest patch version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         # TODO: We will need to figure out how to test against `master`
         go-version: ["1.13", "1.14", "1.15"]
-        # TODO: Add back "on"
-        go111module: ["off"]
+        go111module: ["on", "off"]
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -26,19 +25,17 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
-      # TODO: Go get fails after 30 seconds with "Error: Process completed with exit code 1."
-      # https://github.com/armenzg/sentry-go/runs/1652714010?check_suite_focus=true      
-      # - name: Remove if Go Module mode
-      #   run: |
-      #     if [[ $GO111MODULE == off ]]; then
-      #       # Do we need this variable in other steps?
-      #       # echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV
-      #       # Iris is not supported in legacy GOPATH mode. We delete the source code
-      #       # because otherwise lint, build, and test steps would fail.
-      #       rm -vrf ./iris/ ./example/iris/
-      #       # go get is not required in Module mode
-      #       GOFLAGS=-mod=readonly go get -v -t ./...
-      #     fi
+      - name: Remove if Go Module mode
+        run: |
+          if [[ $GO111MODULE == off ]]; then
+            # XXX: Do we need this variable for the next steps in the workflow?
+            echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV
+            # Iris is not supported in legacy GOPATH mode. We delete the source code
+            # because otherwise lint, build, and test steps would fail.
+            rm -vrf ./iris/ ./example/iris/
+            # go get is not required in Module mode
+            GOFLAGS=-mod=readonly go get -v -t ./...
+          fi
       - name: Build
         run: go build ./...
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: go-workflow
 on:
   push:
-    # Temporarily removed for first PR
-    # branches:
-    #   - master
   pull_request:
 jobs:
   golang-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       matrix:
         # TODO: We will need to figure out how to test against `master`
         go-version: ["1.13", "1.14", "1.15"]
-        go111module: ["on", "off"]
+        # TODO: Add back "off"
+        go111module: ["on"]
 
     env:
       GO111MODULE: ${{ matrix.go111module }}
@@ -25,7 +26,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version}}
       # TODO: Go get fails after 30 seconds with "Error: Process completed with exit code 1."
-      # https://github.com/armenzg/sentry-go/runs/1652714010?check_suite_focus=true
+      # https://github.com/armenzg/sentry-go/runs/1652714010?check_suite_focus=true      
       # - name: Remove if Go Module mode
       #   run: |
       #     if [[ $GO111MODULE == off ]]; then
@@ -54,4 +55,4 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without
           # patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.27.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       GO111MODULE: ${{ matrix.go111module }}
       GOPATH: ${{ github.workspace }}
+    # Required for building with GOPATH
+    # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
@@ -60,6 +62,8 @@ jobs:
     timeout-minutes: 5
     env:
       GOPATH: ${{ github.workspace }}
+    # Required for building with GOPATH
+    # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   golang-tests:
     name: tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
@@ -18,6 +18,7 @@ jobs:
         go111module: ["on"]
 
     env:
+      GOPATH: ${{ github.workspace }}
       GO111MODULE: ${{ matrix.go111module }}
 
     steps:
@@ -46,7 +47,7 @@ jobs:
           go test ./... -race
   golang-lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
+          path: ${{ GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        # TODO: We will need to figure out how to test against `master`
-        # go-version: ["1.13", "1.14", "1.15"]
-        # TODO: Focus on a specific vector of the matrix
-        go-version: ["1.15", "1.14"]
+        go-version: ["1.15", "1.14", "1.13"]
         go111module: ["on", "off"]
     env:
       GO111MODULE: ${{ matrix.go111module }}
@@ -33,8 +30,6 @@ jobs:
       - name: Remove if Go Module mode
         run: |
           if [[ $GO111MODULE == off ]]; then
-            # XXX: Do we need this variable for the next steps in the workflow?
-            echo 'GOFLAGS=' >> $GITHUB_ENV
             # Iris is not supported in legacy GOPATH mode. We delete the source code
             # because otherwise lint, build, and test steps would fail.
             rm -vrf ./iris/ ./example/iris/
@@ -47,39 +42,31 @@ jobs:
         run: |
           go test ./...
           go test ./... -race
-      - name: Linting
+  golang-lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        go-version: ["1.15", "1.14", "1.13"]
+    env:
+        GOPATH: ${{ github.workspace }}
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version}}
+      - name: Lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
           git fetch origin master:remotes/origin/master
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
-  # golang-lint:
-  #   name: lint
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   env:
-  #       GOPATH: ${{ github.workspace }}
-  #   defaults:
-  #     run:
-  #       working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-  #         # We must fetch at least the immediate parents so that if this is
-  #         # a pull request then we can checkout the head.
-  #         fetch-depth: 2
-  #     - uses: actions/setup-go@v2
-  #       with:
-  #         go-version: 1.15
-  #     - name: Get golangci-lint
-  #       run: |
-  #         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          
-  #     - name: Fetch origin/master
-  #       # Fetch origin/master. This is required for `git merge-base` when testing a
-  #       # branch, since Github clones only the target branch.
-  #       run: 
-  #         git fetch origin master:remotes/origin/master
-  #     - name: Linting
-  #       run: |
-  #         $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
             goflags: -mod=readonly
     env:
       GO111MODULE: ${{ matrix.go111module }}
+      GOPATH: ${{ github.workspace }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           # XXX: For some reason getting on `go build` step:
           # `$GOPATH/go.mod exists but should not`
-          rm -rf ${GOPATH}/go.mod
+          # rm -rf ${GOPATH}/go.mod
           if [[ $GO111MODULE == off ]]; then
             # XXX: Do we need this variable for the next steps in the workflow?
             echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: go-workflow
 on:
   push:
-    branches:
-      - master
+    # Temporarily removed for first PR
+    # branches:
+    #   - master
   pull_request:
 jobs:
   golang-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,7 @@ jobs:
           # because otherwise lint, build, and test steps would fail.
           rm -vrf ./iris/ ./example/iris/
           # go get is not required in Module mode
-          GOPATH=$GITHUB_WORKSPACE go get -v -t ./...
-      # Required for building with GOPATH
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
-      - name: Set GOPATH for Module mode
-        if: matrix.go111module == 'on'
-        run: |
-          echo "Hello world!"
-          env | sort
-          echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          go get -v -t ./...
       - name: Build
         run: go build ./...
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,19 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
-      - name: Remove if Go Module mode
-        run: |
-          if [[ $GO111MODULE == off ]]; then
-            # Do we need this variable in other steps?
-            # echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV
-            # Iris is not supported in legacy GOPATH mode. We delete the source code
-            # because otherwise lint, build, and test steps would fail.
-            rm -vrf ./iris/ ./example/iris/
-            # go get is not required in Module mode
-            GOFLAGS=-mod=readonly go get -v -t ./...
-          fi
+      # TODO: Go get fails after 30 seconds with "Error: Process completed with exit code 1."
+      # https://github.com/armenzg/sentry-go/runs/1652714010?check_suite_focus=true
+      # - name: Remove if Go Module mode
+      #   run: |
+      #     if [[ $GO111MODULE == off ]]; then
+      #       # Do we need this variable in other steps?
+      #       # echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV
+      #       # Iris is not supported in legacy GOPATH mode. We delete the source code
+      #       # because otherwise lint, build, and test steps would fail.
+      #       rm -vrf ./iris/ ./example/iris/
+      #       # go get is not required in Module mode
+      #       GOFLAGS=-mod=readonly go get -v -t ./...
+      #     fi
       - name: Build
         run: go build ./...
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: go-workflow
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
   pull_request:
 jobs:
   golang-tests:
@@ -13,9 +13,12 @@ jobs:
       matrix:
         go-version: ["1.15", "1.14", "1.13"]
         go111module: ["on", "off"]
+        include:
+          # includes goflags when go111module is on
+          - go111module: "on"
+            goflags: -mod=readonly
     env:
       GO111MODULE: ${{ matrix.go111module }}
-      GOFLAGS: -mod=readonly
       GOPATH: ${{ github.workspace }}
     defaults:
       run:
@@ -69,4 +72,30 @@ jobs:
           git fetch origin master:remotes/origin/master
           git merge-base origin/master HEAD
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+  golang-outside-gopath:
+    name: module support outside gopath
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GOPATH: ${{ github.workspace }}
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Move outside of GOPATH
+        run: |
+          mv $GOPATH/src/github.com/getsentry/sentry-go ~/sentry-go
+          cd ~/sentry-go
+          export GOPATH=
+          go env GOPATH
+      - name: Tests
+        run: |
+          go test ./...
+          go test ./... -race
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
     # branches:
     #   - master
   pull_request:
-
+env:
+  GOPATH: ${{ github.workspace }}
+defaults:
+  run:
+    working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
 jobs:
   golang-tests:
     name: tests
@@ -18,12 +22,8 @@ jobs:
         go-version: ["1.15"]
         go111module: ["on"]
     env:
-      GOPATH: ${{ github.workspace }}
       GO111MODULE: ${{ matrix.go111module }}
       GOFLAGS: "-mod=readonly"
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -51,10 +51,11 @@ jobs:
   golang-lint:
     name: lint
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
         with:
+          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
@@ -66,6 +67,7 @@ jobs:
       - name: Get golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       - name: Linting
         run: |
           golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,14 @@ jobs:
     strategy:
       matrix:
         # TODO: We will need to figure out how to test against `master`
-        go-version: ["1.13", "1.14", "1.15"]
-        go111module: ["off"]
+        # go-version: ["1.13", "1.14", "1.15"]
+        # TODO: Focus on a specific vector of the matrix
+        go-version: ["1.15"]
+        go111module: ["on"]
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: ${{ matrix.go111module }}
+      GOFLAGS: "-mod=readonly"
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
@@ -51,9 +54,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.3.0
         with:
-          # Required: the version of golangci-lint is required and must be specified without
-          # patch version: we always use the latest patch version.
-          version: v1.29
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+      - name: Linting
+        run: |
+          golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+      # - name: golangci-lint
+      #   uses: golangci/golangci-lint-action@v2.3.0
+      #   with:
+      #     # Required: the version of golangci-lint is required and must be specified without
+      #     # patch version: we always use the latest patch version.
+      #     version: v1.29
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           # Relative path under Github workspace
-          path: src/github.com/getsentry/sentry-go
+          path: sentry-go/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Remove if Go Module mode
         run: |
+          # XXX: For some reason getting on `go build` step:
+          # `$GOPATH/go.mod exists but should not`
+          rm -rf ${GOPATH}/go.mod
           if [[ $GO111MODULE == off ]]; then
             # XXX: Do we need this variable for the next steps in the workflow?
             echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
-      - name: Before install
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          # Fetch origin/master. This is required for `git merge-base` when testing a
-          # branch, since Travis clones only the target branch.
-          git fetch origin master:remotes/origin/master
       - name: Remove if Go Module mode
         run: |
           if [[ $GO111MODULE == off ]]; then
@@ -54,19 +48,25 @@ jobs:
         run: |
           go test ./...
           go test ./... -race
-  # golang-lint:
-  #   name: lint
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 20
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         # We must fetch at least the immediate parents so that if this is
-  #         # a pull request then we can checkout the head.
-  #         fetch-depth: 2
-  #     - name: Linting
-  #       run: |
-  #         golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+  golang-lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+      - name: Before install
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          # Fetch origin/master. This is required for `git merge-base` when testing a
+          # branch, since Travis clones only the target branch.
+          git fetch origin master:remotes/origin/master
+      - name: Linting
+        run: |
+          golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       # - name: golangci-lint
       #   uses: golangci/golangci-lint-action@v2.3.0
       #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,19 @@ jobs:
         # TODO: We will need to figure out how to test against `master`
         go-version: ["1.13", "1.14", "1.15"]
         go111module: ["on", "off"]
-
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: ${{ matrix.go111module }}
-
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
       - uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
       - name: Remove if Go Module mode
         run: |
           # XXX: For some reason getting on `go build` step:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
         # TODO: We will need to figure out how to test against `master`
         # go-version: ["1.13", "1.14", "1.15"]
         # TODO: Focus on a specific vector of the matrix
-        go-version: ["1.15"]
+        go-version: ["1.15", "1.14"]
         go111module: ["on", "off"]
     env:
       GO111MODULE: ${{ matrix.go111module }}
-      GOFLAGS: "-mod=readonly"
+      # GOFLAGS: "-mod=readonly"
       GOPATH: ${{ github.workspace }}
+      GITHUB_REPO: ${{ github.repository }}
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
+          # Let's see if it does a normal checkout or what!
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
@@ -70,6 +69,10 @@ jobs:
           # git remote -v
           # git fetch origin master:remotes/origin/master
           # git fetch https://github.com/getsentry/sentry-go.git master:remotes/upstream/master
+          env | sort
+          echo GITHUB_REF
+          echo GITHUB_HEAD_REF
+          echo GITHUB_BASE_REF
           export SHA=`git merge-base origin/master HEAD`
           echo $SHA
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
             goflags: -mod=readonly
     env:
       GO111MODULE: ${{ matrix.go111module }}
-      GOPATH: ${{ github.workspace }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:
@@ -43,6 +42,11 @@ jobs:
           rm -vrf ./iris/ ./example/iris/
           # go get is not required in Module mode
           go get -v -t ./...
+      # Required for building with GOPATH
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
+      - name: Set GOPATH for Module mode
+        if: matrix.go111module == 'on'
+        run: echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: Build
         run: go build ./...
       - name: Tests
@@ -54,7 +58,6 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
           git fetch origin master:remotes/origin/master
-          git merge-base origin/master HEAD
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
 
   golang-outside-gopath:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,18 @@ jobs:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version}}
       - uses: actions/checkout@v2
         with:
           path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version}}
+      - name: Before install
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          # Fetch origin/master. This is required for `git merge-base` when testing a
+          # branch, since Travis clones only the target branch.
+          git fetch origin master:remotes/origin/master
       - name: Remove if Go Module mode
         run: |
           if [[ $GO111MODULE == off ]]; then
@@ -48,19 +54,19 @@ jobs:
         run: |
           go test ./...
           go test ./... -race
-  golang-lint:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
-      - name: Linting
-        run: |
-          golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+  # golang-lint:
+  #   name: lint
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 20
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         # We must fetch at least the immediate parents so that if this is
+  #         # a pull request then we can checkout the head.
+  #         fetch-depth: 2
+  #     - name: Linting
+  #       run: |
+  #         golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       # - name: golangci-lint
       #   uses: golangci/golangci-lint-action@v2.3.0
       #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       GO111MODULE: ${{ matrix.go111module }}
 
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
+      - uses: actions/checkout@v2
       - name: Remove if Go Module mode
         run: |
           if [[ $GO111MODULE == off ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
+      GO111MODULE: on
+      GOFLAGS: -mod=readonly
       GOPATH: ${{ github.workspace }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
@@ -75,14 +77,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
-      - name: Move outside of GOPATH
+      - name: Run tests outside of GOPATH
         run: |
           mv $GOPATH/src/github.com/getsentry/sentry-go ~/sentry-go
           cd ~/sentry-go
           export GOPATH=
           go env GOPATH
-      - name: Tests
-        run: |
           go test ./...
           go test ./... -race
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,16 @@ jobs:
             goflags: -mod=readonly
     env:
       GO111MODULE: ${{ matrix.go111module }}
-      GITHUB_WORKSPACE: ${{ GITHUB_WORKSPACE }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:
       run:
-        working-directory: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
+        working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
           # Relative path under Github workspace
-          path: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
+          path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,6 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
           git remote -v
           # git fetch origin master:remotes/origin/master
-          git fetch https://github.com/getsentry/sentry-go.git master:remotes/xxx/master
-          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+          git fetch https://github.com/getsentry/sentry-go.git master:remotes/upstream/master
+          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base upstream/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
         go111module: ["on", "off"]
     env:
       GO111MODULE: ${{ matrix.go111module }}
-      # GOFLAGS: "-mod=readonly"
+      GOFLAGS: -mod=readonly
       GOPATH: ${{ github.workspace }}
-      GITHUB_REPO: ${{ github.repository }}
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Get golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
+          $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       - name: Linting
         run: |
           golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,19 +58,15 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
-      - name: Before install
+      - name: Fetch origin/master
+        # Fetch origin/master. This is required for `git merge-base` when testing a
+        # branch, since Github clones only the target branch.
+        run: 
+          git fetch origin master:remotes/origin/master
+      - name: Get golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-          # Fetch origin/master. This is required for `git merge-base` when testing a
-          # branch, since Travis clones only the target branch.
-          git fetch origin master:remotes/origin/master
       - name: Linting
         run: |
           golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
-      # - name: golangci-lint
-      #   uses: golangci/golangci-lint-action@v2.3.0
-      #   with:
-      #     # Required: the version of golangci-lint is required and must be specified without
-      #     # patch version: we always use the latest patch version.
-      #     version: v1.29
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # TODO: We will need to figure out how to test against `master`
         go-version: ["1.13", "1.14", "1.15"]
-        go111module: ["on", "off"]
+        go111module: ["on"]
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: ${{ matrix.go111module }}
@@ -30,17 +30,14 @@ jobs:
           path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
       - name: Remove if Go Module mode
         run: |
-          # XXX: For some reason getting on `go build` step:
-          # `$GOPATH/go.mod exists but should not`
-          # rm -rf ${GOPATH}/go.mod
           if [[ $GO111MODULE == off ]]; then
             # XXX: Do we need this variable for the next steps in the workflow?
-            echo "GOFLAGS=-mod=readonly" >> $GITHUB_ENV
+            echo 'GOFLAGS="-mod=readonly"' >> $GITHUB_ENV
             # Iris is not supported in legacy GOPATH mode. We delete the source code
             # because otherwise lint, build, and test steps would fail.
             rm -vrf ./iris/ ./example/iris/
             # go get is not required in Module mode
-            GOFLAGS=-mod=readonly go get -v -t ./...
+            GOFLAGS="-mod=readonly" go get -v -t ./...
           fi
       - name: Build
         run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       GO111MODULE: ${{ matrix.go111module }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
-    # defaults:
-    #   run:
-    #     working-directory: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
+    defaults:
+      run:
+        working-directory: ${{ env.GITHUB_WORKSPACE }}/sentry-go/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ on:
     # branches:
     #   - master
   pull_request:
-env:
-  GOPATH: ${{ github.workspace }}
-defaults:
-  run:
-    working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
 jobs:
   golang-tests:
     name: tests
@@ -24,6 +19,10 @@ jobs:
     env:
       GO111MODULE: ${{ matrix.go111module }}
       GOFLAGS: "-mod=readonly"
+      GOPATH: ${{ github.workspace }}
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -52,6 +51,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+        GOPATH: ${{ github.workspace }}
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,6 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
           git remote -v
           # git fetch origin master:remotes/origin/master
-          git fetch git@github.com:getsentry/sentry-go.git master:remotes/xxx/master
+          git fetch https://github.com/getsentry/sentry-go.git master:remotes/xxx/master
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,14 @@ jobs:
     # XXX: The defaults hack is intended to be used
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
-    # defaults:
-    #   run:
-    #     working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
           # Relative path under Github workspace
-          # path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
+          path: ${{ github.workspace }}/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,17 @@ jobs:
             goflags: -mod=readonly
     env:
       GO111MODULE: ${{ matrix.go111module }}
+      GITHUB_WORKSPACE: ${{ GITHUB_WORKSPACE }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:
       run:
-        working-directory: ${{ env.GITHUB_WORKSPACE }}/sentry-go/src/github.com/getsentry/sentry-go
+        working-directory: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
           # Relative path under Github workspace
-          path: sentry-go/src/github.com/getsentry/sentry-go
+          path: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version}}
-      - name: Remove if Go Module mode disabled
+      - name: Adjustments for Module mode enabled
+        if: matrix.go111module == 'on'
+        run: |
+          echo "GOFLAGS=${{ matrix.goflags }}" >> $GITHUB_ENV
+      - name: Adjustments for Module mode disabled
         if: matrix.go111module == 'off'
         run: |
           # Iris does not supported in legacy GOPATH mode. We delete the source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           # Iris does not supported in legacy GOPATH mode. We delete the source code
           # because otherwise lint, build, and test steps would fail.
           rm -vrf ./iris/ ./example/iris/
+          go env | sort
           # go get is not required in Module mode
           go get -v -t ./...
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
           # Iris does not supported in legacy GOPATH mode. We delete the source code
           # because otherwise lint, build, and test steps would fail.
           rm -vrf ./iris/ ./example/iris/
-          go env | sort
           # go get is not required in Module mode
           go get -v -t ./...
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          path: ${{ GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
+          # Relative path under Github workspace
+          path: src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2
@@ -76,7 +77,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
+          # Relative path under Github workspace
+          path: src/github.com/getsentry/sentry-go
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
     defaults:
       run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
+        working-directory: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.GOPATH }}/src/github.com/getsentry/sentry-go
+          path: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
           # Getting all history enables using `git merge-base origin/master HEAD`
           fetch-depth: 0
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
   golang-tests:
     name: tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     strategy:
       matrix:
         # TODO: We will need to figure out how to test against `master`
         go-version: ["1.13", "1.14", "1.15"]
-        go111module: ["on"]
+        go111module: ["off"]
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: ${{ matrix.go111module }}
@@ -56,4 +56,4 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without
           # patch version: we always use the latest patch version.
-          version: v1.28.3
+          version: v1.29

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
       - name: Get golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
             goflags: -mod=readonly
     env:
       GO111MODULE: ${{ matrix.go111module }}
+      # XXX: Investigate why GOPATH is needed for Modules off
       GOPATH: ${{ github.workspace }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
       - name: Set GOPATH for Module mode
         if: matrix.go111module == 'on'
-        run: echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        run: |
+          echo "Hello world!"
+          env | sort
+          echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: Build
         run: go build ./...
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       GO111MODULE: ${{ matrix.go111module }}
     # Required for building with GOPATH
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-a-gopath-build
-    defaults:
-      run:
-        working-directory: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
+    # defaults:
+    #   run:
+    #     working-directory: ${{ env.GITHUB_WORKSPACE }}/src/github.com/getsentry/sentry-go
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
           git remote -v
-          git fetch origin master:remotes/origin/master
+          # git fetch origin master:remotes/origin/master
+          git fetch git@github.com:getsentry/sentry-go.git master:remotes/xxx/master
           $(go env GOPATH)/bin/golangci-lint run --new-from-rev=$(git merge-base origin/master HEAD)
       


### PR DESCRIPTION
This runs most of what Travis executes inside of Github actions.
Running against the latest golang has not been ported. All other modes have been ported.

I will enquire as to how to get the latest golang running with the setup-go action.

Since I do not have write access on the upstream repo the checks won't show up on this PR.
You can view the results on my [fork](https://github.com/armenzg/sentry-go/actions/runs/481210918).

Related to https://github.com/getsentry/sentry-go/issues/313.