### PR TITLE
fix: net/http transport goroutines leak

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -386,7 +386,7 @@ func (t *HTTPTransport) worker() {
 				Logger.Printf("Too many requests, backing off till: %s\n", deadline)
 			}
 
-			io.CopyN(ioutil.Discard, response.Body, 512)
+			_, err = io.CopyN(ioutil.Discard, response.Body, 512)
 			response.Body.Close()
 		}
 
@@ -487,7 +487,7 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		Logger.Printf("Too many requests, backing off till: %s\n", t.disabledUntil)
 	}
 
-	io.CopyN(ioutil.Discard, response.Body, 512)
+	_, err = io.CopyN(ioutil.Discard, response.Body, 512)
 	response.Body.Close()
 }
 

--- a/transport.go
+++ b/transport.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -384,6 +386,7 @@ func (t *HTTPTransport) worker() {
 				Logger.Printf("Too many requests, backing off till: %s\n", deadline)
 			}
 
+			io.CopyN(ioutil.Discard, response.Body, 512)
 			response.Body.Close()
 		}
 
@@ -484,6 +487,7 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		Logger.Printf("Too many requests, backing off till: %s\n", t.disabledUntil)
 	}
 
+	io.CopyN(ioutil.Discard, response.Body, 512)
 	response.Body.Close()
 }
 

--- a/transport.go
+++ b/transport.go
@@ -383,6 +383,8 @@ func (t *HTTPTransport) worker() {
 				t.mu.Unlock()
 				Logger.Printf("Too many requests, backing off till: %s\n", deadline)
 			}
+
+			response.Body.Close()
 		}
 
 		// Signal that processing of the batch is done.
@@ -481,6 +483,8 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		t.disabledUntil = time.Now().Add(retryAfter(time.Now(), response))
 		Logger.Printf("Too many requests, backing off till: %s\n", t.disabledUntil)
 	}
+
+	response.Body.Close()
 }
 
 // Flush is a no-op for HTTPSyncTransport. It always returns true immediately.


### PR DESCRIPTION
<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->

Hi! For each transport flush there hung a couple "zombie"-routines 
net/http.(*persistConn).readLoop
net/http.(*persistConn).writeLoop

I suppose it because there is no response.Body.Close() in transport cycles. This not only leads to a zombie-routines but also because of the lack of re-using connections to the loss of performance (no keep-alive).

[net/http/#Client.Do](https://golang.org/pkg/net/http/#Client.Do)

> If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close. If the Body is not both read to EOF and closed, the Client's underlying RoundTripper (typically Transport) may not be able to re-use a persistent TCP connection to the server for a subsequent "keep-alive" request.

It solves resource leak issue in my cases.

Thanks!