### PR TITLE
exception: add comment describing field usage

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -150,8 +150,8 @@ func NewRequest(r *http.Request) *Request {
 
 // Exception specifies an error that occurred.
 type Exception struct {
-	Type       string      `json:"type,omitempty"`
-	Value      string      `json:"value,omitempty"`
+	Type       string      `json:"type,omitempty"`  // used as the main issue title
+	Value      string      `json:"value,omitempty"` // used as the main issue subtitle
 	Module     string      `json:"module,omitempty"`
 	ThreadID   string      `json:"thread_id,omitempty"`
 	Stacktrace *Stacktrace `json:"stacktrace,omitempty"`


### PR DESCRIPTION
It took a few weeks and eventually an email to support to figure out that the `Type` field was used as the main title in the Sentry UI. I figured I would save others the same confusion by adding some comments.