### PR TITLE
fix: Do not override trace context of transactions

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -364,6 +364,14 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 		}
 
 		for key, value := range scope.contexts {
+			if key == "trace" && event.Type == transactionType {
+				// Do not override trace context of
+				// transactions, otherwise it breaks the
+				// transaction event representation.
+				// For error events, the trace context is used
+				// to link errors and traces/spans in Sentry.
+				continue
+			}
 			event.Contexts[key] = value
 		}
 	}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -190,12 +190,6 @@ func TestStartChild(t *testing.T) {
 				Op:      span.Op,
 			},
 		},
-		Tags: nil,
-		// TODO(tracing): Set Transaction.Data here or in
-		// Contexts.Trace, or somewhere else. Currently ignored.
-		Extra: nil,
-		// Timestamp: endTime,
-		// StartTime: startTime,
 		Spans: []*Span{
 			{
 				TraceID:      child.TraceID,


### PR DESCRIPTION
Otherwise the trace context of child spans or other unrelated value in
the scope ends up breaking the transaction representation.

Fixes #318