### PR TITLE
fix: Do not double sample transactions

### DIFF
--- a/client.go
+++ b/client.go
@@ -503,6 +503,9 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 		options.SampleRate = 1.0
 	}
 
+	// Transactions are sampled by options.TracesSampleRate or
+	// options.TracesSampler when they are started. All other events
+	// (errors, messages) are sampled here.
 	if event.Type != transactionType && !sample(options.SampleRate) {
 		Logger.Println("Event dropped due to SampleRate hit.")
 		return nil

--- a/client.go
+++ b/client.go
@@ -503,7 +503,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 		options.SampleRate = 1.0
 	}
 
-	if !sample(options.SampleRate) {
+	if event.Type != transactionType && !sample(options.SampleRate) {
 		Logger.Println("Event dropped due to SampleRate hit.")
 		return nil
 	}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"reflect"
 	"testing"
@@ -312,4 +314,30 @@ func TestSpanFromContext(t *testing.T) {
 	// SpanCheck{
 	// 	RecorderLen: 1,
 	// }.Check(t, child)
+}
+
+func TestDoubleSampling(t *testing.T) {
+	transport := &TransportMock{}
+	ctx := NewTestContext(ClientOptions{
+		SampleRate:       math.SmallestNonzeroFloat64,
+		TracesSampleRate: 1.0,
+		Transport:        transport,
+	})
+	span := StartSpan(ctx, "op", TransactionName("name"))
+
+	// CaptureException should not send any event because of SampleRate.
+	GetHubFromContext(ctx).CaptureException(errors.New("ignored"))
+	if got := len(transport.Events()); got != 0 {
+		t.Fatalf("got %d events, want 0", got)
+	}
+
+	// Finish should send one transaction event, always sampled via
+	// TracesSampleRate.
+	span.Finish()
+	if got := len(transport.Events()); got != 1 {
+		t.Fatalf("got %d events, want 1", got)
+	}
+	if got := transport.Events()[0].Type; got != transactionType {
+		t.Fatalf("got %v event, want %v", got, transactionType)
+	}
 }


### PR DESCRIPTION
Transactions should be sampled only by `TracesSampleRate` or `TracesSampler`, and the general `SampleRate` does not apply.

See https://develop.sentry.dev/sdk/performance/#sampling
![image](https://user-images.githubusercontent.com/88819/107864044-12b61680-6e59-11eb-8df5-375fdda63cd5.png)
