### PR TITLE
fix: Send root span data as Event.Extra

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -332,7 +332,11 @@ func (s *Span) toEvent() *Event {
 		Contexts: map[string]interface{}{
 			"trace": s.traceContext(),
 		},
-		Tags:      s.Tags,
+		Tags: s.Tags,
+		// TODO(tracing): the root span / transaction data field is
+		// mapped into Event.Extra for now, pending spec clarification.
+		// https://github.com/getsentry/develop/issues/244#issuecomment-778694182
+		Extra:     s.Data,
 		Timestamp: s.EndTime,
 		StartTime: s.StartTime,
 		Spans:     finished,

--- a/tracing.go
+++ b/tracing.go
@@ -332,10 +332,7 @@ func (s *Span) toEvent() *Event {
 		Contexts: map[string]interface{}{
 			"trace": s.traceContext(),
 		},
-		Tags: s.Tags,
-		// TODO(tracing): the root span / transaction data field is
-		// mapped into Event.Extra for now, pending spec clarification.
-		// https://github.com/getsentry/develop/issues/244#issuecomment-778694182
+		Tags:      s.Tags,
 		Extra:     s.Data,
 		Timestamp: s.EndTime,
 		StartTime: s.StartTime,

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -139,8 +139,9 @@ func TestStartSpan(t *testing.T) {
 			},
 		},
 		Tags: nil,
-		// TODO(tracing): Set Transaction.Data here or in
-		// Contexts.Trace, or somewhere else. Currently ignored.
+		// TODO(tracing): the root span / transaction data field is
+		// mapped into Event.Extra for now, pending spec clarification.
+		// https://github.com/getsentry/develop/issues/244#issuecomment-778694182
 		Extra:     span.Data,
 		Timestamp: endTime,
 		StartTime: startTime,

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -99,6 +99,9 @@ func TestStartSpan(t *testing.T) {
 	sampled := SampledTrue
 	startTime := time.Now()
 	endTime := startTime.Add(3 * time.Second)
+	data := map[string]interface{}{
+		"k": "v",
+	}
 	span := StartSpan(ctx, op,
 		TransactionName(transaction),
 		func(s *Span) {
@@ -108,6 +111,7 @@ func TestStartSpan(t *testing.T) {
 			s.Sampled = sampled
 			s.StartTime = startTime
 			s.EndTime = endTime
+			s.Data = data
 		},
 	)
 	span.Finish()
@@ -137,7 +141,7 @@ func TestStartSpan(t *testing.T) {
 		Tags: nil,
 		// TODO(tracing): Set Transaction.Data here or in
 		// Contexts.Trace, or somewhere else. Currently ignored.
-		Extra:     nil,
+		Extra:     span.Data,
 		Timestamp: endTime,
 		StartTime: startTime,
 	}


### PR DESCRIPTION
Pending spec clarification since implementation in Relay and different
SDKs diverged.

For now sending data in Event.Extra gets the information into the
Transaction view in Sentry.

Fixes #311.