### PR TITLE
ref(transports): Simplify retryAfter arguments

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -199,36 +199,29 @@ func TestGetRequestFromEvent(t *testing.T) {
 }
 
 func TestRetryAfterNoHeader(t *testing.T) {
-	r := http.Response{}
-	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)
+	assertEqual(t, retryAfter(time.Now(), nil), time.Second*60)
 }
 
 func TestRetryAfterIncorrectHeader(t *testing.T) {
-	r := http.Response{
-		Header: map[string][]string{
-			"Retry-After": {"x"},
-		},
+	h := http.Header{
+		"Retry-After": {"x"},
 	}
-	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)
+	assertEqual(t, retryAfter(time.Now(), h), time.Second*60)
 }
 
 func TestRetryAfterDelayHeader(t *testing.T) {
-	r := http.Response{
-		Header: map[string][]string{
-			"Retry-After": {"1337"},
-		},
+	h := http.Header{
+		"Retry-After": {"1337"},
 	}
-	assertEqual(t, retryAfter(time.Now(), &r), time.Second*1337)
+	assertEqual(t, retryAfter(time.Now(), h), time.Second*1337)
 }
 
 func TestRetryAfterDateHeader(t *testing.T) {
 	now, _ := time.Parse(time.RFC1123, "Wed, 21 Oct 2015 07:28:00 GMT")
-	r := http.Response{
-		Header: map[string][]string{
-			"Retry-After": {"Wed, 21 Oct 2015 07:28:13 GMT"},
-		},
+	h := http.Header{
+		"Retry-After": {"Wed, 21 Oct 2015 07:28:13 GMT"},
 	}
-	assertEqual(t, retryAfter(now, &r), time.Second*13)
+	assertEqual(t, retryAfter(now, h), time.Second*13)
 }
 
 // A testHTTPServer counts events sent to it. It requires a call to Unblock


### PR DESCRIPTION
Internal change.

We only need to look at HTTP headers, not the full response value.