### PR TITLE
docs: Fix mentions to 'all events'

### DIFF
--- a/example/recover-repanic/main.go
+++ b/example/recover-repanic/main.go
@@ -102,7 +102,7 @@ func RecoverRepanic(f func()) {
 	// Add an EventProcessor to the scope. The event processor is a function
 	// that can change events before they are sent to Sentry.
 	// Alternatively, see also ClientOptions.BeforeSend, which is a special
-	// event processor applied to all events.
+	// event processor applied to error events.
 	hub.ConfigureScope(func(scope *sentry.Scope) {
 		scope.AddEventProcessor(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			filterFrames(event)

--- a/example/with_extra/main.go
+++ b/example/with_extra/main.go
@@ -67,7 +67,7 @@ func main() {
 		Dsn:   "https://hello@world.io/1337",
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			// Solution 1 (use beforeSend, which will be applied to
-			// all events and is usually application specific):
+			// error events and is usually application specific):
 			if ex, ok := hint.OriginalException.(CustomComplexError); ok {
 				for key, val := range ex.GimmeMoreData() {
 					event.Extra[key] = val
@@ -80,9 +80,9 @@ func main() {
 		},
 		Transport: &devNullTransport{},
 
-		// Solution 2 (use custom integration, which will also be
-		// applied to all events, but can be easily extracted even as a
-		// separate utility and reused across all your projects):
+		// Solution 2 (use custom integration, which will be
+		// applied to all events, and can be extracted as a
+		// separate utility and reused across projects):
 		Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 			return append(integrations, new(ExtractExtra))
 		},


### PR DESCRIPTION
When the examples and accompanying documentation were written, 'all events' meant 'error events'. 

With transactions added to the SDK, `BeforeSend` is only applied to error events while all `EventProcessor` functions (on client, scope or global) are applied to all outgoing events (errors and transactions).
