### PR TITLE
docs: Clarify that BeforeSend is not called for transactions

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,7 +129,9 @@ type ClientOptions struct {
 	// and if applicable, caught errors type and value.
 	// If the match is found, then a whole event will be dropped.
 	IgnoreErrors []string
-	// Before send callback.
+	// BeforeSend is called before error events are sent to Sentry.
+	// Use it to mutate the event or return nil to discard the event.
+	// See EventProcessor if you need to mutate transactions.
 	BeforeSend func(event *Event, hint *EventHint) *Event
 	// Before breadcrumb add callback.
 	BeforeBreadcrumb func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb

--- a/example/with_extra/main.go
+++ b/example/with_extra/main.go
@@ -81,8 +81,8 @@ func main() {
 		Transport: &devNullTransport{},
 
 		// Solution 2 (use custom integration, which will be
-		// applied to all events, and can be extracted as a
-		// separate utility and reused across projects):
+		// applied to all events, can be extracted as a
+		// separate utility, and reused across projects):
 		Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 			return append(integrations, new(ExtractExtra))
 		},


### PR DESCRIPTION
And apply [suggestion from a previous change](https://github.com/getsentry/sentry-go/pull/350#discussion_r635423967).

Closes #341.
