### PR TITLE
ci: Use race detector only once for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,11 @@ jobs:
         run: go test ./...
       - name: Test (race)
         run: go test -race ./...
+        # The race detector adds considerable runtime overhead. To save time on
+        # pull requests, only run this step for a single job in the matrix. For
+        # all other workflow triggers (e.g., pushes to a release branch) run
+        # this step for the whole matrix.
+        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.16' && matrix.os == 'ubuntu') }}
     timeout-minutes: 10
     strategy:
       matrix:
@@ -105,6 +110,4 @@ jobs:
         run: go vet ./...
       - name: Test
         run: go test ./...
-      - name: Test (race)
-        run: go test -race ./...
     timeout-minutes: 10


### PR DESCRIPTION
We run tests on well-supported platforms, such that there is little
chance the race detector will detect a race in one operating system but
not in the others.

We can save resources, human and machine, by not using the race detector
too many times in every PR.

To be on the safe side, leave it on for pushes to master and release
branches.

Remove it from GOPATH Mode completely since it is redundant.