### PR TITLE
feat(transports): Category-based Rate Limiting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    - lll
     - maligned
     - misspell
     - nakedret

--- a/internal/ratelimit/category.go
+++ b/internal/ratelimit/category.go
@@ -1,0 +1,41 @@
+package ratelimit
+
+import "strings"
+
+// Reference:
+// https://github.com/getsentry/relay/blob/0424a2e017d193a93918053c90cdae9472d164bf/relay-common/src/constants.rs#L116-L127
+
+// Category classifies supported payload types that can be ingested by Sentry
+// and, therefore, rate limited.
+type Category string
+
+// Known rate limit categories. As a special case, the CategoryAll applies to
+// all known payload types.
+const (
+	CategoryAll         Category = ""
+	CategoryError       Category = "error"
+	CategoryTransaction Category = "transaction"
+)
+
+// knownCategories is the set of currently known categories. Other categories
+// are ignored for the purpose of rate-limiting.
+var knownCategories = map[Category]struct{}{
+	CategoryAll:         {},
+	CategoryError:       {},
+	CategoryTransaction: {},
+}
+
+// String returns the category formatted for debugging.
+func (c Category) String() string {
+	switch c {
+	case "":
+		return "CategoryAll"
+	default:
+		var b strings.Builder
+		b.WriteString("Category")
+		for _, w := range strings.Fields(string(c)) {
+			b.WriteString(strings.Title(w))
+		}
+		return b.String()
+	}
+}

--- a/internal/ratelimit/category_test.go
+++ b/internal/ratelimit/category_test.go
@@ -1,0 +1,25 @@
+package ratelimit
+
+import "testing"
+
+func TestCategoryString(t *testing.T) {
+	tests := []struct {
+		Category
+		want string
+	}{
+		{CategoryAll, "CategoryAll"},
+		{CategoryError, "CategoryError"},
+		{CategoryTransaction, "CategoryTransaction"},
+		{Category("unknown"), "CategoryUnknown"},
+		{Category("two words"), "CategoryTwoWords"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.Category.String()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ratelimit/deadline.go
+++ b/internal/ratelimit/deadline.go
@@ -1,0 +1,22 @@
+package ratelimit
+
+import "time"
+
+// A Deadline is a time instant when a rate limit expires.
+type Deadline time.Time
+
+// After reports whether the deadline d is after other.
+func (d Deadline) After(other Deadline) bool {
+	return time.Time(d).After(time.Time(other))
+}
+
+// Equal reports whether d and e represent the same deadline.
+func (d Deadline) Equal(e Deadline) bool {
+	return time.Time(d).Equal(time.Time(e))
+}
+
+// String returns the deadline formatted for debugging.
+func (d Deadline) String() string {
+	// Like time.Time.String, but without the monotonic clock reading.
+	return time.Time(d).Round(0).String()
+}

--- a/internal/ratelimit/doc.go
+++ b/internal/ratelimit/doc.go
@@ -1,0 +1,3 @@
+// Package ratelimit provides tools to work with rate limits imposed by Sentry's
+// data ingestion pipeline.
+package ratelimit

--- a/internal/ratelimit/map.go
+++ b/internal/ratelimit/map.go
@@ -1,0 +1,64 @@
+package ratelimit
+
+import (
+	"net/http"
+	"time"
+)
+
+// Map maps categories to rate limit deadlines.
+//
+// A rate limit is in effect for a given category if either the category's
+// deadline or the deadline for the special CategoryAll has not yet expired.
+//
+// Use IsRateLimited to check whether a category is rate-limited.
+type Map map[Category]Deadline
+
+// IsRateLimited returns true if the category is currently rate limited.
+func (m Map) IsRateLimited(c Category) bool {
+	return m.isRateLimited(c, time.Now())
+}
+
+func (m Map) isRateLimited(c Category, now time.Time) bool {
+	return m.Deadline(c).After(Deadline(now))
+}
+
+// Deadline returns the deadline when the rate limit for the given category or
+// the special CategoryAll expire, whichever is furthest into the future.
+func (m Map) Deadline(c Category) Deadline {
+	categoryDeadline := m[c]
+	allDeadline := m[CategoryAll]
+	if categoryDeadline.After(allDeadline) {
+		return categoryDeadline
+	}
+	return allDeadline
+}
+
+// Merge merges the other map into m.
+//
+// If a category appears in both maps, the deadline that is furthest into the
+// future is preserved.
+func (m Map) Merge(other Map) {
+	for c, d := range other {
+		if d.After(m[c]) {
+			m[c] = d
+		}
+	}
+}
+
+// FromResponse returns a rate limit map from an HTTP response.
+func FromResponse(r *http.Response) Map {
+	return fromResponse(r, time.Now())
+}
+
+func fromResponse(r *http.Response, now time.Time) (m Map) {
+	s := r.Header.Get("X-Sentry-Rate-Limits")
+	if s != "" {
+		return parseXSentryRateLimits(s, now)
+	}
+	if r.StatusCode == http.StatusTooManyRequests {
+		s := r.Header.Get("Retry-After")
+		deadline, _ := parseRetryAfter(s, now)
+		return Map{CategoryAll: deadline}
+	}
+	return Map{}
+}

--- a/internal/ratelimit/map.go
+++ b/internal/ratelimit/map.go
@@ -50,7 +50,7 @@ func FromResponse(r *http.Response) Map {
 	return fromResponse(r, time.Now())
 }
 
-func fromResponse(r *http.Response, now time.Time) (m Map) {
+func fromResponse(r *http.Response, now time.Time) Map {
 	s := r.Header.Get("X-Sentry-Rate-Limits")
 	if s != "" {
 		return parseXSentryRateLimits(s, now)

--- a/internal/ratelimit/map_test.go
+++ b/internal/ratelimit/map_test.go
@@ -1,0 +1,269 @@
+package ratelimit
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *http.Response
+		want     Map
+	}{
+		{
+			"200 no rate limit",
+			&http.Response{
+				StatusCode: http.StatusOK,
+			},
+			Map{},
+		},
+		{
+			"200 ignored Retry-After",
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Retry-After": []string{"100"}, // ignored
+				},
+			},
+			Map{},
+		},
+		{
+			"200 Retry-After + X-Sentry-Rate-Limits",
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Retry-After":          []string{"100"}, // ignored
+					"X-Sentry-Rate-Limits": []string{"50:transaction"},
+				},
+			},
+			Map{CategoryTransaction: Deadline(now.Add(50 * time.Second))},
+		},
+		{
+			"200 X-Sentry-Rate-Limits",
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"X-Sentry-Rate-Limits": []string{"50:transaction"},
+				},
+			},
+			Map{CategoryTransaction: Deadline(now.Add(50 * time.Second))},
+		},
+		{
+			"429 no rate limit, use default",
+			&http.Response{
+				StatusCode: http.StatusTooManyRequests,
+			},
+			Map{CategoryAll: Deadline(now.Add(defaultRetryAfter))},
+		},
+		{
+			"429 Retry-After",
+			&http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Retry-After": []string{"100"},
+				},
+			},
+			Map{CategoryAll: Deadline(now.Add(100 * time.Second))},
+		},
+		{
+			"429 X-Sentry-Rate-Limits",
+			&http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"X-Sentry-Rate-Limits": []string{"50:error"},
+				},
+			},
+			Map{CategoryError: Deadline(now.Add(50 * time.Second))},
+		},
+		{
+			"429 Retry-After + X-Sentry-Rate-Limits",
+			&http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Retry-After":          []string{"100"}, // ignored
+					"X-Sentry-Rate-Limits": []string{"50:error"},
+				},
+			},
+			Map{CategoryError: Deadline(now.Add(50 * time.Second))},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := fromResponse(tt.response, now)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMapDeadlineIsRateLimited(t *testing.T) {
+	noDeadline := Deadline{}
+	plus5s := Deadline(now.Add(5 * time.Second))
+	plus10s := Deadline(now.Add(10 * time.Second))
+	future := now.Add(time.Hour)
+
+	tests := []struct {
+		name string
+		m    Map
+		want map[Category]Deadline
+	}{
+		{
+			"Empty map = no deadlines",
+			Map{},
+			map[Category]Deadline{
+				CategoryAll:         noDeadline,
+				CategoryError:       noDeadline,
+				CategoryTransaction: noDeadline,
+				Category("unknown"): noDeadline,
+			},
+		},
+		{
+			"Only one category",
+			Map{
+				CategoryError: plus5s,
+			},
+			map[Category]Deadline{
+				CategoryAll:         noDeadline,
+				CategoryError:       plus5s,
+				CategoryTransaction: noDeadline,
+				Category("unknown"): noDeadline,
+			},
+		},
+		{
+			"Only CategoryAll",
+			Map{
+				CategoryAll: plus5s,
+			},
+			map[Category]Deadline{
+				CategoryAll:         plus5s,
+				CategoryError:       plus5s,
+				CategoryTransaction: plus5s,
+				Category("unknown"): plus5s,
+			},
+		},
+		{
+			"Two categories",
+			Map{
+				CategoryError:       plus5s,
+				CategoryTransaction: plus10s,
+			},
+			map[Category]Deadline{
+				CategoryAll:         noDeadline,
+				CategoryError:       plus5s,
+				CategoryTransaction: plus10s,
+				Category("unknown"): noDeadline,
+			},
+		},
+		{
+			"CategoryAll earlier",
+			Map{
+				CategoryAll:         plus5s,
+				CategoryTransaction: plus10s,
+			},
+			map[Category]Deadline{
+				CategoryAll:         plus5s,
+				CategoryError:       plus5s,
+				CategoryTransaction: plus10s,
+				Category("unknown"): plus5s,
+			},
+		},
+		{
+			"CategoryAll later",
+			Map{
+				CategoryAll:         plus10s,
+				CategoryTransaction: plus5s,
+			},
+			map[Category]Deadline{
+				CategoryAll:         plus10s,
+				CategoryError:       plus10s,
+				CategoryTransaction: plus10s,
+				Category("unknown"): plus10s,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			for c, want := range tt.want {
+				got := tt.m.Deadline(c)
+				if got != want {
+					t.Fatalf("Deadline(%v): got %v, want %v", c, got, want)
+				}
+				limited := tt.m.isRateLimited(c, now)
+				wantLimited := want != noDeadline
+				if limited != wantLimited {
+					t.Errorf("isRateLimited(%v, now): got %v, want %v", c, limited, wantLimited)
+				}
+				// Nothing should be rate-limited in the future
+				limited = tt.m.isRateLimited(c, future)
+				wantLimited = false
+				if limited != wantLimited {
+					t.Errorf("isRateLimited(%v, future): got %v, want %v", c, limited, wantLimited)
+				}
+			}
+		})
+	}
+}
+
+func TestMapMerge(t *testing.T) {
+	tests := []struct {
+		name     string
+		old, new Map
+		want     Map
+	}{
+		{
+			name: "both empty",
+			old:  Map{},
+			new:  Map{},
+			want: Map{},
+		},
+		{
+			name: "old empty",
+			old:  Map{},
+			new:  Map{CategoryError: Deadline(now)},
+			want: Map{CategoryError: Deadline(now)},
+		},
+		{
+			name: "new empty",
+			old:  Map{CategoryError: Deadline(now)},
+			new:  Map{},
+			want: Map{CategoryError: Deadline(now)},
+		},
+		{
+			name: "no overlap = union",
+			old:  Map{CategoryTransaction: Deadline(now)},
+			new:  Map{CategoryError: Deadline(now)},
+			want: Map{
+				CategoryTransaction: Deadline(now),
+				CategoryError:       Deadline(now),
+			},
+		},
+		{
+			name: "overlap keep old",
+			old:  Map{CategoryError: Deadline(now.Add(time.Minute))},
+			new:  Map{CategoryError: Deadline(now)},
+			want: Map{CategoryError: Deadline(now.Add(time.Minute))},
+		},
+		{
+			name: "overlap replace with new",
+			old:  Map{CategoryError: Deadline(now)},
+			new:  Map{CategoryError: Deadline(now.Add(time.Minute))},
+			want: Map{CategoryError: Deadline(now.Add(time.Minute))},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tt.old.Merge(tt.new)
+			if diff := cmp.Diff(tt.want, tt.old); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/ratelimit/rate_limits.go
+++ b/internal/ratelimit/rate_limits.go
@@ -1,0 +1,76 @@
+package ratelimit
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var errInvalidXSRLRetryAfter = errors.New("invalid retry-after value")
+
+// parseXSentryRateLimits returns a RateLimits map by parsing an input string in
+// the format of the X-Sentry-Rate-Limits header.
+//
+// Example
+//
+//      X-Sentry-Rate-Limits: 60:transaction, 2700:default;error;security
+//
+// This will rate limit transactions for the next 60 seconds and errors for the
+// next 2700 seconds.
+//
+// Limits for unknown categories are ignored.
+func parseXSentryRateLimits(s string, now time.Time) Map {
+	// https://github.com/getsentry/relay/blob/0424a2e017d193a93918053c90cdae9472d164bf/relay-server/src/utils/rate_limits.rs#L44-L82
+	m := make(Map, len(knownCategories))
+	for _, limit := range strings.Split(s, ",") {
+		limit = strings.TrimSpace(limit)
+		if limit == "" {
+			continue
+		}
+		components := strings.Split(limit, ":")
+		if len(components) == 0 {
+			continue
+		}
+		retryAfter, err := parseXSRLRetryAfter(strings.TrimSpace(components[0]), now)
+		if err != nil {
+			continue
+		}
+		categories := ""
+		if len(components) > 1 {
+			categories = components[1]
+		}
+		for _, category := range strings.Split(categories, ";") {
+			c := Category(strings.ToLower(strings.TrimSpace(category)))
+			if _, ok := knownCategories[c]; !ok {
+				// skip unknown categories, keep m small
+				continue
+			}
+			// always keep the deadline furthest into the future
+			if retryAfter.After(m[c]) {
+				m[c] = retryAfter
+			}
+		}
+	}
+	return m
+}
+
+// parseXSRLRetryAfter parses a string into a retry-after rate limit deadline.
+//
+// Valid input is a number, possibly signed and possibly floating-point,
+// indicating the number of seconds to wait before sending another request.
+// Negative values are treated as zero. Fractional values are rounded to the
+// next integer.
+func parseXSRLRetryAfter(s string, now time.Time) (Deadline, error) {
+	// https://github.com/getsentry/relay/blob/0424a2e017d193a93918053c90cdae9472d164bf/relay-quotas/src/rate_limit.rs#L88-L96
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return Deadline{}, errInvalidXSRLRetryAfter
+	}
+	d := time.Duration(math.Ceil(math.Max(f, 0.0))) * time.Second
+	if d < 0 {
+		d = 0
+	}
+	return Deadline(now.Add(d)), nil
+}

--- a/internal/ratelimit/rate_limits_test.go
+++ b/internal/ratelimit/rate_limits_test.go
@@ -1,0 +1,150 @@
+package ratelimit
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var now = time.Date(2008, 5, 12, 16, 26, 19, 0, time.UTC)
+
+func TestParseXSentryRateLimits(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantLimits Map
+	}{
+		// Empty rate limits == nothing is rate-limited
+		{"", Map{}},
+		{",", Map{}},
+		{",,,,", Map{}},
+		{",  ,   ,     ,", Map{}},
+		{":", Map{}},
+		{":::", Map{}},
+		{"::,,:,", Map{}},
+		{":,:;;;:", Map{}},
+
+		{
+			"1",
+			Map{CategoryAll: Deadline(now.Add(1 * time.Second))},
+		},
+		{
+			"2::ignored_scope:ignored_reason",
+			Map{CategoryAll: Deadline(now.Add(2 * time.Second))},
+		},
+		{
+			"3::ignored_scope:ignored_reason",
+			Map{CategoryAll: Deadline(now.Add(3 * time.Second))},
+		},
+
+		{
+			"4:error",
+			Map{CategoryError: Deadline(now.Add(4 * time.Second))},
+		},
+		{
+			"5:error;transaction",
+			Map{
+				CategoryError:       Deadline(now.Add(5 * time.Second)),
+				CategoryTransaction: Deadline(now.Add(5 * time.Second)),
+			},
+		},
+		{
+			"6:error, 7:transaction",
+			Map{
+				CategoryError:       Deadline(now.Add(6 * time.Second)),
+				CategoryTransaction: Deadline(now.Add(7 * time.Second)),
+			},
+		},
+		{
+			// ignore unknown categories
+			"8:error;default;unknown",
+			Map{CategoryError: Deadline(now.Add(8 * time.Second))},
+		},
+		{
+			"30:error:scope1, 20:error:scope2, 40:error",
+			Map{CategoryError: Deadline(now.Add(40 * time.Second))},
+		},
+		{
+			"30:error:scope1, 20:error:scope2, 40::",
+			Map{
+				CategoryAll:   Deadline(now.Add(40 * time.Second)),
+				CategoryError: Deadline(now.Add(30 * time.Second)),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%q", tt.input), func(t *testing.T) {
+			got, want := parseXSentryRateLimits(tt.input, now), tt.wantLimits
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+func TestParseXSRLRetryAfterValidInput(t *testing.T) {
+	// https://github.com/getsentry/relay/blob/0424a2e017d193a93918053c90cdae9472d164bf/relay-quotas/src/rate_limit.rs#L88-L96
+	tests := []struct {
+		input string
+		want  Deadline
+	}{
+		// Integers are the common case
+		{"0", Deadline(now)},
+		{"1", Deadline(now.Add(1 * time.Second))},
+		{"60", Deadline(now.Add(1 * time.Minute))},
+
+		// Any fractional increment round up to the next full second
+		// (replicating implementation in getsentry/relay)
+		{"3.1", Deadline(now.Add(4 * time.Second))},
+		{"3.5", Deadline(now.Add(4 * time.Second))},
+		{"3.9", Deadline(now.Add(4 * time.Second))},
+
+		// Overflows are treated like zero
+		{"100000000000000000", Deadline(now)},
+
+		// Negative numbers are treated like zero
+		{"-Inf", Deadline(now)},
+		{"-0", Deadline(now)},
+		{"-1", Deadline(now)},
+
+		// Special floats are treated like zero
+		{"Inf", Deadline(now)},
+		{"NaN", Deadline(now)},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%q", tt.input), func(t *testing.T) {
+			d, err := parseXSRLRetryAfter(tt.input, now)
+			if err != nil {
+				t.Fatalf("got %v, want nil", err)
+			}
+			got, want := time.Time(d), time.Time(tt.want)
+			if !got.Equal(want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestParseXSRLRetryAfterInvalidInput(t *testing.T) {
+	// https://github.com/getsentry/relay/blob/0424a2e017d193a93918053c90cdae9472d164bf/relay-quotas/src/rate_limit.rs#L88-L96
+	tests := []struct {
+		input string
+	}{
+		{""},
+		{"invalid"},
+		{" 2 "},
+		{"6 0"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := parseXSRLRetryAfter(tt.input, now)
+			if err == nil {
+				t.Fatalf("got %v, want nil", err)
+			}
+			t.Log(err)
+		})
+	}
+}

--- a/internal/ratelimit/retry_after.go
+++ b/internal/ratelimit/retry_after.go
@@ -1,0 +1,40 @@
+package ratelimit
+
+import (
+	"errors"
+	"strconv"
+	"time"
+)
+
+const defaultRetryAfter = 1 * time.Minute
+
+var errInvalidRetryAfter = errors.New("invalid input")
+
+// parseRetryAfter parses a string s as in the standard Retry-After HTTP header
+// and returns a deadline until when requests are rate limited and therefore new
+// requests should not be sent. The input may be either a date or a non-negative
+// integer number of seconds.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+//
+// parseRetryAfter always returns a usable deadline, even in case of an error.
+//
+// This is the original rate limiting mechanism used by Sentry, superseeded by
+// the X-Sentry-Rate-Limits response header.
+func parseRetryAfter(s string, now time.Time) (Deadline, error) {
+	if s == "" {
+		goto invalid
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		if n < 0 {
+			goto invalid
+		}
+		d := time.Duration(n) * time.Second
+		return Deadline(now.Add(d)), nil
+	}
+	if date, err := time.Parse(time.RFC1123, s); err == nil {
+		return Deadline(date), nil
+	}
+invalid:
+	return Deadline(now.Add(defaultRetryAfter)), errInvalidRetryAfter
+}

--- a/internal/ratelimit/retry_after_test.go
+++ b/internal/ratelimit/retry_after_test.go
@@ -1,0 +1,58 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	defaultDeadline := Deadline(now.Add(defaultRetryAfter))
+	tests := map[string]struct {
+		input   string
+		want    Deadline
+		wantErr bool // if true, want is set to defaultDeadline
+	}{
+		// Invalid input
+		"Empty": {
+			input:   "",
+			wantErr: true,
+		},
+		"BadString": {
+			input:   "x",
+			wantErr: true,
+		},
+		"Negative": {
+			input:   "-1",
+			wantErr: true,
+		},
+		"Float": {
+			input:   "5.0",
+			wantErr: true,
+		},
+		// Valid input
+		"Integer": {
+			input: "1337",
+			want:  Deadline(now.Add(1337 * time.Second)),
+		},
+		"Date": {
+			input: "Fri, 08 Mar 2019 11:17:09 GMT",
+			want:  Deadline(time.Date(2019, 3, 8, 11, 17, 9, 0, time.UTC)),
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			got, err := parseRetryAfter(tt.input, now)
+			want := tt.want
+			if tt.wantErr {
+				want = defaultDeadline
+				if err == nil {
+					t.Errorf("got err = nil, want non-nil")
+				}
+			}
+			if !got.Equal(want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -204,6 +204,7 @@ func NewHTTPTransport() *HTTPTransport {
 	transport := HTTPTransport{
 		BufferSize: defaultBufferSize,
 		Timeout:    defaultTimeout,
+		limits:     make(ratelimit.Map),
 	}
 	return &transport
 }
@@ -389,7 +390,7 @@ func (t *HTTPTransport) worker() {
 				continue
 			}
 			t.mu.Lock()
-			t.limits = ratelimit.FromResponse(response)
+			t.limits.Merge(ratelimit.FromResponse(response))
 			t.mu.Unlock()
 			// Drain body up to a limit and close it, allowing the
 			// transport to reuse TCP connections.

--- a/transport_test.go
+++ b/transport_test.go
@@ -19,7 +19,6 @@ type unserializableType struct {
 	UnsupportedField func()
 }
 
-//nolint: lll
 const (
 	basicEvent                         = `{"message":"mkey","sdk":{},"user":{}}`
 	enhancedEventInvalidBreadcrumb     = `{"extra":{"info":"Could not encode original event as JSON. Succeeded by removing Breadcrumbs, Contexts and Extra. Please verify the data you attach to the scope. Error: json: error calling MarshalJSON for type *sentry.Event: json: error calling MarshalJSON for type *sentry.Breadcrumb: json: unsupported type: func()"},"message":"mkey","sdk":{},"user":{}}`

--- a/transport_test.go
+++ b/transport_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -455,7 +455,7 @@ func testRateLimiting(t *testing.T, tr Transport) {
 
 	// Test server that simulates responses with rate limits.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := io.ReadAll(r.Body)
+		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/transport_test.go
+++ b/transport_test.go
@@ -198,32 +198,6 @@ func TestGetRequestFromEvent(t *testing.T) {
 	}
 }
 
-func TestRetryAfterNoHeader(t *testing.T) {
-	assertEqual(t, retryAfter(time.Now(), nil), time.Second*60)
-}
-
-func TestRetryAfterIncorrectHeader(t *testing.T) {
-	h := http.Header{
-		"Retry-After": {"x"},
-	}
-	assertEqual(t, retryAfter(time.Now(), h), time.Second*60)
-}
-
-func TestRetryAfterDelayHeader(t *testing.T) {
-	h := http.Header{
-		"Retry-After": {"1337"},
-	}
-	assertEqual(t, retryAfter(time.Now(), h), time.Second*1337)
-}
-
-func TestRetryAfterDateHeader(t *testing.T) {
-	now, _ := time.Parse(time.RFC1123, "Wed, 21 Oct 2015 07:28:00 GMT")
-	h := http.Header{
-		"Retry-After": {"Wed, 21 Oct 2015 07:28:13 GMT"},
-	}
-	assertEqual(t, retryAfter(now, h), time.Second*13)
-}
-
 // A testHTTPServer counts events sent to it. It requires a call to Unblock
 // before incrementing its internal counter and sending a response to the HTTP
 // client. This allows for coordinating the execution flow when needed.


### PR DESCRIPTION
This adds support for parsing the `X-Sentry-Rate-Limits` and rate limiting errors and transactions independently.