### PR TITLE
ci: Disable lll linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    - lll
     - maligned
     - misspell
     - nakedret

--- a/transport_test.go
+++ b/transport_test.go
@@ -19,7 +19,6 @@ type unserializableType struct {
 	UnsupportedField func()
 }
 
-//nolint: lll
 const (
 	basicEvent                         = `{"message":"mkey","sdk":{},"user":{}}`
 	enhancedEventInvalidBreadcrumb     = `{"extra":{"info":"Could not encode original event as JSON. Succeeded by removing Breadcrumbs, Contexts and Extra. Please verify the data you attach to the scope. Error: json: error calling MarshalJSON for type *sentry.Event: json: error calling MarshalJSON for type *sentry.Breadcrumb: json: unsupported type: func()"},"message":"mkey","sdk":{},"user":{}}`


### PR DESCRIPTION
It has not given us much value. Instead of adding 'nolint' lines for the
few cases where we do need long lines, better not have this linter and
keep the code base free of linter pragmas.
