### PR TITLE
build: Bump go.mod Go version to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.13
+go 1.14
 
 require (
 	github.com/ajg/form v1.5.1 // indirect


### PR DESCRIPTION
This is complimentary to [dropping support for Go 1.13](https://github.com/getsentry/sentry-go/pull/346).
We can now declare the minimum Go version to be 1.14.

We still support the last three stable Go releases, which is more than
what the Go project and community normally do (the norm is to support
the last two stable releases).

https://golang.org/doc/modules/gomod-ref

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
