### PR TITLE
feat(transports): Report User-Agent identifying SDK

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -12,6 +12,9 @@ const Version = "0.10.0"
 // sentry-go SDK.
 const apiVersion = "7"
 
+// userAgent is the User-Agent of outgoing HTTP requests.
+const userAgent = "sentry-go/" + Version
+
 // Init initializes the SDK with options. The returned error is non-nil if
 // options is invalid, for instance if a malformed DSN is provided.
 func Init(options ClientOptions) error {

--- a/transport.go
+++ b/transport.go
@@ -144,7 +144,12 @@ func transactionEnvelopeFromBody(eventID EventID, sentAt time.Time, body json.Ra
 	return &b, nil
 }
 
-func getRequestFromEvent(event *Event, dsn *Dsn) (*http.Request, error) {
+func getRequestFromEvent(event *Event, dsn *Dsn) (r *http.Request, err error) {
+	defer func() {
+		if r != nil {
+			r.Header.Set("User-Agent", userAgent)
+		}
+	}()
 	body := getRequestBodyFromEvent(event)
 	if body == nil {
 		return nil, errors.New("event could not be marshaled")

--- a/transport_test.go
+++ b/transport_test.go
@@ -193,6 +193,10 @@ func TestGetRequestFromEvent(t *testing.T) {
 			if req.URL.String() != test.apiURL {
 				t.Errorf("Incorrect API URL. want: %s, got: %s", test.apiURL, req.URL.String())
 			}
+
+			if ua := req.UserAgent(); ua != userAgent {
+				t.Errorf("got User-Agent = %q, want %q", ua, userAgent)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The default User-Agent for outgoing requests using Go's HTTP client is `Go-http-client/1.1`.

Instead of reporting this generic string that confuses with any other Go program, identify the SDK and version used to send out requests.

The intent here is to facilitate debugging.