### PR TITLE
More ClientOptions.Release documentation

### DIFF
--- a/client.go
+++ b/client.go
@@ -145,6 +145,28 @@ type ClientOptions struct {
 	// The server name to be reported.
 	ServerName string
 	// The release to be sent with events.
+	//
+	// Some Sentry features are built around releases, and, thus, reporting
+	// events with a non-empty release improves the product experience. See
+	// https://docs.sentry.io/product/releases/.
+	//
+	// If Release is not set, the SDK will try to derive a default value
+	// from environment variables or the Git repository in the working
+	// directory.
+	//
+	// If you distribute a compiled binary, it is recommended to set the
+	// Release value explicitly at build time. As an example, you can use:
+	//
+	// 	go build -ldflags='-X main.release=VALUE'
+	//
+	// That will set the value of a predeclared variable 'release' in the
+	// 'main' package to 'VALUE'. Then, use that variable when initializing
+	// the SDK:
+	//
+	// 	sentry.Init(ClientOptions{Release: release})
+	//
+	// See https://golang.org/cmd/go/ and https://golang.org/cmd/link/ for
+	// the official documentation of -ldflags and -X, respectively.
 	Release string
 	// The dist to be sent with events.
 	Dist string

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -22,6 +22,13 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
+// release is the release of this program that will be reported to Sentry.
+// Use go build -ldflags='-X main.release=VALUE' to set this value in build
+// time.
+// If not set, a default release value will be derived in runtime from
+// environment variables or the Git repository in the current working directory.
+var release string
+
 func main() {
 	if len(os.Args) < 2 {
 		log.Fatalf("usage: %s URL", os.Args[0])
@@ -32,7 +39,8 @@ func main() {
 		Dsn: "",
 		// Enable printing of SDK debug messages.
 		// Useful when getting started or trying to figure something out.
-		Debug: true,
+		Debug:   true,
+		Release: release,
 	})
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)

--- a/util.go
+++ b/util.go
@@ -41,7 +41,8 @@ func prettyPrint(data interface{}) {
 	fmt.Println(string(dbg))
 }
 
-// attempts to guess a default release.
+// defaultRelease attempts to guess a default release for the currently running
+// program.
 func defaultRelease() string {
 	// Search environment variables (EV) known to hold release info.
 	envs := []string{


### PR DESCRIPTION
- Briefly explain importance of setting a release
- Document that release may be derived from env or git
- Recommend setting the release during build
- Apply build-time release pattern to examples

This is a follow up on https://github.com/getsentry/sentry-go/pull/363.