### PR TITLE
Do not change Hub.lastEventID for transactions

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -212,12 +212,14 @@ func (hub *Hub) CaptureEvent(event *Event) *EventID {
 	}
 	eventID := client.CaptureEvent(event, nil, scope)
 
-	hub.mu.Lock()
-	defer hub.mu.Unlock()
-	if eventID != nil {
-		hub.lastEventID = *eventID
-	} else {
-		hub.lastEventID = ""
+	if event.Type != transactionType {
+		hub.mu.Lock()
+		defer hub.mu.Unlock()
+		if eventID != nil {
+			hub.lastEventID = *eventID
+		} else {
+			hub.lastEventID = ""
+		}
 	}
 	return eventID
 }

--- a/hub_test.go
+++ b/hub_test.go
@@ -190,6 +190,16 @@ func TestLastEventIDUpdatesAfterCaptures(t *testing.T) {
 	assertEqual(t, *eventID, hub.LastEventID())
 }
 
+func TestLastEventIDNotChangedForTransactions(t *testing.T) {
+	hub, _, _ := setupHubTest()
+
+	errorID := hub.CaptureException(fmt.Errorf("wat"))
+	assertEqual(t, *errorID, hub.LastEventID())
+
+	hub.CaptureEvent(&Event{Type: transactionType})
+	assertEqual(t, *errorID, hub.LastEventID())
+}
+
 func TestAddBreadcrumbRespectMaxBreadcrumbsOption(t *testing.T) {
 	hub, client, scope := setupHubTest()
 	client.options.MaxBreadcrumbs = 2


### PR DESCRIPTION
LastEventID was meant to be used for error IDs, and with the addition of the transaction event type, those use cases got affected.

See https://github.com/getsentry/develop/issues/431.