### PR TITLE
fix: Do not clear LastEventID when events are dropped

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -223,14 +223,10 @@ func (hub *Hub) CaptureEvent(event *Event) *EventID {
 	}
 	eventID := client.CaptureEvent(event, nil, scope)
 
-	if event.Type != transactionType {
+	if event.Type != transactionType && eventID != nil {
 		hub.mu.Lock()
-		defer hub.mu.Unlock()
-		if eventID != nil {
-			hub.lastEventID = *eventID
-		} else {
-			hub.lastEventID = ""
-		}
+		hub.lastEventID = *eventID
+		hub.mu.Unlock()
 	}
 	return eventID
 }
@@ -245,12 +241,10 @@ func (hub *Hub) CaptureMessage(message string) *EventID {
 	}
 	eventID := client.CaptureMessage(message, nil, scope)
 
-	hub.mu.Lock()
-	defer hub.mu.Unlock()
 	if eventID != nil {
+		hub.mu.Lock()
 		hub.lastEventID = *eventID
-	} else {
-		hub.lastEventID = ""
+		hub.mu.Unlock()
 	}
 	return eventID
 }
@@ -265,12 +259,10 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 	}
 	eventID := client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
 
-	hub.mu.Lock()
-	defer hub.mu.Unlock()
 	if eventID != nil {
+		hub.mu.Lock()
 		hub.lastEventID = *eventID
-	} else {
-		hub.lastEventID = ""
+		hub.mu.Unlock()
 	}
 	return eventID
 }

--- a/hub_test.go
+++ b/hub_test.go
@@ -200,6 +200,22 @@ func TestLastEventIDNotChangedForTransactions(t *testing.T) {
 	assertEqual(t, *errorID, hub.LastEventID())
 }
 
+func TestLastEventIDDoesNotReset(t *testing.T) {
+	hub, client, _ := setupHubTest()
+
+	id1 := hub.CaptureException(fmt.Errorf("error 1"))
+	assertEqual(t, hub.LastEventID(), *id1)
+
+	client.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+		// drop all events
+		return nil
+	})
+
+	id2 := hub.CaptureException(fmt.Errorf("error 2"))
+	assertEqual(t, id2, (*EventID)(nil))    // event must have been dropped
+	assertEqual(t, hub.LastEventID(), *id1) // last event ID must not have changed
+}
+
 func TestAddBreadcrumbRespectMaxBreadcrumbsOption(t *testing.T) {
 	hub, client, scope := setupHubTest()
 	client.options.MaxBreadcrumbs = 2


### PR DESCRIPTION
The behavior was unintended (introduced in https://github.com/getsentry/sentry-go/pull/99/commits/10c1f9ff9d68bea97e71efa1666f19144d7adb34) and incompatible with other SDKs.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
