### PR TITLE
docs: Explain Frame.Module and Frame.Package

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -160,9 +160,16 @@ func extractXErrorsPC(err error) []uintptr {
 // Frame represents a function call and it's metadata. Frames are associated
 // with a Stacktrace.
 type Frame struct {
-	Function    string                 `json:"function,omitempty"`
-	Symbol      string                 `json:"symbol,omitempty"`
-	Module      string                 `json:"module,omitempty"`
+	Function string `json:"function,omitempty"`
+	Symbol   string `json:"symbol,omitempty"`
+	// Module is, despite the name, the Sentry protocol equivalent of a Go
+	// package's import path.
+	Module string `json:"module,omitempty"`
+	// Package is not used for Go stack trace frames. In other platforms it
+	// refers to a container where the Module can be found. For example, a
+	// Java JAR, a .NET Assembly, or a native dynamic library.
+	// It exists for completeness, allowing the construction and reporting
+	// of custom event payloads.
 	Package     string                 `json:"package,omitempty"`
 	Filename    string                 `json:"filename,omitempty"`
 	AbsPath     string                 `json:"abs_path,omitempty"`


### PR DESCRIPTION
The naming can be confusing since "Go Package" and "Go Module" have a very specific meaning in Go, but that meaning doesn't match the platform-agnostic meaning from the Sentry protocol.

See also https://github.com/getsentry/sentry-go/pull/377#issuecomment-940004745.