### PR TITLE
feat: Replace os/exec with golang.org/x/sys/execabs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,6 @@ require (
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211008194852-3b03d305991f // indirect
-	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
+	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/util.go
+++ b/util.go
@@ -6,9 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func uuid() string {


### PR DESCRIPTION
Package [`execabs`](golang.org/x/sys/execabs) is a drop-in replacement for `os/exec` that requires PATH lookups to find absolute paths.

This change guarantees that the SDK will never run a `git` binary from the current working directory.

See discussion in https://blog.golang.org/path-security.