### PR TITLE
Sanitize user input before logging in example code

### DIFF
--- a/example/http/main.go
+++ b/example/http/main.go
@@ -119,7 +119,7 @@ func run() error {
 			defer span.Finish()
 			err := t.Execute(w, time.Now().UnixNano())
 			if err != nil {
-				log.Printf("[%s] %s", r.URL.Path, err)
+				log.Printf("[%q] %s", r.URL.Path, err)
 				return
 			}
 		}()
@@ -163,7 +163,7 @@ func run() error {
 		span.Finish()
 
 		if err != nil {
-			log.Printf("[%s] %s", r.URL.Path, err)
+			log.Printf("[%q] %s", r.URL.Path, err)
 			hub := sentry.GetHubFromContext(ctx)
 			hub.CaptureException(err)
 			code := http.StatusInternalServerError


### PR DESCRIPTION
For https://github.com/github/codeql-go/issues/650.

CodeQL is still not able to understand `"%q"` right now, but still we can make the change for better/safer example code.