### PR TITLE
feat: Derive release names from Git tags

### DIFF
--- a/util.go
+++ b/util.go
@@ -66,8 +66,11 @@ func defaultRelease() (release string) {
 		}
 	}
 
-	// Derive a version string from Git.
-	cmd := exec.Command("git", "rev-parse", "HEAD")
+	// Derive a version string from Git. Example outputs:
+	// 	v1.0.1-0-g9de4
+	// 	v2.0-8-g77df-dirty
+	// 	4f72d7
+	cmd := exec.Command("git", "describe", "--long", "--always", "--dirty")
 	b, err := cmd.Output()
 	if err != nil {
 		// Either Git is not available or the current directory is not a


### PR DESCRIPTION
For projects that have tags in their Git repository, what is common in Go projects, we can derive more meaningful release names with a tag as prefix, instead of using a long random-looking hash as release name.

The new algorithm also derives a different release name if the repository state is "dirty" (local changes not committed).

If no tags are available, a short unambiguous hash of the last commit is used.

```
Before:
	4f72d7725080f61e924409c8ddd008739fd4a837

After:
	v1.0.1-0-g9de4
	v2.0-8-g77df-dirty
	4f72d7
```