### PR TITLE
build: Bump supported Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go: ["1.16", "1.15", "1.14"]
+        go: ["1.17", "1.16", "1.15"]
         os: [ubuntu, windows, macos]
       fail-fast: false
   test-gopath:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.14
+go 1.15
 
 require (
 	github.com/ajg/form v1.5.1 // indirect


### PR DESCRIPTION
Continuing with our cadence to support the last 3 Go releases.

See [our README](https://github.com/getsentry/sentry-go/blob/6f773c6ed0047c04787e986536a4478be1452162/README.md#requirements).