### PR TITLE
decode the body  as a json if the Content-Type is application/json

### DIFF
--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -39,6 +39,7 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "http://example.com/panic",
 					Method: "GET",
+					Data:   "",
 					Headers: map[string]string{
 						"Host":       "example.com",
 						"User-Agent": "fasthttp",
@@ -82,6 +83,7 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "http://example.com/get",
 					Method: "GET",
+					Data:   "",
 					Headers: map[string]string{
 						"Host":       "example.com",
 						"User-Agent": "fasthttp",

--- a/interfaces.go
+++ b/interfaces.go
@@ -103,7 +103,7 @@ type User struct {
 type Request struct {
 	URL         string            `json:"url,omitempty"`
 	Method      string            `json:"method,omitempty"`
-	Data        string            `json:"data,omitempty"`
+	Data        interface{}       `json:"data,omitempty"`
 	QueryString string            `json:"query_string,omitempty"`
 	Cookies     string            `json:"cookies,omitempty"`
 	Headers     map[string]string `json:"headers,omitempty"`
@@ -142,6 +142,7 @@ func NewRequest(r *http.Request) *Request {
 		URL:         url,
 		Method:      r.Method,
 		QueryString: r.URL.RawQuery,
+		Data:        "",
 		Cookies:     cookies,
 		Headers:     headers,
 		Env:         env,


### PR DESCRIPTION
I propose this change to enable the Go integration of sentry to send a json representation of the payload instead of a raw byte representation of the payload.

Currently, if some filtering is enable on a project, the whole body is affected and then filtered, with this proposal, only the identified field will be filtered.

![before](https://user-images.githubusercontent.com/4057108/147275355-c34d0427-d422-409d-aac2-b608651918c6.png)
![after](https://user-images.githubusercontent.com/4057108/147275363-6270317f-8d58-4229-bec3-6e8e648470e0.png)

fixes : https://github.com/getsentry/sentry-go/issues/404