### PR TITLE
misc: Update deprecated linters and fix code for remaining rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - exportloopref
     - gochecknoinits
     - goconst
     - gocritic
@@ -14,17 +15,14 @@ linters:
     - godot
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - prealloc
-    - scopelint
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/client.go
+++ b/client.go
@@ -60,6 +60,7 @@ func (r *lockedRand) Float64() float64 {
 // other hand, the source returned from rand.NewSource is not safe for
 // concurrent use, so we need to couple its use with a sync.Mutex.
 var rng = &lockedRand{
+	//#nosec G404 -- We are fine using transparent, non-secure value here.
 	r: rand.New(rand.NewSource(time.Now().UnixNano())),
 }
 

--- a/example/iris/main.go
+++ b/example/iris/main.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package main

--- a/example/recover-repanic/main.go
+++ b/example/recover-repanic/main.go
@@ -57,6 +57,7 @@ func main() {
 			defer wg.Done()
 			RecoverRepanic(func() {
 				// Sleep to simulate some work.
+				//#nosec G404 -- We are fine using transparent, non-secure value here.
 				time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
 				// Intentionally access an index out of bounds to trigger a runtime
 				// panic.

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package sentryiris

--- a/scope.go
+++ b/scope.go
@@ -69,11 +69,9 @@ func (scope *Scope) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
-	breadcrumbs := append(scope.breadcrumbs, breadcrumb)
-	if len(breadcrumbs) > limit {
-		scope.breadcrumbs = breadcrumbs[1 : limit+1]
-	} else {
-		scope.breadcrumbs = breadcrumbs
+	scope.breadcrumbs = append(scope.breadcrumbs, breadcrumb)
+	if len(scope.breadcrumbs) > limit {
+		scope.breadcrumbs = scope.breadcrumbs[1 : limit+1]
 	}
 }
 

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -127,7 +127,7 @@ func extractPcs(method reflect.Value) []uintptr {
 					pcs = append(pcs, uintptr(field.Uint()))
 					break
 				}
- 			}
+			}
 		}
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -54,7 +54,8 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 func getTLSConfig(options ClientOptions) *tls.Config {
 	if options.CaCerts != nil {
 		return &tls.Config{
-			RootCAs: options.CaCerts,
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    options.CaCerts,
 		}
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -53,9 +53,10 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 
 func getTLSConfig(options ClientOptions) *tls.Config {
 	if options.CaCerts != nil {
+		//#nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
+		// 				 but we don't want to break peoples code without the major bump.
 		return &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			RootCAs:    options.CaCerts,
+			RootCAs: options.CaCerts,
 		}
 	}
 


### PR DESCRIPTION
- `maligned` is now included in `govet`
- `golint` is dropped in favor of `revive`
- `scopelint` is dropped in favor of `exportloopref`
- `interfacer` is deprecated
- `//go:build go1.13` is new syntax in `1.17` - https://go.dev/doc/go1.17#go-command
- changing min. TLS to `1.2` as its `gosec` requirement
- the rest is stylistic