### PR TITLE
add: max-depth options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ coverage.txt
 FIXME.md
 TODO.md
 !NOTES.md
+
+# IDE system files
+.idea
+.vscode

--- a/client.go
+++ b/client.go
@@ -192,6 +192,14 @@ type ClientOptions struct {
 	HTTPSProxy string
 	// An optional set of SSL certificates to use.
 	CaCerts *x509.CertPool
+	// MaxErrorDepth is the maximum number of errors reported in a chain of errors.
+	// This protects the SDK from an arbitrarily long chain of wrapped errors.
+	//
+	// An additional consideration is that arguably reporting a long chain of errors
+	// is of little use when debugging production errors with Sentry. The Sentry UI
+	// is not optimized for long chains either. The top-level error together with a
+	// stack trace is often the most useful information.
+	MaxErrorDepth int
 }
 
 // Client is the underlying processor that is used by the main API and Hub
@@ -236,6 +244,10 @@ func NewClient(options ClientOptions) (*Client, error) {
 
 	if options.Environment == "" {
 		options.Environment = os.Getenv("SENTRY_ENVIRONMENT")
+	}
+
+	if options.MaxErrorDepth == 0 {
+		options.MaxErrorDepth = maxErrorDepth
 	}
 
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar
@@ -460,7 +472,7 @@ func (client *Client) eventFromException(exception error, level Level) *Event {
 	event := NewEvent()
 	event.Level = level
 
-	for i := 0; i < maxErrorDepth && err != nil; i++ {
+	for i := 0; i < client.options.MaxErrorDepth && err != nil; i++ {
 		event.Exception = append(event.Exception, Exception{
 			Value:      err.Error(),
 			Type:       reflect.TypeOf(err).String(),


### PR DESCRIPTION
<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? 
- create max error depth as a options because at my system has large errors wrapping stacktrace
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
