### PR TITLE
ci: Update golangci-lint-action to 1.45.2 for Go 1.18 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.2
+          version: v1.45.2
           only-new-issues: true
     timeout-minutes: 10


### PR DESCRIPTION
Required for PRs to be linted properly, eg. https://github.com/getsentry/sentry-go/runs/6095100285?check_suite_focus=true

ref https://github.com/golangci/golangci-lint/issues/2649