### PR TITLE
ci: Use go1.17 for lint/test until we officially support go1.18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       #       gopath-
       - uses: actions/setup-go@v2
         with:
-          go-version: "1"
+          go-version: "1.17"
       - name: Remove Unsupported Code
         run: |
           # Iris requires Module mode, therefore we delete the relevant code to


### PR DESCRIPTION
There are some changes required to support go1.18, and I want the CI to stay green until we make them.