### PR TITLE
ci: Test against go1.18, drop go1.15 support

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: '27 15 * * 2'
+    - cron: "27 15 * * 2"
 
 jobs:
   analyze:
@@ -17,16 +17,16 @@ jobs:
       security-events: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: go
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,13 +18,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17"
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.45
           only-new-issues: true
     timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: 'Release a new version'
+    name: "Release a new version"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,10 @@ jobs:
       GO111MODULE: "on"
       GOFLAGS: "-mod=readonly"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           # In order:
@@ -38,16 +41,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go }}-
             ${{ runner.os }}-go-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
       - name: Build
         run: go build ./...
       - name: Vet
         run: go vet ./...
       - name: Check go.mod Tidiness
-        run: go mod tidy -go=1.17 -compat=1.15 && git diff --exit-code
-        if: ${{ matrix.go == '1.17' }}
+        run: go mod tidy -go=1.18 -compat=1.16 && git diff --exit-code
+        if: ${{ matrix.go == '1.18' }}
       - name: Test
         run: go test -count=1 ./...
       - name: Test (race)
@@ -56,11 +56,11 @@ jobs:
         # pull requests, only run this step for a single job in the matrix. For
         # all other workflow triggers (e.g., pushes to a release branch) run
         # this step for the whole matrix.
-        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.17' && matrix.os == 'ubuntu') }}
+        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.18' && matrix.os == 'ubuntu') }}
     timeout-minutes: 10
     strategy:
       matrix:
-        go: ["1.17", "1.16", "1.15"]
+        go: ["1.18", "1.17", "1.16"]
         os: [ubuntu, windows, macos]
       fail-fast: false
   test-gopath:
@@ -77,7 +77,8 @@ jobs:
       run:
         working-directory: ${{ env.WORKDIR }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
       # TODO: cache dependencies
@@ -94,9 +95,6 @@ jobs:
       #     key: gopath-${{ github.ref }}
       #     restore-keys: |
       #       gopath-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17"
       - name: Remove Unsupported Code
         run: |
           # Iris requires Module mode, therefore we delete the relevant code to

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -205,7 +205,7 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform",
+			"Contexts", "EventID", "Extra", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
 		cmpopts.IgnoreMapEntries(func(k string, v string) bool {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gin-gonic/gin v1.7.7
@@ -14,6 +14,7 @@ require (
 	github.com/urfave/negroni v1.0.0
 	github.com/valyala/fasthttp v1.6.0
 	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac
+	golang.org/x/text v0.3.7
 )
 
 require (
@@ -65,7 +66,6 @@ require (
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211008194852-3b03d305991f // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/ini.v1 v1.51.1 // indirect

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -213,7 +213,7 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform",
+			"Contexts", "EventID", "Extra", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
 		cmpopts.IgnoreFields(

--- a/internal/ratelimit/category.go
+++ b/internal/ratelimit/category.go
@@ -1,6 +1,11 @@
 package ratelimit
 
-import "strings"
+import (
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
 
 // Reference:
 // https://github.com/getsentry/relay/blob/0424a2e017d193a93918053c90cdae9472d164bf/relay-common/src/constants.rs#L116-L127
@@ -31,11 +36,11 @@ func (c Category) String() string {
 	case "":
 		return "CategoryAll"
 	default:
-		var b strings.Builder
-		b.WriteString("Category")
+		caser := cases.Title(language.English)
+		rv := "Category"
 		for _, w := range strings.Fields(string(c)) {
-			b.WriteString(strings.Title(w))
+			rv += caser.String(w)
 		}
-		return b.String()
+		return rv
 	}
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -151,7 +151,7 @@ func TestStartSpan(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(Event{},
 			"Contexts", "EventID", "Level", "Platform",
-			"Release", "Sdk", "ServerName",
+			"Release", "Sdk", "ServerName", "Modules",
 		),
 		cmpopts.EquateEmpty(),
 	}
@@ -209,7 +209,7 @@ func TestStartChild(t *testing.T) {
 	}
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(Event{},
-			"EventID", "Level", "Platform",
+			"EventID", "Level", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp", "StartTime",
 		),
 		cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {


### PR DESCRIPTION
Swapped `strings.Title` for `cases.Caser`, as former is deprecated.
Other than that, minor CI/test updates, and no functional changes.

NOTE: This version drops support for Go 1.15, however no changes have been made that would make the SDK not work with Go 1.15. The currently supported Go versions are the last 3 stable releases: 1.16, 1.17 and 1.18.