### PR TITLE
feat: :sparkles: Added function to continue from trace string

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -545,9 +545,18 @@ func TransactionName(name string) SpanOption {
 // ContinueFromRequest returns a span option that updates the span to continue
 // an existing trace. If it cannot detect an existing trace in the request, the
 // span will be left unchanged.
+//
+// ContinueFromRequest is an alias for:
+// 	ContinueFromTrace(r.Header.Get("sentry-trace"))
 func ContinueFromRequest(r *http.Request) SpanOption {
+	return ContinueFromTrace(r.Header.Get("sentry-trace"))
+}
+
+// ContinueFromTrace returns a span option that updates the span to continue
+// an existing trace. If it cannot detect an existing trace in the request, the
+// span will be left unchanged.
+func ContinueFromTrace(trace string) SpanOption {
 	return func(s *Span) {
-		trace := r.Header.Get("sentry-trace")
 		if trace == "" {
 			return
 		}

--- a/tracing.go
+++ b/tracing.go
@@ -553,8 +553,7 @@ func ContinueFromRequest(r *http.Request) SpanOption {
 }
 
 // ContinueFromTrace returns a span option that updates the span to continue
-// an existing trace. If it cannot detect an existing trace in the request, the
-// span will be left unchanged.
+// an existing TraceID.
 func ContinueFromTrace(trace string) SpanOption {
 	return func(s *Span) {
 		if trace == "" {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -342,6 +342,32 @@ func TestContinueSpanFromRequest(t *testing.T) {
 		})
 	}
 }
+func TestContinueSpanFromTrace(t *testing.T) {
+	traceID := TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")
+	spanID := SpanIDFromHex("b72fa28504b07285")
+
+	for _, sampled := range []Sampled{SampledTrue, SampledFalse, SampledUndefined} {
+		sampled := sampled
+		t.Run(sampled.String(), func(t *testing.T) {
+			var s Span
+			trace := (&Span{
+				TraceID: traceID,
+				SpanID:  spanID,
+				Sampled: sampled,
+			}).ToSentryTrace()
+			ContinueFromTrace(trace)(&s)
+			if s.TraceID != traceID {
+				t.Errorf("got %q, want %q", s.TraceID, traceID)
+			}
+			if s.ParentSpanID != spanID {
+				t.Errorf("got %q, want %q", s.ParentSpanID, spanID)
+			}
+			if s.Sampled != sampled {
+				t.Errorf("got %q, want %q", s.Sampled, sampled)
+			}
+		})
+	}
+}
 
 func TestSpanFromContext(t *testing.T) {
 	// SpanFromContext always returns a non-nil value, such that you can use


### PR DESCRIPTION
**tl;dr: This allows users to easily add traces from sources other than http.Request**

Recently ran in to a situation where we want to add tracing between services where not all of them uses HTTP to communicate (in this case, rabbitMQ) so I refactored a bit and added a new exposed function that continues from a trace header.

This does not introduce any breaking changes from what I can see and the tests does of course still pass.
