### PR TITLE
Tweak readme, assume new users are using go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 [![go.dev](https://img.shields.io/badge/go.dev-pkg-007d9c.svg?style=flat)](https://pkg.go.dev/github.com/getsentry/sentry-go)
 
 `sentry-go` provides a Sentry client implementation for the Go programming
-language. This is the next line of the Go SDK for [Sentry](https://sentry.io/),
+language. This is the next generation of the Go SDK for [Sentry](https://sentry.io/),
 intended to replace the `raven-go` package.
 
 > Looking for the old `raven-go` SDK documentation? See the Legacy client section [here](https://docs.sentry.io/clients/go/).
-> If you want to start using sentry-go instead, check out the [migration guide](https://docs.sentry.io/platforms/go/migration/).
+> If you want to start using `sentry-go` instead, check out the [migration guide](https://docs.sentry.io/platforms/go/migration/).
 
 ## Requirements
 
@@ -37,14 +37,6 @@ though support for this configuration is best-effort.
 ## Installation
 
 `sentry-go` can be installed like any other Go library through `go get`:
-
-```console
-$ go get github.com/getsentry/sentry-go
-```
-
-Or, if you are already using
-[Go Modules](https://github.com/golang/go/wiki/Modules), you may specify a
-version number as well:
 
 ```console
 $ go get github.com/getsentry/sentry-go@latest


### PR DESCRIPTION
Anyone reading the readme is likely using go modules. 
Plus the last three versions of go are supported, which means `1.15` is the oldest supported version, so 99% of users on go 1.15 will be using go modules.

Also replaced the word `"line"` with `"generation"` because at first glance I was confused on how the next line in the file... took a moment to realize this is the next iteration or generation.
