### PR TITLE
ref: Use a Context type mapping to map[string]interface{}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref: Use a Context type mapping to a map[string]interface{} for all contexts
+
 ## v0.13.0
 
 - ref: Change DSN ProjectID to be a string (#420)

--- a/integrations.go
+++ b/integrations.go
@@ -72,18 +72,18 @@ func (ei *environmentIntegration) SetupOnce(client *Client) {
 func (ei *environmentIntegration) processor(event *Event, hint *EventHint) *Event {
 	// Initialize maps as necessary.
 	if event.Contexts == nil {
-		event.Contexts = make(map[string]interface{})
+		event.Contexts = make(map[string]Context)
 	}
 	for _, name := range []string{"device", "os", "runtime"} {
 		if event.Contexts[name] == nil {
-			event.Contexts[name] = make(map[string]interface{})
+			event.Contexts[name] = make(Context)
 		}
 	}
 
 	// Set contextual information preserving existing data. For each context, if
 	// the existing value is not of type map[string]interface{}, then no
 	// additional information is added.
-	if deviceContext, ok := event.Contexts["device"].(map[string]interface{}); ok {
+	if deviceContext, ok := event.Contexts["device"]; ok {
 		if _, ok := deviceContext["arch"]; !ok {
 			deviceContext["arch"] = runtime.GOARCH
 		}
@@ -91,12 +91,12 @@ func (ei *environmentIntegration) processor(event *Event, hint *EventHint) *Even
 			deviceContext["num_cpu"] = runtime.NumCPU()
 		}
 	}
-	if osContext, ok := event.Contexts["os"].(map[string]interface{}); ok {
+	if osContext, ok := event.Contexts["os"]; ok {
 		if _, ok := osContext["name"]; !ok {
 			osContext["name"] = runtime.GOOS
 		}
 	}
-	if runtimeContext, ok := event.Contexts["runtime"].(map[string]interface{}); ok {
+	if runtimeContext, ok := event.Contexts["runtime"]; ok {
 		if _, ok := runtimeContext["name"]; !ok {
 			runtimeContext["name"] = "go"
 		}

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -357,13 +357,13 @@ func TestEnvironmentIntegrationDoesNotOverrideExistingContexts(t *testing.T) {
 	}
 	scope := NewScope()
 
-	scope.contexts["device"] = map[string]interface{}{
+	scope.contexts["device"] = Context{
 		"foo": "bar",
 	}
-	scope.contexts["os"] = map[string]interface{}{
+	scope.contexts["os"] = Context{
 		"name": "test",
 	}
-	scope.contexts["custom"] = "value"
+	scope.contexts["custom"] = Context{"key": "value"}
 	hub := NewHub(client, scope)
 	hub.CaptureMessage("test event")
 
@@ -378,13 +378,13 @@ func TestEnvironmentIntegrationDoesNotOverrideExistingContexts(t *testing.T) {
 
 	contexts := events[0].Contexts
 
-	if contexts["device"].(map[string]interface{})["foo"] != "bar" {
+	if contexts["device"]["foo"] != "bar" {
 		t.Errorf(`contexts["device"] = %#v, want contexts["device"]["foo"] == "bar"`, contexts["device"])
 	}
-	if contexts["os"].(map[string]interface{})["name"] != "test" {
+	if contexts["os"]["name"] != "test" {
 		t.Errorf(`contexts["os"] = %#v, want contexts["os"]["name"] == "test"`, contexts["os"])
 	}
-	if contexts["custom"] != "value" {
-		t.Errorf(`contexts["custom"] = %#v, want "value"`, contexts["custom"])
+	if contexts["custom"]["key"] != "value" {
+		t.Errorf(`contexts["custom"]["key"] = %#v, want "value"`, contexts["custom"]["key"])
 	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -161,10 +161,12 @@ type Exception struct {
 // An EventID must be 32 characters long, lowercase and not have any dashes.
 type EventID string
 
+type Context map[string]interface{}
+
 // Event is the fundamental data structure that is sent to Sentry.
 type Event struct {
 	Breadcrumbs []*Breadcrumb          `json:"breadcrumbs,omitempty"`
-	Contexts    map[string]interface{} `json:"contexts,omitempty"`
+	Contexts    map[string]Context     `json:"contexts,omitempty"`
 	Dist        string                 `json:"dist,omitempty"`
 	Environment string                 `json:"environment,omitempty"`
 	EventID     EventID                `json:"event_id,omitempty"`
@@ -286,7 +288,7 @@ func (e *Event) transactionMarshalJSON() ([]byte, error) {
 // NewEvent creates a new Event.
 func NewEvent() *Event {
 	event := Event{
-		Contexts: make(map[string]interface{}),
+		Contexts: make(map[string]Context),
 		Extra:    make(map[string]interface{}),
 		Tags:     make(map[string]string),
 		Modules:  make(map[string]string),

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fatih/structs"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -126,8 +127,10 @@ func TestStructSnapshots(t *testing.T) {
 				Extra: map[string]interface{}{
 					"extra_key": "extra_val",
 				},
-				Contexts: map[string]interface{}{
-					"context_key": "context_val",
+				Contexts: map[string]Context{
+					"context_key": Context{
+						"context_key": "context_val",
+					},
 				},
 			},
 		},
@@ -138,14 +141,14 @@ func TestStructSnapshots(t *testing.T) {
 				Spans:     []*Span{testSpan},
 				StartTime: time.Unix(3, 0).UTC(),
 				Timestamp: time.Unix(5, 0).UTC(),
-				Contexts: map[string]interface{}{
-					"trace": &TraceContext{
+				Contexts: map[string]Context{
+					"trace": structs.Map(TraceContext{
 						TraceID:     TraceIDFromHex("90d57511038845dcb4164a70fc3a7fdb"),
 						SpanID:      SpanIDFromHex("f7f3fd754a9040eb"),
 						Op:          "http.GET",
 						Description: "description",
 						Status:      SpanStatusOK,
-					},
+					}),
 				},
 			},
 		},

--- a/scope.go
+++ b/scope.go
@@ -28,7 +28,7 @@ type Scope struct {
 	breadcrumbs []*Breadcrumb
 	user        User
 	tags        map[string]string
-	contexts    map[string]interface{}
+	contexts    map[string]Context
 	extra       map[string]interface{}
 	fingerprint []string
 	level       Level
@@ -51,7 +51,7 @@ func NewScope() *Scope {
 	scope := Scope{
 		breadcrumbs: make([]*Breadcrumb, 0),
 		tags:        make(map[string]string),
-		contexts:    make(map[string]interface{}),
+		contexts:    make(map[string]Context),
 		extra:       make(map[string]interface{}),
 		fingerprint: make([]string, 0),
 	}
@@ -209,7 +209,7 @@ func (scope *Scope) RemoveTag(key string) {
 }
 
 // SetContext adds a context to the current scope.
-func (scope *Scope) SetContext(key string, value interface{}) {
+func (scope *Scope) SetContext(key string, value Context) {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -217,7 +217,7 @@ func (scope *Scope) SetContext(key string, value interface{}) {
 }
 
 // SetContexts assigns multiple contexts to the current scope.
-func (scope *Scope) SetContexts(contexts map[string]interface{}) {
+func (scope *Scope) SetContexts(contexts map[string]Context) {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -358,7 +358,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 
 	if len(scope.contexts) > 0 {
 		if event.Contexts == nil {
-			event.Contexts = make(map[string]interface{})
+			event.Contexts = make(map[string]Context)
 		}
 
 		for key, value := range scope.contexts {

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -49,7 +49,7 @@ func TestConcurrentScopeUsage(t *testing.T) {
 
 func touchScope(scope *sentry.Scope, x int) {
 	scope.SetTag("foo", "bar")
-	scope.SetContext("foo", "bar")
+	scope.SetContext("foo", sentry.Context{"foo": "bar"})
 	scope.SetExtra("foo", "bar")
 	scope.SetLevel(sentry.LevelDebug)
 	scope.SetTransaction("foo")

--- a/testdata/error_event.golden
+++ b/testdata/error_event.golden
@@ -7,7 +7,9 @@
         }
     ],
     "contexts": {
-        "context_key": "context_val"
+        "context_key": {
+            "context_key": "context_val"
+        }
     },
     "environment": "production",
     "event_id": "0123456789abcdef",

--- a/testdata/transaction_event.golden
+++ b/testdata/transaction_event.golden
@@ -1,11 +1,11 @@
 {
     "contexts": {
         "trace": {
-            "trace_id": "90d57511038845dcb4164a70fc3a7fdb",
-            "span_id": "f7f3fd754a9040eb",
-            "op": "http.GET",
             "description": "description",
-            "status": "ok"
+            "op": "http.GET",
+            "span_id": "f7f3fd754a9040eb",
+            "status": "ok",
+            "trace_id": "90d57511038845dcb4164a70fc3a7fdb"
         }
     },
     "sdk": {},

--- a/tracing.go
+++ b/tracing.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/fatih/structs"
 )
 
 // A Span is the building block of a Sentry transaction. Spans build up a tree
@@ -148,7 +150,7 @@ func StartSpan(ctx context.Context, operation string, options ...SpanOption) *Sp
 
 	// Update scope so that all events include a trace context, allowing
 	// Sentry to correlate errors to transactions/spans.
-	hubFromContext(ctx).Scope().SetContext("trace", span.traceContext())
+	hubFromContext(ctx).Scope().SetContext("trace", structs.Map(span.traceContext()))
 
 	return &span
 }
@@ -329,8 +331,8 @@ func (s *Span) toEvent() *Event {
 	return &Event{
 		Type:        transactionType,
 		Transaction: hub.Scope().Transaction(),
-		Contexts: map[string]interface{}{
-			"trace": s.traceContext(),
+		Contexts: map[string]Context{
+			"trace": structs.Map(s.traceContext()),
 		},
 		Tags:      s.Tags,
 		Extra:     s.Data,
@@ -473,12 +475,12 @@ func (ss SpanStatus) MarshalJSON() ([]byte, error) {
 // A TraceContext carries information about an ongoing trace and is meant to be
 // stored in Event.Contexts (as *TraceContext).
 type TraceContext struct {
-	TraceID      TraceID    `json:"trace_id"`
-	SpanID       SpanID     `json:"span_id"`
-	ParentSpanID SpanID     `json:"parent_span_id"`
-	Op           string     `json:"op,omitempty"`
-	Description  string     `json:"description,omitempty"`
-	Status       SpanStatus `json:"status,omitempty"`
+	TraceID      TraceID    `json:"trace_id" structs:"trace_id"`
+	SpanID       SpanID     `json:"span_id" structs:"span_id"`
+	ParentSpanID SpanID     `json:"parent_span_id" structs:"parent_span_id,omitempty"`
+	Op           string     `json:"op,omitempty" structs:"op,omitempty"`
+	Description  string     `json:"description,omitempty" structs:"description,omitempty"`
+	Status       SpanStatus `json:"status,omitempty" structs:"status,omitempty"`
 }
 
 func (tc *TraceContext) MarshalJSON() ([]byte, error) {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fatih/structs"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -130,15 +131,15 @@ func TestStartSpan(t *testing.T) {
 	want := &Event{
 		Type:        transactionType,
 		Transaction: transaction,
-		Contexts: map[string]interface{}{
-			"trace": &TraceContext{
+		Contexts: map[string]Context{
+			"trace": structs.Map(TraceContext{
 				TraceID:      span.TraceID,
 				SpanID:       span.SpanID,
 				ParentSpanID: parentSpanID,
 				Op:           op,
 				Description:  description,
 				Status:       status,
-			},
+			}),
 		},
 		Tags: nil,
 		// TODO(tracing): the root span / transaction data field is
@@ -190,12 +191,12 @@ func TestStartChild(t *testing.T) {
 	want := &Event{
 		Type:        transactionType,
 		Transaction: "Test Transaction",
-		Contexts: map[string]interface{}{
-			"trace": &TraceContext{
+		Contexts: map[string]Context{
+			"trace": structs.Map(TraceContext{
 				TraceID: span.TraceID,
 				SpanID:  span.SpanID,
 				Op:      span.Op,
-			},
+			}),
 		},
 		Spans: []*Span{
 			{

--- a/transport_test.go
+++ b/transport_test.go
@@ -77,8 +77,8 @@ func TestGetRequestBodyFromEventInvalidExtraField(t *testing.T) {
 func TestGetRequestBodyFromEventInvalidContextField(t *testing.T) {
 	body := getRequestBodyFromEvent(&Event{
 		Message: "mkey",
-		Contexts: map[string]interface{}{
-			"wat": unserializableType{},
+		Contexts: map[string]Context{
+			"wat": Context{"key": unserializableType{}},
 		},
 	})
 
@@ -101,8 +101,8 @@ func TestGetRequestBodyFromEventMultipleInvalidFields(t *testing.T) {
 		Extra: map[string]interface{}{
 			"wat": unserializableType{},
 		},
-		Contexts: map[string]interface{}{
-			"wat": unserializableType{},
+		Contexts: map[string]Context{
+			"wat": Context{"key": unserializableType{}},
 		},
 	})
 


### PR DESCRIPTION
When Sentry processes an event, it only accepts a context being a key/value object. This PR aims to enforce we're passing a `map[string]interface{}` instead of an `interface{}`.