### PR TITLE
Add StripSpanContextKeyFromContext function

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -626,3 +626,12 @@ func spanFromContext(ctx context.Context) *Span {
 	}
 	return nil
 }
+
+// StripSpanContextKeyFromContext returns a new context with the parent span removed
+// but critically retaining the parentSpanID, allowing for new transactions
+// to be formed within the same running process while retaining all the current
+// context benefits, including existing sentry context keys (apart  from
+// `spanContextKey`) and timeouts etc.
+func StripSpanContextKeyFromContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, spanContextKey{}, nil)
+}


### PR DESCRIPTION
StripSpanContextKeyFromContext returns a new context with the parent span removed
but critically retaining the parentSpanID, allowing for new transactions
to be formed within the same running process while retaining all the current
context benefits, including existing sentry context keys (apart  from
`spanContextKey`) and timeouts etc.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
