### PR TITLE
Export `spanFromContext`

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -600,27 +600,9 @@ func TransactionFromContext(ctx context.Context) *Span {
 	return nil
 }
 
-// spanFromContext returns the last span stored in the context or a dummy
+// SpanFromContext returns the last span stored in the context or a dummy
 // non-nil span.
-//
-// TODO(tracing): consider exporting this. Without this, users cannot retrieve a
-// span from a context since spanContextKey is not exported.
-//
-// This can be added retroactively, and in the meantime think better whether it
-// should return nil (like GetHubFromContext), always non-nil (like
-// HubFromContext), or both: two exported functions.
-//
-// Note the equivalence:
-//
-// 	SpanFromContext(ctx).StartChild(...) === StartSpan(ctx, ...)
-//
-// So we don't aim spanFromContext at creating spans, but mutating existing
-// spans that you'd have no access otherwise (because it was created in code you
-// do not control, for example SDK auto-instrumentation).
-//
-// For now we provide TransactionFromContext, which solves the more common case
-// of setting tags, etc, on the current transaction.
-func spanFromContext(ctx context.Context) *Span {
+func SpanFromContext(ctx context.Context) *Span {
 	if span, ok := ctx.Value(spanContextKey{}).(*Span); ok {
 		return span
 	}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -259,7 +259,7 @@ func (c SpanCheck) Check(t *testing.T, span *Span) {
 		t.Errorf("original context value lost")
 	}
 	// Invariant: SpanFromContext(span.Context) == span
-	if spanFromContext(gotCtx) != span {
+	if SpanFromContext(gotCtx) != span {
 		t.Errorf("span not in its context")
 	}
 
@@ -377,7 +377,7 @@ func TestSpanFromContext(t *testing.T) {
 	// SpanFromContext(ctx).StartChild(...) === StartSpan(ctx, ...)
 
 	ctx := NewTestContext(ClientOptions{})
-	span := spanFromContext(ctx)
+	span := SpanFromContext(ctx)
 
 	_ = span
 


### PR DESCRIPTION
Matches the logic from `TransactionFromContext` and returns nil.
This is idiomatic and does what it says on the tin, if the context
does not have a span contained within it, I would not expect anything
to be returned. An error seems... extra.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
