### PR TITLE
Add StripSpanContextKeyFromContext

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -600,27 +600,9 @@ func TransactionFromContext(ctx context.Context) *Span {
 	return nil
 }
 
-// spanFromContext returns the last span stored in the context or a dummy
+// SpanFromContext returns the last span stored in the context or a dummy
 // non-nil span.
-//
-// TODO(tracing): consider exporting this. Without this, users cannot retrieve a
-// span from a context since spanContextKey is not exported.
-//
-// This can be added retroactively, and in the meantime think better whether it
-// should return nil (like GetHubFromContext), always non-nil (like
-// HubFromContext), or both: two exported functions.
-//
-// Note the equivalence:
-//
-// 	SpanFromContext(ctx).StartChild(...) === StartSpan(ctx, ...)
-//
-// So we don't aim spanFromContext at creating spans, but mutating existing
-// spans that you'd have no access otherwise (because it was created in code you
-// do not control, for example SDK auto-instrumentation).
-//
-// For now we provide TransactionFromContext, which solves the more common case
-// of setting tags, etc, on the current transaction.
-func spanFromContext(ctx context.Context) *Span {
+func SpanFromContext(ctx context.Context) *Span {
 	if span, ok := ctx.Value(spanContextKey{}).(*Span); ok {
 		return span
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -608,3 +608,12 @@ func SpanFromContext(ctx context.Context) *Span {
 	}
 	return nil
 }
+
+// StripSpanContextKeyFromContext returns a new context with the parent span removed
+// but critically retaining the parentSpanID, allowing for new transactions
+// to be formed within the same running process while retaining all the current
+// context benefits, including existing sentry context keys (apart  from
+// `spanContextKey`) and timeouts etc.
+func StripSpanContextKeyFromContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, spanContextKey{}, nil)
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -259,7 +259,7 @@ func (c SpanCheck) Check(t *testing.T, span *Span) {
 		t.Errorf("original context value lost")
 	}
 	// Invariant: SpanFromContext(span.Context) == span
-	if spanFromContext(gotCtx) != span {
+	if SpanFromContext(gotCtx) != span {
 		t.Errorf("span not in its context")
 	}
 
@@ -377,7 +377,7 @@ func TestSpanFromContext(t *testing.T) {
 	// SpanFromContext(ctx).StartChild(...) === StartSpan(ctx, ...)
 
 	ctx := NewTestContext(ClientOptions{})
-	span := spanFromContext(ctx)
+	span := SpanFromContext(ctx)
 
 	_ = span
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry-go/pull/452 for the `spanFromContext` change, I'm hoping that can be merged before this.

`SpanFromContext` will allow us to extract the spanid from a context, we can then strip the span from that context (yielding a new context), which can be then used to create a new span with a span option to populate the parentspanid (which remains unpopulated if a parent span doesn't exist).

Ultimately this allows us to construct new transactions in-process **and** keep the existing context chain.