### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -60,7 +59,7 @@ func (r *lockedRand) Float64() float64 {
 // other hand, the source returned from rand.NewSource is not safe for
 // concurrent use, so we need to couple its use with a sync.Mutex.
 var rng = &lockedRand{
-	//#nosec G404 -- We are fine using transparent, non-secure value here.
+	// #nosec G404 -- We are fine using transparent, non-secure value here.
 	r: rand.New(rand.NewSource(time.Now().UnixNano())),
 }
 
@@ -74,7 +73,7 @@ type usageError struct {
 
 // Logger is an instance of log.Logger that is use to provide debug information about running Sentry Client
 // can be enabled by either using Logger.SetOutput directly or with Debug client option.
-var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags)
+var Logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
 
 // EventProcessor is a function that processes an event.
 // Event processors are used to change an event before it is sent to Sentry.
@@ -388,7 +387,7 @@ func (client *Client) Recover(err interface{}, hint *EventHint, scope EventModif
 	// use the Context for communicating deadline nor cancelation. All it does
 	// is store the Context in the EventHint and there nil means the Context is
 	// not available.
-	//nolint: staticcheck
+	// nolint: staticcheck
 	return client.RecoverWithContext(nil, err, hint, scope)
 }
 

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -125,7 +125,7 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 	r.URL.RawQuery = string(ctx.URI().QueryString())
 
 	// Body
-	r.Body = ioutil.NopCloser(bytes.NewReader(ctx.Request.Body()))
+	r.Body = io.NopCloser(bytes.NewReader(ctx.Request.Body()))
 
 	return r
 }

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -2,7 +2,7 @@ package sentryhttp_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -52,7 +52,7 @@ func TestIntegration(t *testing.T) {
 			Body:   "payload",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Error(err)
 				}
@@ -102,7 +102,7 @@ func TestIntegration(t *testing.T) {
 			Body:   largePayload,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Error(err)
 				}

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -163,13 +163,13 @@ func TestStructSnapshots(t *testing.T) {
 
 			golden := filepath.Join(".", "testdata", fmt.Sprintf("%s.golden", test.testName))
 			if *update {
-				err := ioutil.WriteFile(golden, got, 0600)
+				err := os.WriteFile(golden, got, 0600)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			want, err := ioutil.ReadFile(golden)
+			want, err := os.ReadFile(golden)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -181,7 +180,7 @@ func WriteGoldenFile(t *testing.T, path string, bytes []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(path, bytes, 0666)
+	err = os.WriteFile(path, bytes, 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +188,7 @@ func WriteGoldenFile(t *testing.T, path string, bytes []byte) {
 
 func ReadOrGenerateGoldenFile(t *testing.T, path string, bytes []byte) string {
 	t.Helper()
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 		if *generate {

--- a/scope.go
+++ b/scope.go
@@ -146,7 +146,7 @@ const maxRequestBodyBytes = 10 * 1024
 
 // A limitedBuffer is like a bytes.Buffer, but limited to store at most Capacity
 // bytes. Any writes past the capacity are silently discarded, similar to
-// ioutil.Discard.
+// io.Discard.
 type limitedBuffer struct {
 	Capacity int
 

--- a/sourcereader.go
+++ b/sourcereader.go
@@ -2,7 +2,7 @@ package sentry
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"sync"
 )
 
@@ -24,7 +24,7 @@ func (sr *sourceReader) readContextLines(filename string, line, context int) ([]
 	lines, ok := sr.cache[filename]
 
 	if !ok {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			sr.cache[filename] = nil
 			return nil, 0

--- a/transport.go
+++ b/transport.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
@@ -53,7 +52,7 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 
 func getTLSConfig(options ClientOptions) *tls.Config {
 	if options.CaCerts != nil {
-		//#nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
+		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
 		// 				 but we don't want to break peoples code without the major bump.
 		return &tls.Config{
 			RootCAs: options.CaCerts,
@@ -401,7 +400,7 @@ func (t *HTTPTransport) worker() {
 			t.mu.Unlock()
 			// Drain body up to a limit and close it, allowing the
 			// transport to reuse TCP connections.
-			_, _ = io.CopyN(ioutil.Discard, response.Body, maxDrainResponseBytes)
+			_, _ = io.CopyN(io.Discard, response.Body, maxDrainResponseBytes)
 			response.Body.Close()
 		}
 
@@ -529,7 +528,7 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 
 	// Drain body up to a limit and close it, allowing the
 	// transport to reuse TCP connections.
-	_, _ = io.CopyN(ioutil.Discard, response.Body, maxDrainResponseBytes)
+	_, _ = io.CopyN(io.Discard, response.Body, maxDrainResponseBytes)
 	response.Body.Close()
 }
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -459,7 +459,7 @@ func testRateLimiting(t *testing.T, tr Transport) {
 
 	// Test server that simulates responses with rate limits.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.

