### PR TITLE
Optimize stacktrace from 7.36kB to 2.30kB and speed too

### DIFF
--- a/client.go
+++ b/client.go
@@ -338,6 +338,10 @@ func (client *Client) setupIntegrations() {
 		integration.SetupOnce(client)
 		Logger.Printf("Integration installed: %s\n", integration.Name())
 	}
+
+	sort.Slice(client.integrations, func(i, j int) bool {
+		return client.integrations[i].Name() < client.integrations[j].Name()
+	})
 }
 
 // AddEventProcessor adds an event processor to the client. It must not be
@@ -582,22 +586,22 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 	}
 
 	if event.ServerName == "" {
-		if client.Options().ServerName != "" {
-			event.ServerName = client.Options().ServerName
-		} else {
+		event.ServerName = client.Options().ServerName
+
+		if event.ServerName == "" {
 			event.ServerName = hostname
 		}
 	}
 
-	if event.Release == "" && client.Options().Release != "" {
+	if event.Release == "" {
 		event.Release = client.Options().Release
 	}
 
-	if event.Dist == "" && client.Options().Dist != "" {
+	if event.Dist == "" {
 		event.Dist = client.Options().Dist
 	}
 
-	if event.Environment == "" && client.Options().Environment != "" {
+	if event.Environment == "" {
 		event.Environment = client.Options().Environment
 	}
 
@@ -641,11 +645,10 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 }
 
 func (client Client) listIntegrations() []string {
-	integrations := make([]string, 0, len(client.integrations))
-	for _, integration := range client.integrations {
-		integrations = append(integrations, integration.Name())
+	integrations := make([]string, len(client.integrations))
+	for i, integration := range client.integrations {
+		integrations[i] = integration.Name()
 	}
-	sort.Strings(integrations)
 	return integrations
 }
 

--- a/scope.go
+++ b/scope.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"reflect"
 	"sync"
 	"time"
 )
@@ -339,10 +338,6 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 	defer scope.mu.RUnlock()
 
 	if len(scope.breadcrumbs) > 0 {
-		if event.Breadcrumbs == nil {
-			event.Breadcrumbs = []*Breadcrumb{}
-		}
-
 		event.Breadcrumbs = append(event.Breadcrumbs, scope.breadcrumbs...)
 	}
 
@@ -384,14 +379,13 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 		}
 	}
 
-	if (reflect.DeepEqual(event.User, User{})) {
+	var emptyUser User
+	if event.User == emptyUser {
 		event.User = scope.user
 	}
 
-	if (event.Fingerprint == nil || len(event.Fingerprint) == 0) &&
-		len(scope.fingerprint) > 0 {
-		event.Fingerprint = make([]string, len(scope.fingerprint))
-		copy(event.Fingerprint, scope.fingerprint)
+	if len(event.Fingerprint) == 0 {
+		event.Fingerprint = append(event.Fingerprint, scope.fingerprint...)
 	}
 
 	if scope.level != "" {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -245,7 +245,7 @@ func splitQualifiedFunctionName(name string) (pkg string, fun string) {
 }
 
 func extractFrames(pcs []uintptr) []Frame {
-	var frames []Frame
+	var frames = make([]Frame, 0, len(pcs))
 	callersFrames := runtime.CallersFrames(pcs)
 
 	for {
@@ -273,7 +273,8 @@ func filterFrames(frames []Frame) []Frame {
 		return nil
 	}
 
-	filteredFrames := make([]Frame, 0, len(frames))
+	// reuse
+	filteredFrames := frames[:0]
 
 	for _, frame := range frames {
 		// Skip Go internal frames.

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -251,13 +251,16 @@ func extractFrames(pcs []uintptr) []Frame {
 	for {
 		callerFrame, more := callersFrames.Next()
 
-		frames = append([]Frame{
-			NewFrame(callerFrame),
-		}, frames...)
+		frames = append(frames, NewFrame(callerFrame))
 
 		if !more {
 			break
 		}
+	}
+
+	// reverse
+	for i, j := 0, len(frames)-1; i < j; i, j = i+1, j-1 {
+		frames[i], frames[j] = frames[j], frames[i]
 	}
 
 	return frames

--- a/transport.go
+++ b/transport.go
@@ -556,14 +556,16 @@ func (t *HTTPSyncTransport) disabled(c ratelimit.Category) bool {
 // Only used internally when an empty DSN is provided, which effectively disables the SDK.
 type noopTransport struct{}
 
-func (t noopTransport) Configure(ClientOptions) {
+var _ Transport = noopTransport{}
+
+func (noopTransport) Configure(ClientOptions) {
 	Logger.Println("Sentry client initialized with an empty DSN. Using noopTransport. No events will be delivered.")
 }
 
-func (t noopTransport) SendEvent(*Event) {
+func (noopTransport) SendEvent(*Event) {
 	Logger.Println("Event dropped due to noopTransport usage.")
 }
 
-func (t noopTransport) Flush(time.Duration) bool {
+func (noopTransport) Flush(time.Duration) bool {
 	return true
 }

--- a/transport.go
+++ b/transport.go
@@ -556,14 +556,14 @@ func (t *HTTPSyncTransport) disabled(c ratelimit.Category) bool {
 // Only used internally when an empty DSN is provided, which effectively disables the SDK.
 type noopTransport struct{}
 
-func (t *noopTransport) Configure(options ClientOptions) {
+func (t noopTransport) Configure(ClientOptions) {
 	Logger.Println("Sentry client initialized with an empty DSN. Using noopTransport. No events will be delivered.")
 }
 
-func (t *noopTransport) SendEvent(event *Event) {
+func (t noopTransport) SendEvent(*Event) {
 	Logger.Println("Event dropped due to noopTransport usage.")
 }
 
-func (t *noopTransport) Flush(_ time.Duration) bool {
+func (t noopTransport) Flush(time.Duration) bool {
 	return true
 }


### PR DESCRIPTION
```bash
go test ./... -run=$^ -bench=Benchmark -benchmem -count=10 > old.txt
go test ./... -run=$^ -bench=Benchmark -benchmem -count=10 > new.txt
benchstat old.txt new.txt
```
```text
name              old time/op    new time/op    delta
ProcessEvent-12     1.50µs ±14%    1.56µs ±22%     ~     (p=0.684 n=10+10)
NewStacktrace-12    8.24µs ±25%    4.34µs ±14%  -47.30%  (p=0.000 n=10+10)

name              old alloc/op   new alloc/op   delta
ProcessEvent-12       946B ± 0%      939B ± 0%   -0.73%  (p=0.000 n=10+7)
NewStacktrace-12    7.36kB ± 0%    2.30kB ± 0%  -68.70%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
ProcessEvent-12       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
NewStacktrace-12      15.0 ± 0%       4.0 ± 0%  -73.33%  (p=0.000 n=10+10)
```