### PR TITLE
Add logrus support

### DIFF
--- a/example/logrus/main.go
+++ b/example/logrus/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/getsentry/sentry-go"
+	sentrylogrus "github.com/getsentry/sentry-go/logrus"
+)
+
+func main() {
+	logger := logrus.New()
+
+	// Log DEBUG and higher level logs to STDERR
+	logger.Level = logrus.DebugLevel
+	logger.Out = os.Stderr
+
+	// Send only ERROR and higher level logs to Sentry
+	sentryLevels := []logrus.Level{logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel}
+
+	sentryHook, err := sentrylogrus.New(sentryLevels, sentry.ClientOptions{
+		Dsn: "",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer sentryHook.Flush(5 * time.Second)
+	logger.AddHook(sentryHook)
+
+	// The following line is logged to STDERR, but not to Sentry
+	logger.Infof("Application has started")
+
+	// The following line is logged to STDERR and also sent to Sentry
+	logger.Errorf("oh no!")
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/pingcap/errors v0.11.4
 	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/negroni v1.0.0
 	github.com/valyala/fasthttp v1.40.0
 	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec
@@ -59,7 +60,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/schollz/closestmatch v2.1.0+incompatible // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/tdewolff/minify/v2 v2.12.4 // indirect
 	github.com/tdewolff/parse/v2 v2.6.4 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -1,0 +1,240 @@
+// Package logrusentry provides a simple Logrus hook for Sentry.
+package logrusentry
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	sentry "github.com/getsentry/sentry-go"
+	"github.com/sirupsen/logrus"
+)
+
+// These default log field keys are used to pass specific metadata in a way that
+// Sentry understands. If they are found in the log fields, and the value is of
+// the expected datatype, it will be converted from a generic field, into Sentry
+// metadata.
+//
+// These keys may be overridden by calling SetKey on the hook object.
+const (
+	// FieldRequest holds an *http.Request.
+	FieldRequest = "request"
+	// FieldUser holds a User or *User value.
+	FieldUser = "user"
+	// FieldTransaction holds a transaction ID as a string.
+	FieldTransaction = "transaction"
+	// FieldFingerprint holds a string slice ([]string), used to dictate the
+	// deduplication of this event
+	FieldFingerprint = "fingerprint"
+
+	// These fields are simply omitted, as they are duplicated by the Sentry SDK.
+	FieldGoVersion = "go_version"
+	FieldMaxProcs  = "go_maxprocs"
+)
+
+// ClientOptions is an alias for sentry.ClientOptions, and is all of the options
+// available for configuring the sentry SDK client.
+type ClientOptions = sentry.ClientOptions
+
+// User is an alias for sentry.User. Pass a this value with key FieldUser, and
+// it will be passed to Sentry appropriately.
+type User = sentry.User
+
+// Event is an alias for sentry.Event.
+type Event = sentry.Event
+
+// EventHint is an alias for sentry.EventHint
+type EventHint = sentry.EventHint
+
+// Hook is the logrus hook for Sentry.
+//
+// It is not safe to configure the hook while logging is happening. Please
+// perform all configuration before using it.
+type Hook struct {
+	client   *sentry.Client
+	scope    *sentry.Scope
+	hub      *sentry.Hub
+	fallback FallbackFunc
+	keys     map[string]string
+	levels   []logrus.Level
+}
+
+var _ logrus.Hook = &Hook{}
+
+// New initializes a new Sentry hook.
+func New(levels []logrus.Level, opts ClientOptions) (*Hook, error) {
+	client, err := sentry.NewClient(opts)
+	if err != nil {
+		return nil, err
+	}
+	h := &Hook{
+		levels: levels,
+		client: client,
+		scope:  sentry.NewScope(),
+		keys:   make(map[string]string),
+	}
+	h.setHub()
+	return h, nil
+}
+
+// setHub refreshes the hub, to be used any time client or scope changes.
+func (h *Hook) setHub() {
+	h.hub = sentry.NewHub(h.client, h.scope)
+}
+
+// AddTags adds tags to the hook's scope.
+func (h *Hook) AddTags(tags map[string]string) {
+	h.scope.SetTags(tags)
+	h.setHub()
+}
+
+// A FallbackFunc can be used to attempt to handle any errors in logging, before
+// resorting to Logrus's standard error reporting.
+type FallbackFunc func(*logrus.Entry) error
+
+// Fallback sets a fallback function, which will be called in case logging to
+// sentry fails. In case of a logging failure in the Fire() method, the
+// fallback function is called with the original logrus entry. If the
+// fallback function returns nil, the error is considered handled. If it returns
+// an error, that error is passed along to logrus as the return value from the
+// Fire() call. If no fallback function is defined, a default error message is
+// returned to Logrus in case of failure to send to Sentry.
+func (h *Hook) Fallback(fb FallbackFunc) {
+	h.fallback = fb
+}
+
+// SetKey sets an alternate field key. Use this if the default values conflict
+// with other loggers, for instance. You may pass "" for new, to unset an
+// existing alternate.
+func (h *Hook) SetKey(oldKey, newKey string) {
+	if oldKey == "" {
+		return
+	}
+	if newKey == "" {
+		delete(h.keys, oldKey)
+		return
+	}
+	delete(h.keys, newKey)
+	h.keys[oldKey] = newKey
+}
+
+func (h *Hook) key(key string) string {
+	if val := h.keys[key]; val != "" {
+		return val
+	}
+	return key
+}
+
+// Levels returns the list of logging levels that will be sent to
+// Sentry.
+func (h *Hook) Levels() []logrus.Level {
+	return h.levels
+}
+
+// Fire sends entry to Sentry.
+func (h *Hook) Fire(entry *logrus.Entry) error {
+	event := h.entry2event(entry)
+	if id := h.hub.CaptureEvent(event); id == nil {
+		if h.fallback != nil {
+			return h.fallback(entry)
+		}
+		return errors.New("failed to send to sentry")
+	}
+	return nil
+}
+
+var levelMap = map[logrus.Level]sentry.Level{
+	logrus.TraceLevel: sentry.LevelDebug,
+	logrus.DebugLevel: sentry.LevelDebug,
+	logrus.InfoLevel:  sentry.LevelInfo,
+	logrus.WarnLevel:  sentry.LevelWarning,
+	logrus.ErrorLevel: sentry.LevelError,
+	logrus.FatalLevel: sentry.LevelFatal,
+	logrus.PanicLevel: sentry.LevelFatal,
+}
+
+func (h *Hook) entry2event(l *logrus.Entry) *sentry.Event {
+	data := make(logrus.Fields, len(l.Data))
+	for k, v := range l.Data {
+		data[k] = v
+	}
+	s := &sentry.Event{
+		Level:     levelMap[l.Level],
+		Extra:     data,
+		Message:   l.Message,
+		Timestamp: l.Time,
+	}
+	key := h.key(FieldRequest)
+	if req, ok := s.Extra[key].(*http.Request); ok {
+		delete(s.Extra, key)
+		s.Request = sentry.NewRequest(req)
+	}
+	if err, ok := s.Extra[logrus.ErrorKey].(error); ok {
+		delete(s.Extra, logrus.ErrorKey)
+		ex := h.exceptions(err)
+		s.Exception = ex
+	}
+	key = h.key(FieldUser)
+	if user, ok := s.Extra[key].(User); ok {
+		delete(s.Extra, key)
+		s.User = user
+	}
+	if user, ok := s.Extra[key].(*User); ok {
+		delete(s.Extra, key)
+		s.User = *user
+	}
+	key = h.key(FieldTransaction)
+	if txn, ok := s.Extra[key].(string); ok {
+		delete(s.Extra, key)
+		s.Transaction = txn
+	}
+	key = h.key(FieldFingerprint)
+	if fp, ok := s.Extra[key].([]string); ok {
+		delete(s.Extra, key)
+		s.Fingerprint = fp
+	}
+	delete(s.Extra, FieldGoVersion)
+	delete(s.Extra, FieldMaxProcs)
+	return s
+}
+
+func (h *Hook) exceptions(err error) []sentry.Exception {
+	if !h.hub.Client().Options().AttachStacktrace {
+		return []sentry.Exception{{
+			Type:  "error",
+			Value: err.Error(),
+		}}
+	}
+	excs := []sentry.Exception{}
+	var last *sentry.Exception
+	for ; err != nil; err = errors.Unwrap(err) {
+		exc := sentry.Exception{
+			Type:       "error",
+			Value:      err.Error(),
+			Stacktrace: sentry.ExtractStacktrace(err),
+		}
+		if last != nil && exc.Value == last.Value {
+			if last.Stacktrace == nil {
+				last.Stacktrace = exc.Stacktrace
+				continue
+			}
+			if exc.Stacktrace == nil {
+				continue
+			}
+		}
+		excs = append(excs, exc)
+		last = &excs[len(excs)-1]
+	}
+	// reverse
+	for i, j := 0, len(excs)-1; i < j; i, j = i+1, j-1 {
+		excs[i], excs[j] = excs[j], excs[i]
+	}
+	return excs
+}
+
+// Flush waits until the underlying Sentry transport sends any buffered events,
+// blocking for at most the given timeout. It returns false if the timeout was
+// reached, in which case some events may not have been sent.
+func (h *Hook) Flush(timeout time.Duration) bool {
+	return h.client.Flush(timeout)
+}

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -24,7 +24,7 @@ const (
 	// FieldTransaction holds a transaction ID as a string.
 	FieldTransaction = "transaction"
 	// FieldFingerprint holds a string slice ([]string), used to dictate the
-	// deduplication of this event
+	// deduplication of this event.
 	FieldFingerprint = "fingerprint"
 
 	// These fields are simply omitted, as they are duplicated by the Sentry SDK.
@@ -43,7 +43,7 @@ type User = sentry.User
 // Event is an alias for sentry.Event.
 type Event = sentry.Event
 
-// EventHint is an alias for sentry.EventHint
+// EventHint is an alias for sentry.EventHint.
 type EventHint = sentry.EventHint
 
 // Hook is the logrus hook for Sentry.

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -24,7 +24,7 @@ const (
 	// FieldTransaction holds a transaction ID as a string.
 	FieldTransaction = "transaction"
 	// FieldFingerprint holds a string slice ([]string), used to dictate the
-	// deduplication of this event.
+	// grouping of this event.
 	FieldFingerprint = "fingerprint"
 
 	// These fields are simply omitted, as they are duplicated by the Sentry SDK.

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -85,14 +85,14 @@ func (h *Hook) AddTags(tags map[string]string) {
 // resorting to Logrus's standard error reporting.
 type FallbackFunc func(*logrus.Entry) error
 
-// Fallback sets a fallback function, which will be called in case logging to
+// SetFallback sets a fallback function, which will be called in case logging to
 // sentry fails. In case of a logging failure in the Fire() method, the
 // fallback function is called with the original logrus entry. If the
 // fallback function returns nil, the error is considered handled. If it returns
 // an error, that error is passed along to logrus as the return value from the
 // Fire() call. If no fallback function is defined, a default error message is
 // returned to Logrus in case of failure to send to Sentry.
-func (h *Hook) Fallback(fb FallbackFunc) {
+func (h *Hook) SetFallback(fb FallbackFunc) {
 	h.fallback = fb
 }
 

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -1,5 +1,5 @@
-// Package logrusentry provides a simple Logrus hook for Sentry.
-package logrusentry
+// Package sentrylogrus provides a simple Logrus hook for Sentry.
+package sentrylogrus
 
 import (
 	"errors"

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -126,7 +126,7 @@ func (h *Hook) Levels() []logrus.Level {
 
 // Fire sends entry to Sentry.
 func (h *Hook) Fire(entry *logrus.Entry) error {
-	event := h.entry2event(entry)
+	event := h.entryToEvent(entry)
 	if id := h.hub.CaptureEvent(event); id == nil {
 		if h.fallback != nil {
 			return h.fallback(entry)
@@ -146,7 +146,7 @@ var levelMap = map[logrus.Level]sentry.Level{
 	logrus.PanicLevel: sentry.LevelFatal,
 }
 
-func (h *Hook) entry2event(l *logrus.Entry) *sentry.Event {
+func (h *Hook) entryToEvent(l *logrus.Entry) *sentry.Event {
 	data := make(logrus.Fields, len(l.Data))
 	for k, v := range l.Data {
 		data[k] = v

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -47,12 +47,19 @@ type Hook struct {
 
 var _ logrus.Hook = &Hook{}
 
-// New initializes a new Sentry hook.
+// New initializes a new Logrus hook which sends logs to a new Sentry client
+// configured according to opts.
 func New(levels []logrus.Level, opts sentry.ClientOptions) (*Hook, error) {
 	client, err := sentry.NewClient(opts)
 	if err != nil {
 		return nil, err
 	}
+	return NewFromClient(levels, client), nil
+}
+
+// NewFromClient initializes a new Logrus hook which sends logs to the provided
+// sentry client.
+func NewFromClient(levels []logrus.Level, client *sentry.Client) *Hook {
 	h := &Hook{
 		levels: levels,
 		client: client,
@@ -60,7 +67,7 @@ func New(levels []logrus.Level, opts sentry.ClientOptions) (*Hook, error) {
 		keys:   make(map[string]string),
 	}
 	h.setHub()
-	return h, nil
+	return h
 }
 
 // setHub refreshes the hub, to be used any time client or scope changes.

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -32,20 +32,6 @@ const (
 	FieldMaxProcs  = "go_maxprocs"
 )
 
-// ClientOptions is an alias for sentry.ClientOptions, and is all of the options
-// available for configuring the sentry SDK client.
-type ClientOptions = sentry.ClientOptions
-
-// User is an alias for sentry.User. Pass a this value with key FieldUser, and
-// it will be passed to Sentry appropriately.
-type User = sentry.User
-
-// Event is an alias for sentry.Event.
-type Event = sentry.Event
-
-// EventHint is an alias for sentry.EventHint.
-type EventHint = sentry.EventHint
-
 // Hook is the logrus hook for Sentry.
 //
 // It is not safe to configure the hook while logging is happening. Please
@@ -62,7 +48,7 @@ type Hook struct {
 var _ logrus.Hook = &Hook{}
 
 // New initializes a new Sentry hook.
-func New(levels []logrus.Level, opts ClientOptions) (*Hook, error) {
+func New(levels []logrus.Level, opts sentry.ClientOptions) (*Hook, error) {
 	client, err := sentry.NewClient(opts)
 	if err != nil {
 		return nil, err
@@ -175,11 +161,11 @@ func (h *Hook) entry2event(l *logrus.Entry) *sentry.Event {
 		s.Exception = ex
 	}
 	key = h.key(FieldUser)
-	if user, ok := s.Extra[key].(User); ok {
+	if user, ok := s.Extra[key].(sentry.User); ok {
 		delete(s.Extra, key)
 		s.User = user
 	}
-	if user, ok := s.Extra[key].(*User); ok {
+	if user, ok := s.Extra[key].(*sentry.User); ok {
 		delete(s.Extra, key)
 		s.User = *user
 	}

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if id := h.client.CaptureEvent(&sentry.Event{}, nil, nil); id == nil {
+		if id := h.hub.CaptureEvent(&sentry.Event{}); id == nil {
 			t.Error("CaptureEvent failed")
 		}
 		if !h.Flush(5 * time.Second) {

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -1,4 +1,4 @@
-package logrusentry
+package sentrylogrus
 
 import (
 	"encoding/json"

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -399,7 +399,7 @@ func Test_entry2event(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := h.entry2event(tt.entry)
+			got := h.entryToEvent(tt.entry)
 			if d := cmp.Diff(tt.want, got); d != "" {
 				t.Error(d)
 			}

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -1,0 +1,356 @@
+package logrusentry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	pkgerr "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	aleerr "gitlab.com/flimzy/ale/errors"
+	"gitlab.com/flimzy/testy"
+)
+
+const testDSN = "http://test:test@localhost/1234"
+
+func xport(req *http.Request) http.RoundTripper {
+	return testy.HTTPResponder(func(r *http.Request) (*http.Response, error) {
+		*req = *r
+		return &http.Response{}, nil
+	})
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid DSN", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(nil, ClientOptions{Dsn: "%xxx"})
+		testy.Error(t, `[Sentry] DsnParseError: invalid url: parse "%xxx": invalid URL escape "%xx"`, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		req := new(http.Request)
+		h, err := New(nil, ClientOptions{
+			Dsn:           testDSN,
+			HTTPTransport: xport(req),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id := h.client.CaptureEvent(&sentry.Event{}, nil, nil); id == nil {
+			t.Error("CaptureEvent failed")
+		}
+		if !h.Flush(5 * time.Second) {
+			t.Error("flush failed")
+		}
+		testEvent(t, req.Body)
+	})
+}
+
+func TestFire(t *testing.T) {
+	t.Parallel()
+	type tt struct {
+		opts   ClientOptions
+		levels []logrus.Level
+		entry  *logrus.Entry
+		err    string
+	}
+
+	tests := testy.NewTable()
+	tests.Add("error", tt{
+		levels: []logrus.Level{logrus.ErrorLevel},
+		entry: &logrus.Entry{
+			Level: logrus.ErrorLevel,
+		},
+	})
+
+	tests.Run(t, func(t *testing.T, tt tt) {
+		t.Parallel()
+		req := new(http.Request)
+		opts := tt.opts
+		opts.Dsn = testDSN
+		opts.HTTPTransport = xport(req)
+		hook, err := New(tt.levels, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = hook.Fire(tt.entry)
+		testy.Error(t, tt.err, err)
+
+		if !hook.Flush(5 * time.Second) {
+			t.Error("flush failed")
+		}
+		testEvent(t, req.Body)
+	})
+}
+
+func Test_e2e(t *testing.T) {
+	t.Parallel()
+	type tt struct {
+		levels  []logrus.Level
+		opts    ClientOptions
+		init    func(*Hook)
+		log     func(*logrus.Logger)
+		skipped bool
+	}
+
+	tests := testy.NewTable()
+	tests.Add("skip info", tt{
+		levels: []logrus.Level{logrus.ErrorLevel},
+		log: func(l *logrus.Logger) {
+			l.Info("foo")
+		},
+		skipped: true,
+	})
+	tests.Add("error level", tt{
+		levels: []logrus.Level{logrus.ErrorLevel},
+		log: func(l *logrus.Logger) {
+			l.Error("foo")
+		},
+	})
+	tests.Add("metadata", tt{
+		levels: []logrus.Level{logrus.ErrorLevel},
+		opts: ClientOptions{
+			Environment: "production",
+			ServerName:  "localhost",
+			Release:     "v1.2.3",
+			Dist:        "beta",
+		},
+		log: func(l *logrus.Logger) {
+			l.Error("foo")
+		},
+	})
+	tests.Add("tags", tt{
+		levels: []logrus.Level{logrus.ErrorLevel},
+		opts: ClientOptions{
+			AttachStacktrace: true,
+		},
+		init: func(h *Hook) {
+			h.AddTags(map[string]string{
+				"foo": "bar",
+			})
+		},
+		log: func(l *logrus.Logger) {
+			l.Error("foo")
+		},
+	})
+
+	tests.Run(t, func(t *testing.T, tt tt) {
+		t.Parallel()
+		req := new(http.Request)
+		l := logrus.New()
+		opts := tt.opts
+		opts.Dsn = testDSN
+		opts.HTTPTransport = xport(req)
+		hook, err := New(tt.levels, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if init := tt.init; init != nil {
+			init(hook)
+		}
+		l.SetOutput(ioutil.Discard)
+		l.AddHook(hook)
+		tt.log(l)
+
+		if !hook.Flush(5 * time.Second) {
+			t.Fatal("failed to flush")
+		}
+		if tt.skipped {
+			if req.Method != "" {
+				t.Error("Got an unexpected request")
+			}
+			return
+		}
+		testEvent(t, req.Body)
+	})
+}
+
+func testEvent(t *testing.T, r io.ReadCloser) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = r.Close()
+	})
+	var event map[string]interface{}
+	if err := json.NewDecoder(r).Decode(&event); err != nil {
+		t.Fatal(err)
+	}
+	// normalize fields
+	event["timestamp"] = "xxx"
+	event["event_id"] = "yyy"
+	event["contexts"] = "zzz"
+	event["server_name"] = "server"
+	if d := testy.DiffAsJSON(testy.Snapshot(t), event); d != nil {
+		t.Error(d)
+	}
+}
+
+func Test_entry2event(t *testing.T) {
+	t.Parallel()
+	tests := testy.NewTable()
+	tests.Add("empty event", &logrus.Entry{})
+	tests.Add("data fields", &logrus.Entry{
+		Data: map[string]interface{}{
+			"foo": 123.4,
+			"bar": "oink",
+		},
+	})
+	tests.Add("info level", &logrus.Entry{
+		Level: logrus.InfoLevel,
+	})
+	tests.Add("message", &logrus.Entry{
+		Message: "the only thing we have to fear is fear itself",
+	})
+	tests.Add("timestamp", &logrus.Entry{
+		Time: time.Unix(1, 2).UTC(),
+	})
+	tests.Add("http request", &logrus.Entry{
+		Data: map[string]interface{}{
+			FieldRequest: httptest.NewRequest("GET", "/", nil),
+		},
+	})
+	tests.Add("non-http request", &logrus.Entry{
+		Data: map[string]interface{}{
+			FieldRequest: "some other request type",
+		},
+	})
+	tests.Add("error", &logrus.Entry{
+		Data: map[string]interface{}{
+			logrus.ErrorKey: errors.New("things failed"),
+		},
+	})
+	tests.Add("non-error", &logrus.Entry{
+		Data: map[string]interface{}{
+			logrus.ErrorKey: "this isn't really an error",
+		},
+	})
+	tests.Add("stack trace error", &logrus.Entry{
+		Data: map[string]interface{}{
+			logrus.ErrorKey: pkgerr.WithStack(errors.New("failure")),
+		},
+	})
+	tests.Add("user", &logrus.Entry{
+		Data: map[string]interface{}{
+			FieldUser: User{
+				ID: "bob",
+			},
+		},
+	})
+	tests.Add("user pointer", &logrus.Entry{
+		Data: map[string]interface{}{
+			FieldUser: &User{
+				ID: "alice",
+			},
+		},
+	})
+	tests.Add("non-user", &logrus.Entry{
+		Data: map[string]interface{}{
+			FieldUser: "just say no to drugs",
+		},
+	})
+
+	res := []testy.Replacement{
+		{
+			Regexp:      regexp.MustCompile(`\(len=\d+\) "[^"]+/backend/log/`),
+			Replacement: `(len=XX) ".../backend/log/`,
+		},
+	}
+
+	h, err := New(nil, ClientOptions{
+		Dsn:              testDSN,
+		AttachStacktrace: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests.Run(t, func(t *testing.T, tt *logrus.Entry) {
+		t.Parallel()
+		got := h.entry2event(tt)
+		if d := testy.DiffInterface(testy.Snapshot(t), got, res...); d != nil {
+			t.Error(d)
+		}
+	})
+}
+
+func Test_exceptions(t *testing.T) {
+	t.Parallel()
+	type tt struct {
+		trace bool
+		err   error
+	}
+
+	tests := testy.NewTable()
+	tests.Add("std error", tt{
+		trace: true,
+		err:   errors.New("foo"),
+	})
+	tests.Add("wrapped, no stack", tt{
+		trace: true,
+		err:   fmt.Errorf("foo: %w", errors.New("bar")),
+	})
+	tests.Add("ignored stack", tt{
+		trace: false,
+		err:   pkgerr.New("foo"),
+	})
+	tests.Add("stack", tt{
+		trace: true,
+		err:   pkgerr.New("foo"),
+	})
+	tests.Add("emulate middleware", func() interface{} {
+		err := errors.New("original")
+		err = fmt.Errorf("fmt: %w", err)
+		err = pkgerr.Wrap(err, "wrap")
+		err = pkgerr.WithStack(err)
+		err = aleerr.NewNotes().NoStack().Fields(aleerr.Fields{
+			"field": "value",
+		}).Wrap(err)
+		return tt{
+			trace: true,
+			err:   err,
+		}
+	})
+	tests.Add("failing", func() interface{} {
+		err := errors.New("converting NULL to string is unsupported")
+		err = fmt.Errorf("sql: Scan error on column index 7, name \"email\": %w", err)
+		err = pkgerr.WithStack(err)
+		err = aleerr.NewNotes().NoStack().Fields(aleerr.Fields{
+			"field": "value",
+		}).Wrap(err)
+		return tt{
+			trace: true,
+			err:   err,
+		}
+	})
+
+	tests.Run(t, func(t *testing.T, tt tt) {
+		t.Parallel()
+		h, err := New(nil, ClientOptions{AttachStacktrace: tt.trace})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := h.exceptions(tt.err)
+		res := []testy.Replacement{
+			{
+				Regexp:      regexp.MustCompile(`AbsPath: \(string\) \(len=\d+\) ".*/backend/log`),
+				Replacement: `AbsPath: (string) (len=XX) ".../backend/log`,
+			},
+			{
+				Regexp:      regexp.MustCompile(`AbsPath: \(string\) \(len=\d+\) ".*/go/pkg/mod`),
+				Replacement: `AbsPath: (string) (len=XX) ".../go/pkg/mod`,
+			},
+		}
+		if d := testy.DiffInterface(testy.Snapshot(t), got, res...); d != nil {
+			t.Error(d)
+		}
+	})
+}

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 	t.Run("invalid DSN", func(t *testing.T) {
 		t.Parallel()
-		_, err := New(nil, ClientOptions{Dsn: "%xxx"})
+		_, err := New(nil, sentry.ClientOptions{Dsn: "%xxx"})
 		if err == nil || !strings.Contains(err.Error(), "invalid URL escape") {
 			t.Errorf("Unexpected error: %s", err)
 		}
@@ -46,7 +46,7 @@ func TestNew(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		req := new(http.Request)
-		h, err := New(nil, ClientOptions{
+		h, err := New(nil, sentry.ClientOptions{
 			Dsn:           testDSN,
 			HTTPTransport: xport(req),
 		})
@@ -73,7 +73,7 @@ func TestFire(t *testing.T) {
 	}
 
 	req := new(http.Request)
-	opts := ClientOptions{}
+	opts := sentry.ClientOptions{}
 	opts.Dsn = testDSN
 	opts.HTTPTransport = xport(req)
 	hook, err := New([]logrus.Level{logrus.ErrorLevel}, opts)
@@ -98,7 +98,7 @@ func Test_e2e(t *testing.T) {
 	tests := []struct {
 		name    string
 		levels  []logrus.Level
-		opts    ClientOptions
+		opts    sentry.ClientOptions
 		init    func(*Hook)
 		log     func(*logrus.Logger)
 		skipped bool
@@ -126,7 +126,7 @@ func Test_e2e(t *testing.T) {
 		{
 			name:   "metadata",
 			levels: []logrus.Level{logrus.ErrorLevel},
-			opts: ClientOptions{
+			opts: sentry.ClientOptions{
 				Environment: "production",
 				ServerName:  "localhost",
 				Release:     "v1.2.3",
@@ -145,7 +145,7 @@ func Test_e2e(t *testing.T) {
 		{
 			name:   "tags",
 			levels: []logrus.Level{logrus.ErrorLevel},
-			opts: ClientOptions{
+			opts: sentry.ClientOptions{
 				AttachStacktrace: true,
 			},
 			init: func(h *Hook) {
@@ -341,7 +341,7 @@ func Test_entry2event(t *testing.T) {
 			name: "user",
 			entry: &logrus.Entry{
 				Data: map[string]interface{}{
-					FieldUser: User{
+					FieldUser: sentry.User{
 						ID: "bob",
 					},
 				},
@@ -358,7 +358,7 @@ func Test_entry2event(t *testing.T) {
 			name: "user pointer",
 			entry: &logrus.Entry{
 				Data: map[string]interface{}{
-					FieldUser: &User{
+					FieldUser: &sentry.User{
 						ID: "alice",
 					},
 				},
@@ -387,7 +387,7 @@ func Test_entry2event(t *testing.T) {
 		},
 	}
 
-	h, err := New(nil, ClientOptions{
+	h, err := New(nil, sentry.ClientOptions{
 		Dsn:              testDSN,
 		AttachStacktrace: true,
 	})
@@ -472,7 +472,7 @@ func Test_exceptions(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			h, err := New(nil, ClientOptions{AttachStacktrace: tt.trace})
+			h, err := New(nil, sentry.ClientOptions{AttachStacktrace: tt.trace})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -289,7 +289,6 @@ func Test_entry2event(t *testing.T) {
 					URL:     "http://example.com/",
 					Method:  http.MethodGet,
 					Headers: map[string]string{"Host": "example.com"},
-					Env:     map[string]string{"REMOTE_ADDR": "192.0.2.1", "REMOTE_PORT": "1234"},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adapts my free-standing logrus hook (https://gitlab.com/flimzy/logrusentry) for inclusion in this repo. Closes #43 

There's a good chance this hook doesn't take advantage of all available/relevant Sentry features.  But it's been serving me well for several years now, at at least three different companies.  Please advise if there are any functional or stylistic changes that are desired. I'm happy to do what I can to get this included in this repo.