### PR TITLE
feat: Add a method to start a transaction

### DIFF
--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -86,15 +86,19 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 			hub = sentry.CurrentHub().Clone()
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
-		span := sentry.StartSpan(ctx, "http.server",
-			sentry.TransactionName(fmt.Sprintf("%s %s", r.Method, r.URL.Path)),
+		options := []sentry.SpanOption{
+			sentry.OpName("http.server"),
 			sentry.ContinueFromRequest(r),
+		}
+		transaction := sentry.StartTransaction(ctx,
+			fmt.Sprintf("%s %s", r.Method, r.URL.Path),
+			options...,
 		)
-		defer span.Finish()
+		defer transaction.Finish()
 		// TODO(tracing): if the next handler.ServeHTTP panics, store
 		// information on the transaction accordingly (status, tag,
 		// level?, ...).
-		r = r.WithContext(span.Context())
+		r = r.WithContext(transaction.Context())
 		hub.Scope().SetRequest(r)
 		defer h.recoverWithSentry(hub, r)
 		// TODO(tracing): use custom response writer to intercept


### PR DESCRIPTION
In the quest of having a similar API as the other SDKs, we wanted to add a `StartTransaction` function to start a transaction.

Since the Go SDK makes everything a span and the root span becomes the transaction, we don't need more than a function that calls `StartSpan` in order to make something compatible with a big difference being `TransactionName` is now required instead of `Op` and `Op` can be set as an option.

You might notice I chose to `panic` if there's already a transaction in progress in the context. I'm not 100% sure how other SDKs are handling this case. We could choose to return the current transaction, stop the current transaction and start a new one instead of a `panic`. This will still means several transactions can happen at the same time, just with different contexts.