### PR TITLE
ref: Rename ClientOptions.SendDefaultPii to ClientOptions.SendDefaultPII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - fix: Scope values should not override Event values (#446)
 - feat: Extend User inteface by adding Data, Name and Segment (#483)
 - feat: Make maximum amount of spans configurable (#460)
-- feat: Add ClientOptions.SendDefaultPii #485
+- feat: Add ClientOptions.SendDefaultPII (#485)
 
 ## 0.14.0
 

--- a/client.go
+++ b/client.go
@@ -136,7 +136,7 @@ type ClientOptions struct {
 	IgnoreErrors []string
 	// If this flag is enabled, certain personally identifiable information (PII) is added by active integrations.
 	// By default, no such data is sent.
-	SendDefaultPii bool
+	SendDefaultPII bool
 	// BeforeSend is called before error events are sent to Sentry.
 	// Use it to mutate the event or return nil to discard the event.
 	// See EventProcessor if you need to mutate transactions.

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -142,7 +142,7 @@ func TestIntegration(t *testing.T) {
 
 	eventsCh := make(chan *sentry.Event, len(tests))
 	err := sentry.Init(sentry.ClientOptions{
-		SendDefaultPii: true,
+		SendDefaultPII: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -156,7 +156,7 @@ func TestIntegration(t *testing.T) {
 
 	eventsCh := make(chan *sentry.Event, len(tests))
 	err := sentry.Init(sentry.ClientOptions{
-		SendDefaultPii: true,
+		SendDefaultPII: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event

--- a/interfaces.go
+++ b/interfaces.go
@@ -170,7 +170,7 @@ func NewRequest(r *http.Request) *Request {
 	headers := map[string]string{}
 
 	if client := CurrentHub().Client(); client != nil {
-		if client.Options().SendDefaultPii {
+		if client.Options().SendDefaultPII {
 			// We read only the first Cookie header because of the specification:
 			// https://tools.ietf.org/html/rfc6265#section-5.4
 			// When the user agent generates an HTTP request, the user agent MUST NOT

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -68,7 +68,7 @@ func TestUserMarshalJson(t *testing.T) {
 func TestNewRequest(t *testing.T) {
 	currentHub.BindClient(&Client{
 		options: ClientOptions{
-			SendDefaultPii: true,
+			SendDefaultPII: true,
 		},
 	})
 	// Unbind the client afterwards, to not affect other tests
@@ -105,7 +105,7 @@ func TestNewRequest(t *testing.T) {
 	}
 }
 
-func TestNewRequestWithNoPii(t *testing.T) {
+func TestNewRequestWithNoPII(t *testing.T) {
 	const payload = `{"test_data": true}`
 	r := httptest.NewRequest("POST", "/test/?q=sentry", strings.NewReader(payload))
 	r.Header.Add("Authorization", "Bearer 1234567890")


### PR DESCRIPTION
re: https://github.com/getsentry/sentry-go/pull/485#discussion_r1011500255