### PR TITLE
Added doc on how to handle logrus.Fatalf events

### DIFF
--- a/example/logrus/main.go
+++ b/example/logrus/main.go
@@ -43,9 +43,16 @@ func main() {
 	defer sentryHook.Flush(5 * time.Second)
 	logger.AddHook(sentryHook)
 
+	// Flushes before calling os.Exit(1) when using logger.Fatal
+	// (else all defers are not called, and Sentry does not have time to send the event)
+	logrus.RegisterExitHandler(func() { sentryHook.Flush(5 * time.Second) })
+
 	// The following line is logged to STDERR, but not to Sentry
 	logger.Infof("Application has started")
 
 	// The following line is logged to STDERR and also sent to Sentry
 	logger.Errorf("oh no!")
+
+	// The following line is logged to STDERR, sent to Sentry, then the program abruptly stops
+	logger.Fatalf("can't continue...")
 }


### PR DESCRIPTION
This PR adds some doc on how to handle `logrus.Fatalf` events.

When calling `logrus.Fatalf()`, `logrus` calls `os.Exit(1)` immediately after treating the log. They are two consequences :
- all `defer` are ignored;
- it is almost certain that Sentry will not have time to send the `fatal` event to the remote server before the program stops.

Fortunately, [`logrus.RegisterExitHandler`](https://github.com/sirupsen/logrus#fatal-handlers) allows to run arbitrary code before the call to `os.Exit`. I propose to add it to the `logrus` example.
