### PR TITLE
fix: Do not clone the hub inside StartTransaction

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -682,11 +682,7 @@ func StartTransaction(ctx context.Context, name string, options ...SpanOption) *
 	if exists {
 		return currentTransaction
 	}
-	hub := GetHubFromContext(ctx)
-	if hub == nil {
-		hub = CurrentHub().Clone()
-		ctx = SetHubOnContext(ctx, hub)
-	}
+
 	options = append(options, TransactionName(name))
 	return StartSpan(
 		ctx,


### PR DESCRIPTION
Cloning the Hub inside `StartTransaction` is not necessary and can mess up the scope.
Calling `sentry.Init()` already creates the "initial" hub, integrations have to make sure to attach it to the context.

Closes #502 