### PR TITLE
Create an empty DSC in case there is no baggage header

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -699,6 +699,13 @@ func ContinueFromHeaders(trace, baggage string) SpanOption {
 		if baggage != "" {
 			s.updateFromBaggage([]byte(baggage))
 		}
+		// In case a sentry-trace header is present but no baggage header,
+		// create an empty, frozen DynamicSamplingContext.
+		if trace != "" && baggage == "" {
+			s.dynamicSamplingContext = DynamicSamplingContext{
+				Frozen: true,
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Added the case where a legacy FE/mobile SDK would send a `sentry-trace` header but no `baggage` header.