### PR TITLE
docs: Update link to releases in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ though support for this configuration is best-effort.
 $ go get github.com/getsentry/sentry-go@latest
 ```
 
-Check out the [list of released versions](https://pkg.go.dev/github.com/getsentry/sentry-go?tab=versions).
+Check out the [list of released versions](https://github.com/getsentry/sentry-go/releases).
 
 ## Configuration
 


### PR DESCRIPTION
Based on the feedback we got in #514, I changed the link to point to the GitHub release instead, as they provide a more useful changelog.