### PR TITLE
fix: Use "example.com" host in example/test DSNs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func setupClientTest() (*Client, *ScopeMock, *TransportMock) {
 	scope := &ScopeMock{}
 	transport := &TransportMock{}
 	client, _ := NewClient(ClientOptions{
-		Dsn:       "http://whatever@really.com/1337",
+		Dsn:       "http://whatever@example.com/1337",
 		Transport: transport,
 		Integrations: func(i []Integration) []Integration {
 			return []Integration{}

--- a/example/feature-showcase/main.go
+++ b/example/feature-showcase/main.go
@@ -116,7 +116,7 @@ func eventHint() {
 func main() {
 	if err := sentry.Init(sentry.ClientOptions{
 		Debug:        true,
-		Dsn:          "https://hello@world.io/1337",
+		Dsn:          "https://hello@example.com/1337",
 		IgnoreErrors: []string{"^(?i)drop me"},
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			if ex, ok := hint.OriginalException.(CustomComplexError); ok {

--- a/example/flush/main.go
+++ b/example/flush/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	_ = sentry.Init(sentry.ClientOptions{
-		Dsn:   "https://hello@world.io/1337",
+		Dsn:   "https://hello@example.com/1337",
 		Debug: true,
 	})
 

--- a/example/multiclient/main.go
+++ b/example/multiclient/main.go
@@ -25,7 +25,7 @@ func (pi *pickleIntegration) processor(event *sentry.Event, hint *sentry.EventHi
 func main() {
 	scope1 := sentry.NewScope()
 	client1, _ := sentry.NewClient(sentry.ClientOptions{
-		Dsn: "https://hello@world.io/1",
+		Dsn: "https://hello@example.com/1",
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			log.Println(event.Message)
 			return nil
@@ -38,7 +38,7 @@ func main() {
 
 	scope2 := sentry.NewScope()
 	client2, _ := sentry.NewClient(sentry.ClientOptions{
-		Dsn: "https://hello@world.io/2",
+		Dsn: "https://hello@example.com/2",
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			log.Println(event.Message)
 			return nil

--- a/example/recover/main.go
+++ b/example/recover/main.go
@@ -41,7 +41,7 @@ func bazMsg() {
 func main() {
 	_ = sentry.Init(sentry.ClientOptions{
 		Debug:            true,
-		Dsn:              "https://hello@world.io/1337",
+		Dsn:              "https://hello@example.com/1337",
 		AttachStacktrace: true,
 		BeforeSend: func(e *sentry.Event, h *sentry.EventHint) *sentry.Event {
 			fmt.Println(prettyPrint(e))

--- a/example/synctransport/main.go
+++ b/example/synctransport/main.go
@@ -12,7 +12,7 @@ func main() {
 	sentrySyncTransport.Timeout = time.Second * 3
 
 	_ = sentry.Init(sentry.ClientOptions{
-		Dsn:       "https://hello@world.io/1337",
+		Dsn:       "https://hello@example.com/1337",
 		Debug:     true,
 		Transport: sentrySyncTransport,
 	})

--- a/example/with_extra/main.go
+++ b/example/with_extra/main.go
@@ -64,7 +64,7 @@ func (ee ExtractExtra) SetupOnce(client *sentry.Client) {
 func main() {
 	if err := sentry.Init(sentry.ClientOptions{
 		Debug: true,
-		Dsn:   "https://hello@world.io/1337",
+		Dsn:   "https://hello@example.com/1337",
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			// Solution 1 (use beforeSend, which will be applied to
 			// error events and is usually application specific):

--- a/hub_test.go
+++ b/hub_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+const testDsn = "http://whatever@example.com/1337"
+
 func setupHubTest() (*Hub, *Client, *Scope) {
-	client, _ := NewClient(ClientOptions{Dsn: "http://whatever@really.com/1337"})
+	client, _ := NewClient(ClientOptions{Dsn: testDsn})
 	scope := NewScope()
 	hub := NewHub(client, scope)
 	return hub, client, scope
@@ -93,7 +95,7 @@ func TestPopScopeCannotLeaveStackEmpty(t *testing.T) {
 func TestBindClient(t *testing.T) {
 	hub, client, _ := setupHubTest()
 	hub.PushScope()
-	newClient, _ := NewClient(ClientOptions{Dsn: "http://whatever@really.com/1337"})
+	newClient, _ := NewClient(ClientOptions{Dsn: testDsn})
 	hub.BindClient(newClient)
 
 	if (*hub.stack)[0].client == (*hub.stack)[1].client {
@@ -121,7 +123,7 @@ func TestWithScopeBindClient(t *testing.T) {
 	hub, client, _ := setupHubTest()
 
 	hub.WithScope(func(scope *Scope) {
-		newClient, _ := NewClient(ClientOptions{Dsn: "http://whatever@really.com/1337"})
+		newClient, _ := NewClient(ClientOptions{Dsn: testDsn})
 		hub.BindClient(newClient)
 		if hub.stackTop().client != newClient {
 			t.Error("should use newly bound client")


### PR DESCRIPTION
To be on the safe side, let's not use domains in tests and examples that might be in actual use.
`example.com` should be a safe choice for those purposes: https://en.wikipedia.org/wiki/Example.com