### PR TITLE
Adding context.Context hub extractor for sentry-logrus integration

### DIFF
--- a/logrus/hubextractor.go
+++ b/logrus/hubextractor.go
@@ -1,0 +1,17 @@
+package sentrylogrus
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/getsentry/sentry-go"
+)
+
+var DefaultContextExtractor ContextHubFunc = func(entry *logrus.Entry) *sentry.Hub {
+	if ctx := entry.Context; ctx != nil {
+		hub := sentry.GetHubFromContext(ctx)
+		if hub != nil {
+			return hub
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Ho-ho-ho!

**Problem:**
When using sentry-logrus integration, it's no option for capturing events with connected traces, 'cause scopes between global sentry and hook integration isn't same.

**Probably solution:**
There no way to "just add `hook.NewFromHub(levels, hub)`", -> it will race condition.

**Solution:**
Adding custom extraction for sentry.Hub from current context (with using `logrus.WithContext(ctx)` and injected `sentry.Hub` to ctx via `SetHubOnContext`, or any middlewares, or smth else) solves this clearly.

Current change doesn't broke current API, but it gives ability for resolving explained problem.

P.S.:
Probably, test isn't clearly, but I not found any more clear solution for test this, whithout more API changing