### PR TITLE
fix(dynamic-sampling): Do not freeze DSC if no Sentry values are present

### DIFF
--- a/dynamic_sampling_context.go
+++ b/dynamic_sampling_context.go
@@ -33,7 +33,8 @@ func DynamicSamplingContextFromHeader(header []byte) (DynamicSamplingContext, er
 
 	return DynamicSamplingContext{
 		Entries: entries,
-		Frozen:  true,
+		// If there's at least one Sentry value, we consider the DSC frozen
+		Frozen: len(entries) > 0,
 	}, nil
 }
 

--- a/dynamic_sampling_context_test.go
+++ b/dynamic_sampling_context_test.go
@@ -11,13 +11,23 @@ func TestDynamicSamplingContextFromHeader(t *testing.T) {
 		input []byte
 		want  DynamicSamplingContext
 	}{
+		// Empty baggage header
 		{
 			input: []byte(""),
 			want: DynamicSamplingContext{
-				Frozen:  true,
+				Frozen:  false,
 				Entries: map[string]string{},
 			},
 		},
+		// Third-party baggage
+		{
+			input: []byte("other-vendor-key1=value1;value2, other-vendor-key2=value3"),
+			want: DynamicSamplingContext{
+				Frozen:  false,
+				Entries: map[string]string{},
+			},
+		},
+		// Sentry-only baggage
 		{
 			input: []byte("sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1"),
 			want: DynamicSamplingContext{
@@ -29,6 +39,7 @@ func TestDynamicSamplingContextFromHeader(t *testing.T) {
 				},
 			},
 		},
+		// Mixed baggage
 		{
 			input: []byte("sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1,foo=bar;foo;bar;bar=baz"),
 			want: DynamicSamplingContext{

--- a/dynamic_sampling_context_test.go
+++ b/dynamic_sampling_context_test.go
@@ -8,8 +8,9 @@ import (
 
 func TestDynamicSamplingContextFromHeader(t *testing.T) {
 	tests := []struct {
-		input []byte
-		want  DynamicSamplingContext
+		input  []byte
+		want   DynamicSamplingContext
+		errMsg string
 	}{
 		// Empty baggage header
 		{
@@ -51,14 +52,22 @@ func TestDynamicSamplingContextFromHeader(t *testing.T) {
 				},
 			},
 		},
+		// Invalid baggage value
+		{
+			input: []byte(","),
+			want: DynamicSamplingContext{
+				Frozen: false,
+			},
+			errMsg: "invalid baggage list-member: \"\"",
+		},
 	}
 
 	for _, tc := range tests {
 		got, err := DynamicSamplingContextFromHeader(tc.input)
+		assertEqual(t, got, tc.want, "Context mismatch")
 		if err != nil {
-			t.Fatal(err)
+			assertEqual(t, err.Error(), tc.errMsg, "Error mismatch")
 		}
-		assertEqual(t, got, tc.want)
 	}
 }
 

--- a/tracing.go
+++ b/tracing.go
@@ -693,18 +693,14 @@ func ContinueFromRequest(r *http.Request) SpanOption {
 // an existing TraceID and propagates the Dynamic Sampling context.
 func ContinueFromHeaders(trace, baggage string) SpanOption {
 	return func(s *Span) {
-		if trace != "" {
-			s.updateFromSentryTrace([]byte(trace))
-		}
 		if baggage != "" {
 			s.updateFromBaggage([]byte(baggage))
 		}
-		// In case a sentry-trace header is present but no baggage header,
-		// create an empty, frozen DynamicSamplingContext.
-		if trace != "" && baggage == "" {
-			s.dynamicSamplingContext = DynamicSamplingContext{
-				Frozen: true,
-			}
+		if trace != "" {
+			s.updateFromSentryTrace([]byte(trace))
+			// In case a sentry-trace header is present, we want to freeze the
+			// DynamicSamplingContext in all cases.
+			s.dynamicSamplingContext.Frozen = true
 		}
 	}
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -478,8 +478,7 @@ func TestContinueTransactionFromHeaders(t *testing.T) {
 			},
 		},
 		{
-			// sentry-trace and baggage with Sentry values => we
-			// immediately.
+			// sentry-trace and baggage with Sentry values => we freeze immediately.
 			traceStr:   "bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1",
 			baggageStr: "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1",
 			wantSpan: Span{
@@ -497,6 +496,19 @@ func TestContinueTransactionFromHeaders(t *testing.T) {
 				},
 			},
 		},
+		// TODO(anton): we should handle this case properly
+		// {
+		// 	// No sentry-trace, but baggage with Sentry values => this is a head SDK, so the DSC
+		// 	// should be empty and unfrozen.
+		// 	traceStr:   "",
+		// 	baggageStr: "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1",
+		// 	wantSpan: Span{
+		// 		isTransaction: true,
+		// 		dynamicSamplingContext: DynamicSamplingContext{
+		// 			Frozen: false,
+		// 		},
+		// 	},
+		// },
 	}
 
 	for _, tt := range tests {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -496,19 +496,6 @@ func TestContinueTransactionFromHeaders(t *testing.T) {
 				},
 			},
 		},
-		// TODO(anton): we should handle this case properly
-		// {
-		// 	// No sentry-trace, but baggage with Sentry values => this is a head SDK, so the DSC
-		// 	// should be empty and unfrozen.
-		// 	traceStr:   "",
-		// 	baggageStr: "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1",
-		// 	wantSpan: Span{
-		// 		isTransaction: true,
-		// 		dynamicSamplingContext: DynamicSamplingContext{
-		// 			Frozen: false,
-		// 		},
-		// 	},
-		// },
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
From https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#freezing-dynamic-sampling-context:

> When an SDK receives an HTTP request that was "instrumented" or "traced" by a Sentry SDK, the receiving SDK should consider the incoming DSC as instantly frozen. Any values on the DSC should be propagated "as is" - this includes values like "environment" or "release".

> SDKs should recognize incoming requests as "instrumented" or "traced" when at least one of the following applies:
> The incoming request has a sentry-trace header
    The incoming request has a baggage header **containing one or more keys starting with "sentry-"**

Therefore, when creating a DSC from a header, let's freeze it only when there's at least one `sentry-` value.
