### PR TITLE
ref(tracing): Add constants for "sentry-trace" and "baggage" header names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Misc
+
+- Add SentryTraceHeader and SentryBaggageHeader constants ([#538](https://github.com/getsentry/sentry-go/pull/538/))
+
 ## 0.17.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.17.0.

--- a/tracing.go
+++ b/tracing.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	SentryTraceHeader   = "sentry-tracing"
+	SentryTraceHeader   = "sentry-trace"
 	SentryBaggageHeader = "baggage"
 )
 

--- a/tracing.go
+++ b/tracing.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+const (
+	SentryTraceHeader   = "sentry-tracing"
+	SentryBaggageHeader = "baggage"
+)
+
 // A Span is the building block of a Sentry transaction. Spans build up a tree
 // structure of timed operations. The span tree makes up a transaction event
 // that is sent to Sentry when the root span is finished.
@@ -684,9 +689,9 @@ func TransctionSource(source TransactionSource) SpanOption {
 //
 // ContinueFromRequest is an alias for:
 //
-// ContinueFromHeaders(r.Header.Get("sentry-trace"), r.Header.Get("baggage")).
+// ContinueFromHeaders(r.Header.Get(SentryTraceHeader), r.Header.Get(SentryBaggageHeader)).
 func ContinueFromRequest(r *http.Request) SpanOption {
-	return ContinueFromHeaders(r.Header.Get("sentry-trace"), r.Header.Get("baggage"))
+	return ContinueFromHeaders(r.Header.Get(SentryTraceHeader), r.Header.Get(SentryBaggageHeader))
 }
 
 // ContinueFromHeaders returns a span option that updates the span to continue

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -409,7 +409,7 @@ func TestContinueSpanFromRequest(t *testing.T) {
 		sampled := sampled
 		t.Run(sampled.String(), func(t *testing.T) {
 			var s Span
-			hkey := http.CanonicalHeaderKey("sentry-trace")
+			hkey := http.CanonicalHeaderKey(SentryTraceHeader)
 			hval := (&Span{
 				TraceID: traceID,
 				SpanID:  spanID,

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -409,7 +409,7 @@ func TestContinueSpanFromRequest(t *testing.T) {
 		sampled := sampled
 		t.Run(sampled.String(), func(t *testing.T) {
 			var s Span
-			hkey := http.CanonicalHeaderKey(SentryTraceHeader)
+			hkey := http.CanonicalHeaderKey("sentry-trace")
 			hval := (&Span{
 				TraceID: traceID,
 				SpanID:  spanID,


### PR DESCRIPTION
This is helpful to have for the ongoing OTel work (happening in #537).