### PR TITLE
feat(tracing): Add Span.SetDynamicSamplingContext method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Misc
+
+- Add `Span.SetDynamicSamplingContext` method ([#539](https://github.com/getsentry/sentry-go/pull/539/))
+
 ## 0.17.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.17.0.

--- a/tracing.go
+++ b/tracing.go
@@ -235,6 +235,14 @@ func (s *Span) ToBaggage() string {
 	return s.dynamicSamplingContext.String()
 }
 
+// SetDynamicSamplingContext sets the given dynamic sampling context on the
+// current transaction.
+func (s *Span) SetDynamicSamplingContext(dsc DynamicSamplingContext) {
+	if s.isTransaction {
+		s.dynamicSamplingContext = dsc
+	}
+}
+
 // sentryTracePattern matches either
 //
 //	TRACE_ID - SPAN_ID

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -654,3 +654,38 @@ func TestDoesNotCrashWithEmptyContext(t *testing.T) {
 	tx.Sampled = SampledTrue
 	tx.Finish()
 }
+
+func TestSetDynamicSamplingContextWorksOnTransaction(t *testing.T) {
+	s := Span{
+		isTransaction:          true,
+		dynamicSamplingContext: DynamicSamplingContext{Frozen: false},
+	}
+	newDsc := DynamicSamplingContext{
+		Entries: map[string]string{"environment": "dev"},
+		Frozen:  true,
+	}
+
+	s.SetDynamicSamplingContext(newDsc)
+
+	if diff := cmp.Diff(newDsc, s.dynamicSamplingContext); diff != "" {
+		t.Errorf("DynamicSamplingContext mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSetDynamicSamplingContextDoesNothingOnSpan(t *testing.T) {
+	// SetDynamicSamplingContext should do nothing on non-transaction spans
+	s := Span{
+		isTransaction:          false,
+		dynamicSamplingContext: DynamicSamplingContext{},
+	}
+	newDsc := DynamicSamplingContext{
+		Entries: map[string]string{"environment": "dev"},
+		Frozen:  true,
+	}
+
+	s.SetDynamicSamplingContext(newDsc)
+
+	if diff := cmp.Diff(DynamicSamplingContext{}, s.dynamicSamplingContext); diff != "" {
+		t.Errorf("DynamicSamplingContext mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This PR adds `Span.SetDynamicSamplingContext` method that allows to set the given dynamic sampling context on a transaction. For spans it does nothings.

This is needed for the OTel work (#537).