### PR TITLE
feat: Add DSN getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Misc
 
 - Add SentryTraceHeader and SentryBaggageHeader constants ([#538](https://github.com/getsentry/sentry-go/pull/538/))
+- Add DSN getters ([#540](https://github.com/getsentry/sentry-go/pull/540))
 
 ## 0.17.0
 

--- a/dsn.go
+++ b/dsn.go
@@ -145,6 +145,41 @@ func (dsn Dsn) String() string {
 	return url
 }
 
+// Get the scheme of the DSN.
+func (dsn Dsn) GetScheme() string {
+	return string(dsn.scheme)
+}
+
+// Get the public key of the DSN.
+func (dsn Dsn) GetPublicKey() string {
+	return dsn.publicKey
+}
+
+// Get the secret key of the DSN.
+func (dsn Dsn) GetSecretKey() string {
+	return dsn.secretKey
+}
+
+// Get the host of the DSN.
+func (dsn Dsn) GetHost() string {
+	return dsn.host
+}
+
+// Get the port of the DSN.
+func (dsn Dsn) GetPort() int {
+	return dsn.port
+}
+
+// Get the path of the DSN.
+func (dsn Dsn) GetPath() string {
+	return dsn.path
+}
+
+// Get the project ID of the DSN.
+func (dsn Dsn) GetProjectID() string {
+	return dsn.projectID
+}
+
 // StoreAPIURL returns the URL of the store endpoint of the project associated
 // with the DSN.
 func (dsn Dsn) StoreAPIURL() *url.URL {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -190,3 +190,120 @@ func TestRequestHeadersWithSecretKey(t *testing.T) {
 		t.Error("expected auth header to fulfill provided pattern")
 	}
 }
+
+func TestGetScheme(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"http://public:secret@domain/42", "http"},
+		{"https://public:secret@domain/42", "https"},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetScheme(), tt.want)
+	}
+}
+
+func TestGetPublicKey(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"https://public:secret@domain/42", "public"},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetPublicKey(), tt.want)
+	}
+}
+
+func TestGetSecretKey(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"https://public:secret@domain/42", "secret"},
+		{"https://public@domain/42", ""},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetSecretKey(), tt.want)
+	}
+}
+
+func TestGetHost(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"http://public:secret@domain/42", "domain"},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetHost(), tt.want)
+	}
+}
+
+func TestGetPort(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want int
+	}{
+		{"https://public:secret@domain/42", 443},
+		{"http://public:secret@domain/42", 80},
+		{"https://public:secret@domain:3000/42", 3000},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetPort(), tt.want)
+	}
+}
+
+func TestGetPath(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"https://public:secret@domain/42", ""},
+		{"https://public:secret@domain/foo/bar/42", "/foo/bar"},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetPath(), tt.want)
+	}
+}
+
+func TestGetProjectID(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"https://public:secret@domain/42", "42"},
+	}
+	for _, tt := range tests {
+		dsn, err := NewDsn(tt.dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, dsn.GetProjectID(), tt.want)
+	}
+}


### PR DESCRIPTION
Unsure about `func (dsn Dsn) GetScheme() string` instead of `func (dsn Dsn) GetScheme() sheme`.

I want to avoid exporting `type scheme string` though 🤔 

This is needed for OTel (https://github.com/getsentry/sentry-go/pull/537).