### PR TITLE
test: Run tests and collect coverage for all submodules, if present

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - release/**
+      # REMOVEME
+      - tonyo/otel-plus-testing-submodules
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
         go: ["1.19", "1.18", "1.17"]
         os: [ubuntu, windows, macos]
       fail-fast: false
+  # Test the GOPATH mode with the oldest Go version we support
   test-gopath:
     name: GOPATH Mode
     runs-on: ubuntu-latest
@@ -84,6 +85,8 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
     steps:
       - uses: actions/setup-go@v3
+        with:
+          go-version: "1.17"
       - uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,9 @@ jobs:
         run: go mod tidy -go=1.19 -compat=1.17 && git diff --exit-code
         if: ${{ matrix.go == '1.19' }}
       - name: Test
-        run: go test -count=1 ./...
-      - name: Test (race)
-        run: go test -count=1 -race ./... -coverprofile=coverage.out -covermode=atomic
+        run: make test-race
+      - name: Collect coverage
+        run: make test-coverage
         # The race detector adds considerable runtime overhead. To save time on
         # pull requests, only run this step for a single job in the matrix. For
         # all other workflow triggers (e.g., pushes to a release branch) run
@@ -59,6 +59,8 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.19' && matrix.os == 'ubuntu') }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          directory: .coverage
     timeout-minutes: 10
     strategy:
       matrix:
@@ -109,5 +111,5 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Test
-        run: go test -count=1 ./...
+        run: make test-race
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
       - release/**
-      # REMOVEME
-      - tonyo/otel-plus-testing-submodules
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,6 @@ jobs:
         run: make test-race
       - name: Collect coverage
         run: make test-coverage
-        # The race detector adds considerable runtime overhead. To save time on
-        # pull requests, only run this step for a single job in the matrix. For
-        # all other workflow triggers (e.g., pushes to a release branch) run
-        # this step for the whole matrix.
-        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.19' && matrix.os == 'ubuntu') }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,14 @@ jobs:
         run: go mod tidy -go=1.19 -compat=1.17 && git diff --exit-code
         if: ${{ matrix.go == '1.19' }}
       - name: Test
+        run: make test
+      - name: Test (with race detection)
         run: make test-race
+        # The race detector adds considerable runtime overhead. To save time on
+        # pull requests, only run this step for a single job in the matrix. For
+        # all other workflow triggers (e.g., pushes to a release branch) run
+        # this step for the whole matrix.
+        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.19' && matrix.os == 'ubuntu') }}
       - name: Collect coverage
         run: make test-coverage
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# Code coverage artifacts
 coverage.txt
+coverage.out
+coverage.html
+.coverage/
 
 # Just my personal way of tracking stuff — Kamil
 FIXME.md

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir  ## Test with coverage en
 	for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo ">>> Running tests with coverage for module: $${dir}"; \
 	  echo "$(GO) test -count=1 -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" $${dir}/..."; \
-	  DIR_ABS=$$(realpath $${dir}) ;\
+	  DIR_ABS=$$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $${dir}) ; \
 	  REPORT_NAME=$$(basename $${DIR_ABS}); \
 	  (cd "$${dir}" && \
 	    $(GO) test -count=1 -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,24 @@
+### Inspired by https://github.com/open-telemetry/opentelemetry-go/blob/main/Makefile
+
 .DEFAULT_GOAL := help
+
+ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
+GO = go
+TIMEOUT = 60
+
+# Tools
+
+TOOLS = $(CURDIR)/.tools
+
+$(TOOLS):
+	@mkdir -p $@
+$(TOOLS)/%: | $(TOOLS)
+	cd $(TOOLS_MOD_DIR) && \
+	$(GO) build -o $@ $(PACKAGE)
+
+GOCOVMERGE = $(TOOLS)/gocovmerge
+$(TOOLS)/gocovmerge: PACKAGE=github.com/wadey/gocovmerge
+
 
 # Parse Makefile and display the help
 help: ## Show help
@@ -9,17 +29,38 @@ build: ## Build everything
 	go build ./...
 .PHONY: build
 
+
+# Tests
+TEST_TARGETS := test-short test-verbose test-race
+.PHONY: $(TEST_TARGETS) test
+test-race: ARGS=-race
+test-short:   ARGS=-short
+test-verbose: ARGS=-v -race
+$(TEST_TARGETS): test
+test: $(ALL_GO_MOD_DIRS:%=test/%)
+test/%: DIR=$*
+test/%:
+	@echo ">>> Running tests for module: $(DIR)"
+	cd $(DIR) && $(GO) test -timeout $(TIMEOUT)s $(ARGS) ./...
+
+COVERAGE_MODE    = atomic
+COVERAGE_PROFILE = coverage.out
+.PHONY: test-coverage
+test-coverage: | $(GOCOVMERGE)
+	@set -e; \
+	printf "" > coverage.txt; \
+	for dir in $(ALL_GO_MOD_DIRS); do \
+	  echo "$(GO) test -coverpkg=go.opentelemetry.io/otel/... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" $${dir}/..."; \
+	  (cd "$${dir}" && \
+	    $(GO) list ./... \
+	    | xargs $(GO) test -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" && \
+	  $(GO) tool cover -html=coverage.out -o coverage.html); \
+	done; \
+	$(GOCOVMERGE) $$(find . -name coverage.out) > coverage.txt
+
 vet: ## Run "go vet"
 	go vet ./...
 .PHONY: vet
-
-test: ## Run tests
-	go test -count=1 ./...
-.PHONY: test
-
-test-with-race-detection: ## Run tests with data race detector
-	go test -count=1 -race ./...
-.PHONY: test-with-race-detection
 
 test-with-coverage: ## Test with coverage enabled
 	go test -count=1 -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,9 @@ clean-report-dir: $(COVERAGE_REPORT_DIR)
 test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir
 	@set -e; \
 	for dir in $(ALL_GO_MOD_DIRS); do \
-	  echo "$(GO) test -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" $${dir}/..."; \
+	  echo "$(GO) test -count=1 -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" $${dir}/..."; \
 	  (cd "$${dir}" && \
-	    $(GO) test -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" && \
+	    $(GO) test -count=1 -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" && \
 		cp $(COVERAGE_PROFILE) "$(COVERAGE_REPORT_DIR_ABS)/$${RANDOM}_$(COVERAGE_PROFILE)" && \
 	    $(GO) tool cover -html=$(COVERAGE_PROFILE) -o coverage.html); \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR := $(dir $(MKFILE_PATH))
 ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 GO = go
-TIMEOUT = 60
+TIMEOUT = 300
 
 # Parse Makefile and display the help
 help: ## Show help


### PR DESCRIPTION
At the moment we only run test/coverage commands for the root module. 
Given the ongoing OTEL work (#537), we want to run the CI steps also for the new submodule(s).

The general approach for `test`/`test-coverage` targets was taken from https://github.com/open-telemetry/opentelemetry-go/blob/main/Makefile, and we can further iterate, if necessary.