### PR TITLE
feat(tracing): Add TraceParentContext and helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add DSN getters ([#540](https://github.com/getsentry/sentry-go/pull/540))
 - Add Span.SetData() ([#542](https://github.com/getsentry/sentry-go/pull/542))
 - Add Span.IsTransaction() ([#543](https://github.com/getsentry/sentry-go/pull/543))
-- Add TraceParentContext structure and its helper methods ([545](https://github.com/getsentry/sentry-go/pull/545))
+- Add TraceParentContext structure ([545](https://github.com/getsentry/sentry-go/pull/545))
 
 ## 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add DSN getters ([#540](https://github.com/getsentry/sentry-go/pull/540))
 - Add Span.SetData() ([#542](https://github.com/getsentry/sentry-go/pull/542))
 - Add Span.IsTransaction() ([#543](https://github.com/getsentry/sentry-go/pull/543))
+- Add TraceParentContext structure and its helper methods ([545](https://github.com/getsentry/sentry-go/pull/545))
 
 ## 0.17.0
 

--- a/tracing.go
+++ b/tracing.go
@@ -59,10 +59,10 @@ type Span struct { //nolint: maligned // prefer readability over optimal memory 
 // The context is normally extracted from a received "sentry-trace" header and
 // used to initialize a new transaction.
 //
-// Note: the name might be not the best one. It (somewhat unintentionally) alludes
-// to W3C "traceparent" header (https://www.w3.org/TR/trace-context/), which serves
-// a similar purpose to "sentry-trace". We should consider making this type
-// internal-only and give it a better name.
+// Note: the name might be not the best one. It was taken mostly to stay aligned
+// with other SDKs, and it alludes to W3C "traceparent" header (https://www.w3.org/TR/trace-context/),
+// which serves a similar purpose to "sentry-trace". We should eventually consider
+// making this type internal-only and give it a better name.
 type TraceParentContext struct {
 	TraceID      TraceID
 	ParentSpanID SpanID

--- a/tracing.go
+++ b/tracing.go
@@ -56,8 +56,13 @@ type Span struct { //nolint: maligned // prefer readability over optimal memory 
 
 // TraceParentContext describes the context of a (remote) parent span.
 //
-// The context is normally extracted from a received sentry-trace header and
+// The context is normally extracted from a received "sentry-trace" header and
 // used to initialize a new transaction.
+//
+// Note: the name might be not the best one. It (somewhat unintentionally) alludes
+// to W3C "traceparent" header (https://www.w3.org/TR/trace-context/), which serves
+// a similar purpose to "sentry-trace". We should consider making this type
+// internal-only and give it a better name.
 type TraceParentContext struct {
 	TraceID      TraceID
 	ParentSpanID SpanID

--- a/tracing.go
+++ b/tracing.go
@@ -730,7 +730,7 @@ func OpName(name string) SpanOption {
 }
 
 // TransctionSource sets the source of the transaction name.
-// TODO(anton): Fix the typo
+// TODO(anton): Fix the typo.
 func TransctionSource(source TransactionSource) SpanOption {
 	return func(s *Span) {
 		s.Source = source

--- a/tracing.go
+++ b/tracing.go
@@ -737,13 +737,6 @@ func TransctionSource(source TransactionSource) SpanOption {
 	}
 }
 
-// SpanSampled updates the sampling flag for a given span.
-func SpanSampled(sampled Sampled) SpanOption {
-	return func(s *Span) {
-		s.Sampled = sampled
-	}
-}
-
 // ContinueFromRequest returns a span option that updates the span to continue
 // an existing trace. If it cannot detect an existing trace in the request, the
 // span will be left unchanged.

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -777,5 +777,4 @@ func TestParseTraceParentContext(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
Part of the OTel work (#537).

In this PR:
1. Add TraceParentContext structure: it represents a parsed `sentry-trace` header.
    * Add a helper function: `ParseTraceParentContext`
2. Update `updateFromSentryTrace` to return a boolean status (whether the span has been updated).

