### PR TITLE
feat(tracing): Add a new SpanOption: SpanSampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add DSN getters ([#540](https://github.com/getsentry/sentry-go/pull/540))
 - Add Span.SetData() ([#542](https://github.com/getsentry/sentry-go/pull/542))
 - Add Span.IsTransaction() ([#543](https://github.com/getsentry/sentry-go/pull/543))
+- Add a new SpanOption: `SpanSampled` ([#546](https://github.com/getsentry/sentry-go/pull/546))
 
 ## 0.17.0
 

--- a/tracing.go
+++ b/tracing.go
@@ -706,6 +706,13 @@ func TransctionSource(source TransactionSource) SpanOption {
 	}
 }
 
+// SpanSampled updates the sampling flag for a given span.
+func SpanSampled(sampled Sampled) SpanOption {
+	return func(s *Span) {
+		s.Sampled = sampled
+	}
+}
+
 // ContinueFromRequest returns a span option that updates the span to continue
 // an existing trace. If it cannot detect an existing trace in the request, the
 // span will be left unchanged.

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -645,9 +645,7 @@ func TestSample(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 0.0,
 	})
-	span = StartSpan(ctx, "op", TransactionName("name"), func(s *Span) {
-		s.Sampled = SampledTrue
-	})
+	span = StartSpan(ctx, "op", TransactionName("name"), SpanSampled(SampledTrue))
 	if got := span.Sampled; got != SampledTrue {
 		t.Fatalf("got %s, want %s", got, SampledTrue)
 	}


### PR DESCRIPTION
A new SpanOption needed for the OTel work (#537).
Can be used to control the sampling flag when creating a new transaction.