### PR TITLE
feat: Add "transaction" pointer on Span

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -492,6 +492,15 @@ func (s *Span) traceContext() *TraceContext {
 // spanRecorder stores the span tree. Guaranteed to be non-nil.
 func (s *Span) spanRecorder() *spanRecorder { return s.recorder }
 
+// GetTransaction returns the root span (transaction span) for
+// the given span.
+func (s *Span) GetTransaction() *Span {
+	if s.transaction == nil {
+		return s
+	}
+	return s.transaction
+}
+
 // ParseTraceParentContext parses a sentry-trace header and builds a TraceParentContext from the
 // parsed values. If the header was parsed correctly, the second returned argument
 // ("valid") will be set to true, otherwise (e.g., empty or malformed header) it will

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -349,6 +349,27 @@ func TestChildShouldInheritParentTransaction(t *testing.T) {
 	}
 }
 
+func TestGetTransaction(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing: true,
+		Transport:     &TransportMock{},
+	})
+
+	transaction := StartTransaction(ctx, "transaction")
+	child := transaction.StartChild("child")
+	grandchild := child.StartChild("grandchild")
+
+	if transaction.GetTransaction() != transaction {
+		t.Fatalf("GetTransaction() should return self for a transaction span")
+	}
+	if child.GetTransaction() != transaction {
+		t.Fatalf("GetTransaction() should return the root level span for immediate children")
+	}
+	if grandchild.GetTransaction() != transaction {
+		t.Fatalf("GetTransaction() should return the root level span for nested spans")
+	}
+}
+
 func TestSetTag(t *testing.T) {
 	ctx := NewTestContext(ClientOptions{
 		EnableTracing: true,


### PR DESCRIPTION
A proposal that we haven't really discussed in details, but was straightforward to implement to showcase. Needed for OTel work (#537).

### Problem

Spans know whether they are transactions (e.g. root spans) thanks to `isTransaction` flag, but there's no nice way to actually "reach" the transaction from a child span. It is needed, for instance, to get a dynamic sampling context for a nested span, in case we want to propagate it to other services.

### Proposal

Introduce `transaction` (name tentative) attribute on `Span`, that always points to the root span of the local span tree. For actual root spans, `transaction` is set to `nil`. With that attribute in place, we can also get rid of `isTransaction` flag.

### Notes and Caveats

1. A side-effect of removing `isTransaction` and introducing `transaction` is that naively created Spans will be transactions by default (since they'll have an empty `transaction`). We don't really promote or support this usecase anywhere (people should be using `StartTransaction` and `StartSpan`), but a thing to keep in mind.
1. Alternatively, for transaction spans, `transaction` can store a pointer to itself, and not `nil`. A small downside is that it will be impossible to create a root level `Span` instance in one go: it'll be something like `t := Span{..}; t.transaction = &t` in tests or elsewhere.



