### PR TITLE
fix(otel): Fix Dynamic Sampling context propagation for nested spans

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
 )
 
 func assertEqual(t *testing.T, got, want interface{}, userMessage ...interface{}) {
@@ -49,4 +51,21 @@ func formatUnequalValues(got, want interface{}) string {
 	}
 
 	return fmt.Sprintf("\ngot: %s\nwant: %s", a, b)
+}
+
+func assertBaggageStringsEqual(t *testing.T, got, want string, userMessage ...interface{}) {
+	t.Helper()
+
+	baggageGot, err := baggage.Parse(got)
+	if err != nil {
+		t.Error(err)
+	}
+	baggageWant, err := baggage.Parse(want)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(baggageGot, baggageWant) {
+		logFailedAssertion(t, formatUnequalValues(got, want), userMessage...)
+	}
 }

--- a/otel/helpers_test.go
+++ b/otel/helpers_test.go
@@ -8,7 +8,6 @@ package sentryotel
 import (
 	"encoding/hex"
 	"fmt"
-	"log"
 	"reflect"
 	"sort"
 	"sync"
@@ -139,17 +138,23 @@ func stringPtr(s string) *string {
 }
 
 func otelTraceIDFromHex(s string) trace.TraceID {
+	if s == "" {
+		return trace.TraceID{}
+	}
 	traceID, err := trace.TraceIDFromHex(s)
 	if err != nil {
-		log.Fatalf("Cannot make a TraceID from the hex string: '%s'", s)
+		panic(err)
 	}
 	return traceID
 }
 
 func otelSpanIDFromHex(s string) trace.SpanID {
+	if s == "" {
+		return trace.SpanID{}
+	}
 	spanID, err := trace.SpanIDFromHex(s)
 	if err != nil {
-		log.Fatalf("Cannot make a SPanID from the hex string: '%s'", s)
+		panic(err)
 	}
 	return spanID
 }

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -50,7 +50,7 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 		containingTransaction := sentrySpan.GetTransaction()
 		dynamicSamplingContext := sentry.DynamicSamplingContextFromTransaction(containingTransaction)
 		containingTransaction.SetDynamicSamplingContext(dynamicSamplingContext)
-		sentryBaggageStr = dynamicSamplingContext.String()
+		sentryBaggageStr = containingTransaction.ToBaggage()
 	}
 	// FIXME: We're basically reparsing the header again, because internally in sentry-go
 	// we currently use a vendored version of "otel/baggage" package.

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -46,7 +46,11 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	// Propagate baggage header
 	sentryBaggageStr := ""
 	if sentrySpan != nil {
-		sentryBaggageStr = sentrySpan.ToBaggage()
+		// Finalize/freeze the baggage
+		containingTransaction := sentrySpan.GetTransaction()
+		dynamicSamplingContext := sentry.DynamicSamplingContextFromTransaction(containingTransaction)
+		containingTransaction.SetDynamicSamplingContext(dynamicSamplingContext)
+		sentryBaggageStr = dynamicSamplingContext.String()
 	}
 	// FIXME: We're basically reparsing the header again, because internally in sentry-go
 	// we currently use a vendored version of "otel/baggage" package.

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -46,11 +46,7 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	// Propagate baggage header
 	sentryBaggageStr := ""
 	if sentrySpan != nil {
-		// Dynamic sampling context is set only on the (root) transaction.
-		sentryTransaction := sentrySpan.GetTransaction()
-		if sentryTransaction != nil {
-			sentryBaggageStr = sentryTransaction.ToBaggage()
-		}
+		sentryBaggageStr = sentrySpan.ToBaggage()
 	}
 	// FIXME: We're basically reparsing the header again, because internally in sentry-go
 	// we currently use a vendored version of "otel/baggage" package.

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -45,10 +45,12 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 
 	// Propagate baggage header
 	sentryBaggageStr := ""
-	if sentrySpan != nil && sentrySpan.IsTransaction() {
-		// TODO(anton): Normally, this should return the DSC baggage from the transaction
-		// (not necessarily the current span). So this might break things in some cases.
-		sentryBaggageStr = sentrySpan.ToBaggage()
+	if sentrySpan != nil {
+		// Dynamic sampling context is set only on the (root) transaction.
+		sentryTransaction := sentrySpan.GetTransaction()
+		if sentryTransaction != nil {
+			sentryBaggageStr = sentryTransaction.ToBaggage()
+		}
 	}
 	// FIXME: We're basically reparsing the header again, because internally in sentry-go
 	// we currently use a vendored version of "otel/baggage" package.

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -45,8 +45,6 @@ func createTransactionAndMaybeSpan(transactionContext transactionTestContext, wi
 		span.SpanID = SpanIDFromHex(transactionContext.spanID)
 		sentrySpanMap.Set(trace.SpanID(span.SpanID), span)
 	}
-
-	transaction.SetDynamicSamplingContext(sentry.DynamicSamplingContextFromTransaction(transaction))
 	sentrySpanMap.Set(trace.SpanID(transaction.SpanID), transaction)
 
 	otelContext := trace.SpanContextConfig{

--- a/tracing.go
+++ b/tracing.go
@@ -288,7 +288,10 @@ func (s *Span) ToSentryTrace() string {
 
 // ToBaggage returns the serialized dynamic sampling context in the baggage format.
 func (s *Span) ToBaggage() string {
-	return s.dynamicSamplingContext.String()
+	if containingTransaction := s.GetTransaction(); containingTransaction != nil {
+		return containingTransaction.dynamicSamplingContext.String()
+	}
+	return ""
 }
 
 // SetDynamicSamplingContext sets the given dynamic sampling context on the


### PR DESCRIPTION
Thanks to #558, we can now fix the DSC/baggage propagation for non-transaction spans in the OTel propagator.

Fixes #553.