### PR TITLE
feat: add support for exception mechanism metadata

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -204,6 +204,22 @@ func NewRequest(r *http.Request) *Request {
 	}
 }
 
+// Mechanism is the mechanism by which an exception was generated and handled.
+type Mechanism struct {
+	Type        string                 `json:"type,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	HelpLink    string                 `json:"help_link,omitempty"`
+	Handled     *bool                  `json:"handled,omitempty"`
+	Data        map[string]interface{} `json:"data,omitempty"`
+}
+
+// SetUnhandled indicates that the exception is an unhandled exception, i.e.
+// from a panic.
+func (m *Mechanism) SetUnhandled() {
+	h := false
+	m.Handled = &h
+}
+
 // Exception specifies an error that occurred.
 type Exception struct {
 	Type       string      `json:"type,omitempty"`  // used as the main issue title
@@ -211,6 +227,7 @@ type Exception struct {
 	Module     string      `json:"module,omitempty"`
 	ThreadID   string      `json:"thread_id,omitempty"`
 	Stacktrace *Stacktrace `json:"stacktrace,omitempty"`
+	Mechanism  *Mechanism  `json:"mechanism,omitempty"`
 }
 
 // SDKMetaData is a struct to stash data which is needed at some point in the SDK's event processing pipeline

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -160,6 +160,55 @@ func TestEventMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestMechanismMarshalJSON(t *testing.T) {
+	mechanism := &Mechanism{
+		Type:        "some type",
+		Description: "some description",
+		HelpLink:    "some help link",
+		Data: map[string]interface{}{
+			"some data":         "some value",
+			"some numeric data": 12345,
+		},
+	}
+
+	got, err := json.Marshal(mechanism)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `{"type":"some type","description":"some description","help_link":"some help link",` +
+		`"data":{"some data":"some value","some numeric data":12345}}`
+
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("Event mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMechanismMarshalJSON_withHandled(t *testing.T) {
+	mechanism := &Mechanism{
+		Type:        "some type",
+		Description: "some description",
+		HelpLink:    "some help link",
+		Data: map[string]interface{}{
+			"some data":         "some value",
+			"some numeric data": 12345,
+		},
+	}
+	mechanism.SetUnhandled()
+
+	got, err := json.Marshal(mechanism)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `{"type":"some type","description":"some description","help_link":"some help link",` +
+		`"handled":false,"data":{"some data":"some value","some numeric data":12345}}`
+
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("Event mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestStructSnapshots(t *testing.T) {
 	testSpan := &Span{
 		TraceID:      TraceIDFromHex("d6c4f03650bd47699ec65c84352b6208"),


### PR DESCRIPTION
This adds support for the exception `mechanism` field, based on the [`relay` schema of the field](https://github.com/getsentry/relay/blob/e785f9a22adef018cec8785a7dec289a6ae74165/relay-general/src/protocol/mechanism.rs#L94-L159).

Primarily, I'd like to be able to annotate exceptions with this data to make the UI more useful. For instance, we have a gRPC interceptor that recovers from `panic`, and I think it would be useful to set the `handled` bit to `false` so that we get the additional UI embellishment (the red skull and "Unhandled" flag) when endpoints panic (versus returning an explicit status or error). This would likely be useful to other HTTP integrations as well.