### PR TITLE
release: Update .craft.yml to be ready for otel submodule release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,11 +1,13 @@
-minVersion: 0.23.1
+minVersion: 0.35.0
 changelogPolicy: simple
 artifactProvider:
   name: none
 targets:
   - name: github
-    includeNames: /none/
     tagPrefix: v
+  - name: github
+    tagPrefix: otel/v
+    tagOnly: true
   - name: registry
     sdks:
       github:getsentry/sentry-go:


### PR DESCRIPTION
Craft v0.35.0 [supports](https://github.com/getsentry/craft/blob/master/CHANGELOG.md#0350) `tagOnly` attribute for github target, so we can already prepare for the next release, where the new submodule (`otel`) becomes the part of the repo.

For now we agreed to have version parity between the root SDK and all submodules, for simplicity.
