### PR TITLE
fix: Create a frozen DSC when calling ToBaggage

### DIFF
--- a/dynamic_sampling_context_test.go
+++ b/dynamic_sampling_context_test.go
@@ -2,8 +2,9 @@ package sentry
 
 import (
 	"context"
-	"strings"
 	"testing"
+
+	"github.com/getsentry/sentry-go/internal/testutils"
 )
 
 func TestDynamicSamplingContextFromHeader(t *testing.T) {
@@ -177,7 +178,5 @@ func TestString(t *testing.T) {
 			"sample_rate": "1",
 		},
 	}
-	assertEqual(t, strings.Contains(dsc.String(), "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03"), true)
-	assertEqual(t, strings.Contains(dsc.String(), "sentry-public_key=public"), true)
-	assertEqual(t, strings.Contains(dsc.String(), "sentry-sample_rate=1"), true)
+	testutils.AssertBaggageStringsEqual(t, dsc.String(), "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1")
 }

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -46,11 +46,7 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	// Propagate baggage header
 	sentryBaggageStr := ""
 	if sentrySpan != nil {
-		// Finalize/freeze the baggage
-		containingTransaction := sentrySpan.GetTransaction()
-		dynamicSamplingContext := sentry.DynamicSamplingContextFromTransaction(containingTransaction)
-		containingTransaction.SetDynamicSamplingContext(dynamicSamplingContext)
-		sentryBaggageStr = containingTransaction.ToBaggage()
+		sentryBaggageStr = sentrySpan.GetTransaction().ToBaggage()
 	}
 	// FIXME: We're basically reparsing the header again, because internally in sentry-go
 	// we currently use a vendored version of "otel/baggage" package.

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -811,32 +811,22 @@ func TestGetTransactionReturnsNilOnManuallyCreatedSpans(t *testing.T) {
 	}
 }
 
-func TestSpanToBaggage(t *testing.T) {
+func TestToBaggage(t *testing.T) {
 	ctx := NewTestContext(ClientOptions{
 		EnableTracing: true,
 		SampleRate:    1.0,
 		Release:       "test-release",
 	})
-
-	// Should work transaction
 	transaction := StartTransaction(ctx, "transaction-name")
 	transaction.TraceID = TraceIDFromHex("f1a4c5c9071eca1cdf04e4132527ed16")
-	// Before finalizing
-	assertBaggageStringsEqual(
-		t,
-		transaction.ToBaggage(),
-		"",
-	)
-	dsc := DynamicSamplingContextFromTransaction(transaction)
-	transaction.SetDynamicSamplingContext(dsc)
-	// After finalizing
+
 	assertBaggageStringsEqual(
 		t,
 		transaction.ToBaggage(),
 		"sentry-trace_id=f1a4c5c9071eca1cdf04e4132527ed16,sentry-release=test-release,sentry-transaction=transaction-name",
 	)
 
-	// Should work on child span
+	// Calling ToBaggage() on a child span should return the same result
 	child := transaction.StartChild("op-name")
 	assertBaggageStringsEqual(
 		t,


### PR DESCRIPTION
This fixes an issue, where someone would call `span.ToBaggage` to fetch the `DynamicSamplingContext` to attach it to an outgoing HTTP request "baggage" header or to render it in an HTML template as a "baggage" meta tag before the transaction is finished.

We need to freeze the DynamicSamplingContext in such cases, as any mutations after the DynamicSamplingContext was propagated to a downstream SDK mess up DynamicSampling.