### PR TITLE
fix(otel): Use vendored bagggage implementation in propagator

### DIFF
--- a/otel/context.go
+++ b/otel/context.go
@@ -6,3 +6,4 @@ package sentryotel
 type dynamicSamplingContextKey struct{}
 type sentryTraceHeaderContextKey struct{}
 type sentryTraceParentContextKey struct{}
+type baggageContextKey struct{}

--- a/otel/helpers_test.go
+++ b/otel/helpers_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
 	"github.com/getsentry/sentry-go/internal/testutils"
 	"github.com/google/go-cmp/cmp"
-	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -28,6 +28,8 @@ var assertFalse = testutils.AssertFalse
 // It is needed because some headers (e.g. "baggage") might contain the same set of values/attributes,
 // (and therefore be semantically equal), but serialized in different order.
 func assertMapCarrierEqual(t *testing.T, got, want propagation.MapCarrier, userMessage ...interface{}) {
+	t.Helper()
+
 	// Make sure that keys are the same
 	gotKeysSorted := got.Keys()
 	sort.Strings(gotKeysSorted)

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/getsentry/sentry-go"
-	"go.opentelemetry.io/otel/baggage"
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -48,13 +48,16 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	if sentrySpan != nil {
 		sentryBaggageStr = sentrySpan.GetTransaction().ToBaggage()
 	}
-	// FIXME: We're basically reparsing the header again, because internally in sentry-go
-	// we currently use a vendored version of "otel/baggage" package.
+	// FIXME(anton): We're basically reparsing the header again, because in sentry-go
+	// we currently don't expose a method to get only DSC or its baggage (only a string).
 	// This is not optimal and we should consider other approaches.
 	sentryBaggage, _ := baggage.Parse(sentryBaggageStr)
 
 	// Merge the baggage values
-	finalBaggage := baggage.FromContext(ctx)
+	finalBaggage, baggageOk := ctx.Value(baggageContextKey{}).(baggage.Baggage)
+	if !baggageOk {
+		finalBaggage = baggage.Baggage{}
+	}
 	for _, member := range sentryBaggage.Members() {
 		var err error
 		finalBaggage, err = finalBaggage.SetMember(member)
@@ -96,7 +99,7 @@ func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextM
 		// Preserve the original baggage
 		parsedBaggage, err := baggage.Parse(baggageHeader)
 		if err == nil {
-			ctx = baggage.ContextWithBaggage(ctx, parsedBaggage)
+			ctx = context.WithValue(ctx, baggageContextKey{}, parsedBaggage)
 		}
 	}
 

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/getsentry/sentry-go"
-	"go.opentelemetry.io/otel/baggage"
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -106,7 +106,7 @@ func TestInjectUsesSentryTraceOnEmptySpan(t *testing.T) {
 func TestInjectUsesBaggageOnEmptySpan(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 	bag, _ := baggage.Parse("key1=value1;value2, key2=value2")
-	ctx := baggage.ContextWithBaggage(context.Background(), bag)
+	ctx := context.WithValue(context.Background(), baggageContextKey{}, bag)
 
 	propagator.Inject(ctx, carrier)
 

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -342,5 +342,4 @@ func TestExtractAndInjectIntegration(t *testing.T) {
 			)
 		})
 	}
-	t.Fail()
 }


### PR DESCRIPTION
After #568, we can finally fix the issue in the propagator that resulted in dropping baggage.
Now we only use our vendored baggage implementation with the fixes that hopefully make our implementation consistent with baggage implementations in other Sentry SDKs.