### PR TITLE
fix(ci): Run "build", "vet", and "mod tidy" for all submodules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Check go.mod Tidiness
-        run: go mod tidy -go=1.19 -compat=1.17 && git diff --exit-code
+        run: make mod-tidy
         if: ${{ matrix.go == '1.19' }}
       - name: Test
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
             ${{ runner.os }}-go-${{ matrix.go }}-
             ${{ runner.os }}-go-
       - name: Build
-        run: go build ./...
+        run: make build
       - name: Vet
-        run: go vet ./...
+        run: make vet
       - name: Check go.mod Tidiness
         run: make mod-tidy
         if: ${{ matrix.go == '1.19' }}

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,15 @@ test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir  ## Test with coverage en
 	done;
 .PHONY: test-coverage clean-report-dir
 
+mod-tidy: ## Check go.mod Tidiness
+	for dir in $(ALL_GO_MOD_DIRS); do \
+		cd "$${dir}"; \
+		echo ">>> Running 'go mod tidy' for module: $${dir}"; \
+		go mod tidy -go=1.19 -compat=1.17; \
+	done; \
+	git diff --exit-code;
+.PHONY: mod-tidy
+
 vet: ## Run "go vet"
 	go vet ./...
 .PHONY: vet

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ help: ## Show help
 .PHONY: help
 
 build: ## Build everything
-	go build ./...
+	for dir in $(ALL_GO_MOD_DIRS); do \
+		cd "$${dir}"; \
+		echo ">>> Running 'go build' for module: $${dir}"; \
+		go build ./...; \
+	done;
 .PHONY: build
 
 ### Tests (inspired by https://github.com/open-telemetry/opentelemetry-go/blob/main/Makefile)
@@ -50,7 +54,7 @@ test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir  ## Test with coverage en
 	done;
 .PHONY: test-coverage clean-report-dir
 
-mod-tidy: ## Check go.mod Tidiness
+mod-tidy: ## Check go.mod tidiness
 	for dir in $(ALL_GO_MOD_DIRS); do \
 		cd "$${dir}"; \
 		echo ">>> Running 'go mod tidy' for module: $${dir}"; \
@@ -60,7 +64,11 @@ mod-tidy: ## Check go.mod Tidiness
 .PHONY: mod-tidy
 
 vet: ## Run "go vet"
-	go vet ./...
+	for dir in $(ALL_GO_MOD_DIRS); do \
+		cd "$${dir}"; \
+		echo ">>> Running 'go vet' for module: $${dir}"; \
+		go vet ./...; \
+	done;
 .PHONY: vet
 
 lint: ## Lint (using "golangci-lint")


### PR DESCRIPTION
In the new module/submodule world, it's not enough to do e.g. `go build ./...`, since it'll ignore submodules.