### PR TITLE
fix(logrus-hook): Don't throw error if sentry event is dropped

### DIFF
--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -121,7 +121,6 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 		if h.fallback != nil {
 			return h.fallback(entry)
 		}
-		return errors.New("failed to send to sentry")
 	}
 	return nil
 }


### PR DESCRIPTION
When using the logrus hook to send logrus logs to sentry, an error was logged when the corresponding sentry event is being dropped client-side. This happens for example when using the `BeforeSend` event transformation function.

This should not be considered an error.

Resolves #578
