### PR TITLE
fix(otel): Overwrite "trace" context in Sentry error

### DIFF
--- a/otel/event_processor.go
+++ b/otel/event_processor.go
@@ -12,6 +12,8 @@ import (
 //
 // Caveat: hint.Context should contain a valid context populated by OpenTelemetry's span context.
 func linkTraceContextToErrorEvent(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	sentry.Logger.Printf("\nEvent Processor\nEvent: %#v\nHint: %#v", event, hint)
+
 	if hint == nil || hint.Context == nil {
 		return event
 	}

--- a/otel/event_processor.go
+++ b/otel/event_processor.go
@@ -15,7 +15,7 @@ func linkTraceContextToErrorEvent(event *sentry.Event, hint *sentry.EventHint) *
 	if hint == nil || hint.Context == nil {
 		return event
 	}
-	// TODO: what we want here is to compare with the (unexported) transactionType
+	// TODO: what we want here is to compare with the (unexported) sentry.transactionType
 	if event.Type == "transaction" {
 		return event
 	}

--- a/otel/event_processor.go
+++ b/otel/event_processor.go
@@ -25,14 +25,8 @@ func linkTraceContextToErrorEvent(event *sentry.Event, hint *sentry.EventHint) *
 	}
 
 	traceContext := event.Contexts["trace"]
-	if len(traceContext) > 0 {
-		// trace context is already set, not touching it
-		return event
-	}
-	event.Contexts["trace"] = map[string]interface{}{
-		"trace_id":       sentrySpan.TraceID.String(),
-		"span_id":        sentrySpan.SpanID.String(),
-		"parent_span_id": sentrySpan.ParentSpanID.String(),
-	}
+	traceContext["trace_id"] = sentrySpan.TraceID.String()
+	traceContext["span_id"] = sentrySpan.SpanID.String()
+	traceContext["parent_span_id"] = sentrySpan.ParentSpanID.String()
 	return event
 }

--- a/otel/event_processor.go
+++ b/otel/event_processor.go
@@ -24,7 +24,11 @@ func linkTraceContextToErrorEvent(event *sentry.Event, hint *sentry.EventHint) *
 		return event
 	}
 
-	traceContext := event.Contexts["trace"]
+	traceContext, found := event.Contexts["trace"]
+	if !found {
+		event.Contexts["trace"] = make(map[string]interface{})
+		traceContext = event.Contexts["trace"]
+	}
 	traceContext["trace_id"] = sentrySpan.TraceID.String()
 	traceContext["span_id"] = sentrySpan.SpanID.String()
 	traceContext["parent_span_id"] = sentrySpan.ParentSpanID.String()

--- a/otel/event_processor.go
+++ b/otel/event_processor.go
@@ -12,9 +12,11 @@ import (
 //
 // Caveat: hint.Context should contain a valid context populated by OpenTelemetry's span context.
 func linkTraceContextToErrorEvent(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-	sentry.Logger.Printf("\nEvent Processor\nEvent: %#v\nHint: %#v", event, hint)
-
 	if hint == nil || hint.Context == nil {
+		return event
+	}
+	// TODO: what we want here is to compare with the (unexported) transactionType
+	if event.Type == "transaction" {
 		return event
 	}
 	otelSpanContext := trace.SpanContextFromContext(hint.Context)

--- a/otel/event_processor_test.go
+++ b/otel/event_processor_test.go
@@ -4,65 +4,54 @@ package sentryotel
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/getsentry/sentry-go"
 )
 
-func TestLinkTraceContextToErrorEventWithEmptyTraceContext(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
-	ctx, otelSpan := tracer.Start(emptyContextWithSentry(), "spanName")
-	sentrySpan, _ := sentrySpanMap.Get(otelSpan.SpanContext().SpanID())
+func TestLinkTraceContextToErrorEventSetsContext(t *testing.T) {
 
-	hub := sentry.GetHubFromContext(ctx)
-	client := hub.Client()
-	client.CaptureException(
-		errors.New("new sentry exception"),
-		&sentry.EventHint{Context: ctx},
-		nil,
-	)
+	withExistingContextOptions := []bool{false, true}
 
-	transport := client.Transport.(*TransportMock)
-	events := transport.Events()
-	assertEqual(t, len(events), 1)
-	err := events[0]
-	exception := err.Exception[0]
-	assertEqual(t, exception.Type, "*errors.errorString")
-	assertEqual(t, exception.Value, "new sentry exception")
-	assertEqual(t, err.Type, "")
-	assertEqual(t,
-		err.Contexts["trace"],
-		map[string]interface{}{
-			"trace_id":       sentrySpan.TraceID.String(),
-			"span_id":        sentrySpan.SpanID.String(),
-			"parent_span_id": sentrySpan.ParentSpanID.String(),
-		},
-	)
-}
+	for _, withExistingContext := range withExistingContextOptions {
+		withExistingContext := withExistingContext
+		name := fmt.Sprintf("withExistingContext_%v", withExistingContext)
 
-func TestLinkTraceContextToErrorEventDoesNotTouchExistingTraceContext(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
-	ctx, _ := tracer.Start(emptyContextWithSentry(), "spanName")
+		t.Run(name, func(t *testing.T) {
+			_, _, tracer := setupSpanProcessorTest()
+			ctx, otelSpan := tracer.Start(emptyContextWithSentry(), "spanName")
+			sentrySpan, _ := sentrySpanMap.Get(otelSpan.SpanContext().SpanID())
 
-	hub := sentry.GetHubFromContext(ctx)
-	hub.Scope().SetContext("trace", map[string]interface{}{"trace_id": "123"})
-	client := hub.Client()
-	client.CaptureException(
-		errors.New("new sentry exception with existing trace context"),
-		&sentry.EventHint{Context: ctx},
-		hub.Scope(),
-	)
+			hub := sentry.GetHubFromContext(ctx)
+			client, scope := hub.Client(), hub.Scope()
 
-	transport := client.Transport.(*TransportMock)
-	events := transport.Events()
-	assertEqual(t, len(events), 1)
-	err := events[0]
-	exception := err.Exception[0]
-	assertEqual(t, exception.Type, "*errors.errorString")
-	assertEqual(t, exception.Value, "new sentry exception with existing trace context")
-	assertEqual(t, err.Type, "")
-	assertEqual(t,
-		err.Contexts["trace"],
-		map[string]interface{}{"trace_id": "123"},
-	)
+			if withExistingContext {
+				// The existing "trace" context should be ovewritten by the event processor
+				scope.SetContext("trace", map[string]interface{}{"trace_id": "123"})
+			}
+			client.CaptureException(
+				errors.New("new sentry exception with existing trace context"),
+				&sentry.EventHint{Context: ctx},
+				hub.Scope(),
+			)
+
+			transport := client.Transport.(*TransportMock)
+			events := transport.Events()
+			assertEqual(t, len(events), 1)
+			err := events[0]
+			exception := err.Exception[0]
+			assertEqual(t, exception.Type, "*errors.errorString")
+			assertEqual(t, exception.Value, "new sentry exception with existing trace context")
+			assertEqual(t, err.Type, "")
+			assertEqual(t,
+				err.Contexts["trace"],
+				map[string]interface{}{
+					"trace_id":       sentrySpan.TraceID.String(),
+					"span_id":        sentrySpan.SpanID.String(),
+					"parent_span_id": sentrySpan.ParentSpanID.String(),
+				},
+			)
+		})
+	}
 }

--- a/transport.go
+++ b/transport.go
@@ -544,8 +544,6 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		Logger.Printf("There was an issue with sending an event: %v", err)
 		return
 	}
-	Logger.Printf("Response status: %q", response.Status)
-
 	t.mu.Lock()
 	t.limits.Merge(ratelimit.FromResponse(response))
 	t.mu.Unlock()

--- a/transport.go
+++ b/transport.go
@@ -544,6 +544,8 @@ func (t *HTTPSyncTransport) SendEvent(event *Event) {
 		Logger.Printf("There was an issue with sending an event: %v", err)
 		return
 	}
+	Logger.Printf("Response status: %q", response.Status)
+
 	t.mu.Lock()
 	t.limits.Merge(ratelimit.FromResponse(response))
 	t.mu.Unlock()


### PR DESCRIPTION
This patches the following issue: when [creating a transaction in the span processor](https://github.com/getsentry/sentry-go/blob/f03b31a4a314fda36229c131a20306ffd686f2e9/otel/span_processor.go#L50-L56), we later overwrite its SpanID/TraceID. The problem is, the trace context is also set on the scope when the span is started: https://github.com/getsentry/sentry-go/blob/f03b31a4a314fda36229c131a20306ffd686f2e9/tracing.go#L176

So ultimately we need to either/or:
1. Pass additional SpanOptions to StartTransaction that set the right SpanID/TraceID right away
2. Overwrite the trace context later.

Here I'm taking approach 2 because it's easier, but generally speaking I believe we should review setting trace context (and a few other tracing related things) on the scope. 