### PR TITLE
Correct copyright holder name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Follow-up to #583.

Part of https://github.com/getsentry/team-ospo/issues/56.