### PR TITLE
feat(tracing): Introduce span.SetContext

### DIFF
--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -133,8 +133,7 @@ func updateTransactionWithOtelData(transaction *sentry.Span, s otelSdkTrace.Read
 		resource[kv.Key] = kv.Value.AsString()
 	}
 
-	// TODO(michi) We might need to set this somewhere else than on the scope
-	hub.Scope().SetContext("otel", map[string]interface{}{
+	transaction.SetContext("otel", map[string]interface{}{
 		"attributes": attributes,
 		"resource":   resource,
 	})

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -834,3 +834,36 @@ func TestToBaggage(t *testing.T) {
 		"sentry-trace_id=f1a4c5c9071eca1cdf04e4132527ed16,sentry-release=test-release,sentry-transaction=transaction-name",
 	)
 }
+
+func TestSpanSetContext(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing: true,
+	})
+	transaction := StartTransaction(ctx, "Test Transaction")
+
+	transaction.SetContext("a", Context{"b": 1})
+
+	assertEqual(t, map[string]Context{"a": {"b": 1}}, transaction.contexts)
+}
+
+func TestSpanSetContextMerges(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing: true,
+	})
+	transaction := StartTransaction(ctx, "Test Transaction")
+	transaction.SetContext("a", Context{"foo": "bar"})
+	transaction.SetContext("b", Context{"b": 2})
+
+	assertEqual(t, map[string]Context{"a": {"foo": "bar"}, "b": {"b": 2}}, transaction.contexts)
+}
+
+func TestSpanSetContextOverrides(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing: true,
+	})
+	transaction := StartTransaction(ctx, "Test Transaction")
+	transaction.SetContext("a", Context{"foo": "bar"})
+	transaction.SetContext("a", Context{"foo": 2})
+
+	assertEqual(t, map[string]Context{"a": {"foo": 2}}, transaction.contexts)
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -260,6 +260,7 @@ func TestStartTransaction(t *testing.T) {
 			s.StartTime = startTime
 			s.EndTime = endTime
 			s.Data = data
+			s.SetContext("otel", Context{"k": "v"})
 		},
 	)
 	transaction.Finish()
@@ -283,6 +284,7 @@ func TestStartTransaction(t *testing.T) {
 				Description: description,
 				Status:      status,
 			}.Map(),
+			"otel": {"k": "v"},
 		},
 		Tags: nil,
 		// TODO(tracing): the root span / transaction data field is


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-go/issues/596

This PR adds the `SetContext` struct method to the span struct.

This allows us to remove the usage of setting context on the scope in the OpenTelemetry span processor