### PR TITLE
fix(otel): Don't use scope for otel transaction name

### DIFF
--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -117,11 +117,6 @@ func getTraceParentContext(ctx context.Context) sentry.TraceParentContext {
 }
 
 func updateTransactionWithOtelData(transaction *sentry.Span, s otelSdkTrace.ReadOnlySpan) {
-	hub := sentry.GetHubFromContext(transaction.Context())
-	if hub == nil {
-		return
-	}
-
 	// TODO(michi) This is crazy inefficient
 	attributes := map[attribute.Key]string{}
 	resource := map[attribute.Key]string{}
@@ -143,8 +138,7 @@ func updateTransactionWithOtelData(transaction *sentry.Span, s otelSdkTrace.Read
 	transaction.Status = utils.MapOtelStatus(s)
 	transaction.Op = spanAttributes.Op
 	transaction.Source = spanAttributes.Source
-	// TODO(michi) We might need to set this somewhere else than on the scope
-	hub.Scope().SetTransaction(spanAttributes.Description)
+	transaction.Description = spanAttributes.Description
 }
 
 func updateSpanWithOtelData(span *sentry.Span, s otelSdkTrace.ReadOnlySpan) {

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -255,7 +255,7 @@ func TestOnEndWithTransaction(t *testing.T) {
 	assertEqual(t, sentryTransaction.Status, sentry.SpanStatusOK)
 	assertEqual(t, sentryTransaction.Source, sentry.TransactionSource("custom"))
 	assertEqual(t, sentryTransaction.Op, "")
-	assertEqual(t, sentryTransaction.Description, "")
+	assertEqual(t, sentryTransaction.Description, "transactionName")
 
 	// One events should be captured by transport
 	sentryTransport := getSentryTransportFromContext(ctx)

--- a/tracing.go
+++ b/tracing.go
@@ -499,9 +499,14 @@ func (s *Span) toEvent() *Event {
 	}
 	contexts["trace"] = s.traceContext().Map()
 
+	transaction := hub.Scope().Transaction()
+	if s.Description != "" {
+		transaction = s.Description
+	}
+
 	return &Event{
 		Type:        transactionType,
-		Transaction: hub.Scope().Transaction(),
+		Transaction: transaction,
 		Contexts:    contexts,
 		Tags:        s.Tags,
 		Extra:       s.Data,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-go/issues/596

This is a hack - so open to keep iterating on this, but in the spirit of just fixing this asap to ship I opened this PR.

This change makes it so that if there is a span description set, use that as the transaction name.

Nothing should be setting this for transactions, as we don't expose this API anywhere, so we should be safe to only make this work for otel.

Draft for now, thoughts appreciated!