### PR TITLE
fix(otel): Better handling for HTTP span attributes

### DIFF
--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -82,7 +82,6 @@ func (ssp *sentrySpanProcessor) OnEnd(s otelSdkTrace.ReadOnlySpan) {
 	} else {
 		updateSpanWithOtelData(sentrySpan, s)
 	}
-
 	sentrySpan.EndTime = s.EndTime()
 	sentrySpan.Finish()
 

--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -82,6 +82,7 @@ func (ssp *sentrySpanProcessor) OnEnd(s otelSdkTrace.ReadOnlySpan) {
 	} else {
 		updateSpanWithOtelData(sentrySpan, s)
 	}
+
 	sentrySpan.EndTime = s.EndTime()
 	sentrySpan.Finish()
 

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -370,18 +370,18 @@ func TestParseSpanAttributesHttpServer(t *testing.T) {
 		"rootSpan",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(attribute.String("http.method", "GET")),
-		trace.WithAttributes(attribute.String("http.target", "/api/checkout?k=v")),
+		trace.WithAttributes(attribute.String("http.target", "/api/checkout1?k=v")),
 		// We ignore "http.url" if "http.target" is present
-		trace.WithAttributes(attribute.String("http.url", "http://localhost:1234/api/checkout1?q1=q2#fragment")),
+		trace.WithAttributes(attribute.String("http.url", "http://localhost:1234/api/checkout?q1=q2#fragment")),
 	)
 	_, otelChildSpan := tracer.Start(
 		ctx,
 		"span name",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(attribute.String("http.method", "POST")),
-		trace.WithAttributes(attribute.String("http.target", "/api/checkout?k=v")),
+		trace.WithAttributes(attribute.String("http.target", "/api/checkout2?k=v")),
 		// We ignore "http.url" if "http.target" is present
-		trace.WithAttributes(attribute.String("http.url", "http://localhost:2345/api/checkout2?q1=q2#fragment")),
+		trace.WithAttributes(attribute.String("http.url", "http://localhost:2345/api/checkout?q1=q2#fragment")),
 	)
 	sentryTransaction, _ := sentrySpanMap.Get(otelRootSpan.SpanContext().SpanID())
 	sentrySpan, _ := sentrySpanMap.Get(otelChildSpan.SpanContext().SpanID())
@@ -390,14 +390,14 @@ func TestParseSpanAttributesHttpServer(t *testing.T) {
 	otelRootSpan.End()
 
 	// Transaction
-	assertEqual(t, sentryTransaction.Name, "GET /api/checkout")
+	assertEqual(t, sentryTransaction.Name, "GET /api/checkout1")
 	assertEqual(t, sentryTransaction.Description, "")
 	assertEqual(t, sentryTransaction.Op, "http.server")
 	assertEqual(t, sentryTransaction.Source, sentry.TransactionSource("url"))
 
 	// Span
 	assertEqual(t, sentrySpan.Name, "")
-	assertEqual(t, sentrySpan.Description, "POST /api/checkout")
+	assertEqual(t, sentrySpan.Description, "POST /api/checkout2")
 	assertEqual(t, sentrySpan.Op, "http.server")
 	assertEqual(t, sentrySpan.Source, sentry.TransactionSource(""))
 }


### PR DESCRIPTION
This fixes a few cases when span description for HTTP spans was super basic (e.g. for HTTP client spans). 

So what looked like this:

![image](https://user-images.githubusercontent.com/1120468/228575476-3bfe48d7-8063-48c7-ae64-b304c93822db.png)

https://sentry-sdks.sentry.io/performance/otel-demo-checkoutservice:64da25426e624ac89e9dc0789207100d/?environment=production-dev&project=4504524774047744&query=&referrer=performance-transaction-summary&statsPeriod=1h&transaction=hipstershop.CheckoutService%2FPlaceOrder&unselectedSeries=p100%28%29

...is now this:

![image](https://user-images.githubusercontent.com/1120468/228574944-7b0c4aa0-d93e-4be0-af09-cfa50005b997.png)

https://sentry-sdks.sentry.io/performance/otel-demo-checkoutservice:366ed120baf0449c8b9af96b89482692/?environment=staging-dev&project=4504524774047744&query=&statsPeriod=1h&transaction=hipstershop.CheckoutService%2FPlaceOrder#span-6e440558257cee22

Fixes #557, part of https://github.com/getsentry/team-webplatform-meta/issues/32