### PR TITLE
fix(tracing): Add WithTransactionSource() span option, deprecate TransctionSource()

### DIFF
--- a/dynamic_sampling_context_test.go
+++ b/dynamic_sampling_context_test.go
@@ -90,7 +90,7 @@ func TestDynamicSamplingContextFromTransaction(t *testing.T) {
 				hubFromContext(ctx).ConfigureScope(func(scope *Scope) {
 					scope.SetUser(User{Segment: "user_segment"})
 				})
-				txn := StartTransaction(ctx, "name", TransctionSource(SourceCustom))
+				txn := StartTransaction(ctx, "name", WithTransactionSource(SourceCustom))
 				txn.TraceID = TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03")
 				return txn
 			}(),
@@ -116,7 +116,7 @@ func TestDynamicSamplingContextFromTransaction(t *testing.T) {
 					Dsn:              "http://public@example.com/sentry/1",
 					Release:          "1.0.0",
 				})
-				txn := StartTransaction(ctx, "name", TransctionSource(SourceURL))
+				txn := StartTransaction(ctx, "name", WithTransactionSource(SourceURL))
 				txn.TraceID = TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03")
 				return txn
 			}(),

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -89,7 +89,7 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 		options := []sentry.SpanOption{
 			sentry.OpName("http.server"),
 			sentry.ContinueFromRequest(r),
-			sentry.TransctionSource(sentry.SourceURL),
+			sentry.WithTransactionSource(sentry.SourceURL),
 		}
 		// We don't mind getting an existing transaction back so we don't need to
 		// check if it is.

--- a/tracing.go
+++ b/tracing.go
@@ -786,8 +786,14 @@ func OpName(name string) SpanOption {
 }
 
 // TransctionSource sets the source of the transaction name.
-// TODO(anton): Fix the typo.
+//
+// Deprecated: Use WithTransactionSource() instead.
 func TransctionSource(source TransactionSource) SpanOption {
+	return WithTransactionSource(source)
+}
+
+// WithTransactionSource sets the source of the transaction name.
+func WithTransactionSource(source TransactionSource) SpanOption {
 	return func(s *Span) {
 		s.Source = source
 	}


### PR DESCRIPTION
This deprecates TransctionSource() (which has a typo and therefore might confuse people) in favor of WithTransactionSource(). "TransactionSource" type already exists, hence the "With" prefix.

TransctionSource() is not removed right away, instead we should add a deprecation note in the changelog of the next release.