### PR TITLE
doc: Update attributions for vendored "baggage"

### DIFF
--- a/internal/otel/baggage/baggage.go
+++ b/internal/otel/baggage/baggage.go
@@ -1,4 +1,6 @@
-// # Copyright The OpenTelemetry Authors
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/c21b6b6bb31a2f74edd06e262f1690f3f6ea3d5c/baggage/baggage.go
+//
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/otel/baggage/baggage_test.go
+++ b/internal/otel/baggage/baggage_test.go
@@ -1,3 +1,5 @@
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/c21b6b6bb31a2f74edd06e262f1690f3f6ea3d5c/baggage/baggage_test.go
+//
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/otel/baggage/internal/baggage/baggage.go
+++ b/internal/otel/baggage/internal/baggage/baggage.go
@@ -1,5 +1,4 @@
-// This file was vendored in unmodified from
-// https://github.com/open-telemetry/opentelemetry-go/blob/c21b6b6bb31a2f74edd06e262f1690f3f6ea3d5c/internal/baggage/baggage.go
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/c21b6b6bb31a2f74edd06e262f1690f3f6ea3d5c/internal/baggage/baggage.go
 //
 // Copyright The OpenTelemetry Authors
 //


### PR DESCRIPTION
"internal/otel/baggage" package was initially vendored from opentelemetry-go, and then later we made some updates to it. According to our new attribution policy, adding some links to the original files (copyright notes are already there).

Ref https://github.com/getsentry/team-webplatform-meta/issues/42, https://github.com/getsentry/team-ospo/issues/120

AFAIK this is the only place where we need to attribute 3rd party code.