### PR TITLE
fix(build): Temporarily remove otel module when building in GOPATH mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,10 @@ jobs:
           # Iris requires Module mode, therefore we delete the relevant code to
           # skip testing it in GOPATH mode.
           rm -vrf ./iris/ ./_examples/iris/
+
+          # OTel module cannot be built right now with Go 1.18 because the latest "main" of
+          # opentelemetry-go use Go 1.19 features.
+          rm -vrf ./otel/
       - name: Download Dependencies
         run: go get -d -t -v ./...
       - name: Build


### PR DESCRIPTION
Looks like the GOPATH tests are failing because opentelemetry-go now has 1.19+ symbols (`atomic.Bool`, `atomic.Pointer`) in their main branch.

Example: https://github.com/getsentry/sentry-go/actions/runs/4563862504/jobs/8052889793

![image](https://user-images.githubusercontent.com/1120468/228841811-8c619b52-dfbc-4ad7-980c-3a9dcf5b22da.png)

We might want to consider dropping the GOPATH builds/support altogether. Opened https://github.com/getsentry/sentry-go/issues/616 to discuss that.
