### PR TITLE
fix(ci): Increase timeout for golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           version: v1.51
           only-new-issues: true
+          args: --timeout=10m
     timeout-minutes: 10


### PR DESCRIPTION
Sometimes we're getting timeouts because the linting step cannot finish within 1 minute, so let's try to raise the timeout.
Example of the timeout: https://github.com/getsentry/sentry-go/actions/runs/4563862500/jobs/8052889794

Most of the time the step takes just a few seconds, but sometimes it doesn't 🤷  Taking the easiest way out for now.