### PR TITLE
fix(ci): Fail properly on "vet", "mod-tidy", and "coverage" steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir  ## Test with coverage en
 .PHONY: test-coverage clean-report-dir
 
 mod-tidy: ## Check go.mod tidiness
+	set -e ; \
 	for dir in $(ALL_GO_MOD_DIRS); do \
 		cd "$${dir}"; \
 		echo ">>> Running 'go mod tidy' for module: $${dir}"; \
@@ -64,6 +65,7 @@ mod-tidy: ## Check go.mod tidiness
 .PHONY: mod-tidy
 
 vet: ## Run "go vet"
+	set -e ; \
 	for dir in $(ALL_GO_MOD_DIRS); do \
 		cd "$${dir}"; \
 		echo ">>> Running 'go vet' for module: $${dir}"; \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ $(COVERAGE_REPORT_DIR):
 clean-report-dir: $(COVERAGE_REPORT_DIR)
 	test $(COVERAGE_REPORT_DIR) && rm -f $(COVERAGE_REPORT_DIR)/*
 test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir  ## Test with coverage enabled
+	set -e ; \
 	for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo ">>> Running tests with coverage for module: $${dir}"; \
 	  DIR_ABS=$$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $${dir}) ; \


### PR DESCRIPTION
In https://github.com/getsentry/sentry-go/pull/609 we noticed that "make vet" was failing on one of the modules ([GA job](https://github.com/getsentry/sentry-go/actions/runs/4597405388/jobs/8120054588)), but the CI job was actually green.
Here we're fixing it by telling bash to exit on any non-zero return code.