### PR TITLE
ref: Add span options aliases (WithSpanSampled, WithOpName, WithTransactionName)

### DIFF
--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -87,7 +87,7 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 		options := []sentry.SpanOption{
-			sentry.OpName("http.server"),
+			sentry.WithOpName("http.server"),
 			sentry.ContinueFromRequest(r),
 			sentry.WithTransactionSource(sentry.SourceURL),
 		}

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -32,7 +32,7 @@ func createTransactionAndMaybeSpan(transactionContext transactionTestContext, wi
 	transaction := sentry.StartTransaction(
 		emptyContextWithSentry(),
 		transactionContext.name,
-		sentry.SpanSampled(transactionContext.sampled),
+		sentry.WithSpanSampled(transactionContext.sampled),
 	)
 	transaction.TraceID = TraceIDFromHex(transactionContext.traceID)
 	transaction.SpanID = SpanIDFromHex(transactionContext.spanID)

--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -50,7 +50,7 @@ func (ssp *sentrySpanProcessor) OnStart(parent context.Context, s otelSdkTrace.R
 		transaction := sentry.StartTransaction(
 			parent,
 			s.Name(),
-			sentry.SpanSampled(traceParentContext.Sampled),
+			sentry.WithSpanSampled(traceParentContext.Sampled),
 		)
 		transaction.SpanID = sentry.SpanID(otelSpanID)
 		transaction.TraceID = sentry.TraceID(otelTraceID)

--- a/tracing.go
+++ b/tracing.go
@@ -787,7 +787,18 @@ type SpanOption func(s *Span)
 // A span tree has a single transaction name, therefore using this option when
 // starting a span affects the span tree as a whole, potentially overwriting a
 // name set previously.
+//
+// Deprecated: Use WithTransactionSource() instead.
 func TransactionName(name string) SpanOption {
+	return WithTransactionName(name)
+}
+
+// WithTransactionName option sets the name of the current transaction.
+//
+// A span tree has a single transaction name, therefore using this option when
+// starting a span affects the span tree as a whole, potentially overwriting a
+// name set previously.
+func WithTransactionName(name string) SpanOption {
 	return func(s *Span) {
 		s.Name = name
 	}
@@ -911,7 +922,7 @@ func StartTransaction(ctx context.Context, name string, options ...SpanOption) *
 		return currentTransaction
 	}
 
-	options = append(options, TransactionName(name))
+	options = append(options, WithTransactionName(name))
 	return StartSpan(
 		ctx,
 		"",

--- a/tracing.go
+++ b/tracing.go
@@ -805,7 +805,14 @@ func WithTransactionName(name string) SpanOption {
 }
 
 // OpName sets the operation name for a given span.
+//
+// Deprecated: Use WithOpName instead.
 func OpName(name string) SpanOption {
+	return WithOpName(name)
+}
+
+// WithOpName sets the operation name for a given span.
+func WithOpName(name string) SpanOption {
 	return func(s *Span) {
 		s.Op = name
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -833,7 +833,14 @@ func WithTransactionSource(source TransactionSource) SpanOption {
 }
 
 // SpanSampled updates the sampling flag for a given span.
+//
+// Deprecated: Use WithSpanSampled() instead
 func SpanSampled(sampled Sampled) SpanOption {
+	return WithSpanSampled(sampled)
+}
+
+// SpanSampled updates the sampling flag for a given span.
+func WithSpanSampled(sampled Sampled) SpanOption {
 	return func(s *Span) {
 		s.Sampled = sampled
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -806,7 +806,7 @@ func WithTransactionName(name string) SpanOption {
 
 // OpName sets the operation name for a given span.
 //
-// Deprecated: Use WithOpName instead.
+// Deprecated: Use WithOpName() instead.
 func OpName(name string) SpanOption {
 	return WithOpName(name)
 }
@@ -839,7 +839,7 @@ func SpanSampled(sampled Sampled) SpanOption {
 	return WithSpanSampled(sampled)
 }
 
-// SpanSampled updates the sampling flag for a given span.
+// WithSpanSampled updates the sampling flag for a given span.
 func WithSpanSampled(sampled Sampled) SpanOption {
 	return func(s *Span) {
 		s.Sampled = sampled

--- a/tracing.go
+++ b/tracing.go
@@ -834,7 +834,7 @@ func WithTransactionSource(source TransactionSource) SpanOption {
 
 // SpanSampled updates the sampling flag for a given span.
 //
-// Deprecated: Use WithSpanSampled() instead
+// Deprecated: Use WithSpanSampled() instead.
 func SpanSampled(sampled Sampled) SpanOption {
 	return WithSpanSampled(sampled)
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -885,3 +885,8 @@ func TestDeprecatedSpanOptionOpName(t *testing.T) {
 func TestDeprecatedSpanOptionSpanSampled(t *testing.T) {
 	StartSpan(context.Background(), "op", SpanSampled(SampledTrue))
 }
+
+// This test should be the only thing to fail when deprecated TransctionSource is removed.
+func TestDeprecatedSpanOptionTransctionSource(t *testing.T) {
+	StartSpan(context.Background(), "op", TransctionSource("src"))
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -875,3 +875,8 @@ func TestSpanSetContextOverrides(t *testing.T) {
 func TestDeprecatedSpanOptionTransactionName(t *testing.T) {
 	StartSpan(context.Background(), "op", TransactionName("name"))
 }
+
+// This test should be the only thing to fail when deprecated OpName is removed
+func TestDeprecatedSpanOptionOpName(t *testing.T) {
+	StartSpan(context.Background(), "op", OpName("name"))
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -871,17 +871,17 @@ func TestSpanSetContextOverrides(t *testing.T) {
 	assertEqual(t, map[string]Context{"a": {"foo": 2}}, transaction.contexts)
 }
 
-// This test should be the only thing to fail when deprecated TransactionName is removed
+// This test should be the only thing to fail when deprecated TransactionName is removed.
 func TestDeprecatedSpanOptionTransactionName(t *testing.T) {
 	StartSpan(context.Background(), "op", TransactionName("name"))
 }
 
-// This test should be the only thing to fail when deprecated OpName is removed
+// This test should be the only thing to fail when deprecated OpName is removed.
 func TestDeprecatedSpanOptionOpName(t *testing.T) {
 	StartSpan(context.Background(), "op", OpName("name"))
 }
 
-// This test should be the only thing to fail when deprecated SpanSampled is removed
+// This test should be the only thing to fail when deprecated SpanSampled is removed.
 func TestDeprecatedSpanOptionSpanSampled(t *testing.T) {
 	StartSpan(context.Background(), "op", SpanSampled(SampledTrue))
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -106,7 +106,7 @@ func TestStartSpan(t *testing.T) {
 		"k": "v",
 	}
 	span := StartSpan(ctx, op,
-		TransactionName(transaction),
+		WithTransactionName(transaction),
 		func(s *Span) {
 			s.Description = description
 			s.Status = status
@@ -177,7 +177,7 @@ func TestStartChild(t *testing.T) {
 		TracesSampleRate: 1.0,
 		Transport:        transport,
 	})
-	span := StartSpan(ctx, "top", TransactionName("Test Transaction"))
+	span := StartSpan(ctx, "top", WithTransactionName("Test Transaction"))
 	child := span.StartChild("child")
 	child.Finish()
 	span.Finish()
@@ -611,7 +611,7 @@ func TestDoubleSampling(t *testing.T) {
 		TracesSampleRate: 1.0,
 		Transport:        transport,
 	})
-	span := StartSpan(ctx, "op", TransactionName("name"))
+	span := StartSpan(ctx, "op", WithTransactionName("name"))
 
 	// CaptureException should not send any event because of SampleRate.
 	GetHubFromContext(ctx).CaptureException(errors.New("ignored"))
@@ -638,7 +638,7 @@ func TestSample(t *testing.T) {
 	ctx = NewTestContext(ClientOptions{
 		EnableTracing: false,
 	})
-	span = StartSpan(ctx, "op", TransactionName("name"))
+	span = StartSpan(ctx, "op", WithTransactionName("name"))
 	if got := span.Sampled; got != SampledFalse {
 		t.Fatalf("got %s, want %s", got, SampledFalse)
 	}
@@ -648,7 +648,7 @@ func TestSample(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 0.0,
 	})
-	span = StartSpan(ctx, "op", TransactionName("name"), SpanSampled(SampledTrue))
+	span = StartSpan(ctx, "op", WithTransactionName("name"), SpanSampled(SampledTrue))
 	if got := span.Sampled; got != SampledTrue {
 		t.Fatalf("got %s, want %s", got, SampledTrue)
 	}
@@ -660,7 +660,7 @@ func TestSample(t *testing.T) {
 			return 1.0
 		},
 	})
-	span = StartSpan(ctx, "op", TransactionName("name"))
+	span = StartSpan(ctx, "op", WithTransactionName("name"))
 	if got := span.Sampled; got != SampledTrue {
 		t.Fatalf("got %s, want %s", got, SampledTrue)
 	}
@@ -670,7 +670,7 @@ func TestSample(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 	})
-	span = StartSpan(ctx, "op", TransactionName("name"))
+	span = StartSpan(ctx, "op", WithTransactionName("name"))
 	childSpan := span.StartChild("child")
 	if got := childSpan.Sampled; got != SampledTrue {
 		t.Fatalf("got %s, want %s", got, SampledTrue)
@@ -681,7 +681,7 @@ func TestSample(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 	})
-	span = StartSpan(ctx, "op", TransactionName("name"))
+	span = StartSpan(ctx, "op", WithTransactionName("name"))
 	if got := span.Sampled; got != SampledTrue {
 		t.Fatalf("got %s, want %s", got, SampledTrue)
 	}
@@ -869,4 +869,9 @@ func TestSpanSetContextOverrides(t *testing.T) {
 	transaction.SetContext("a", Context{"foo": 2})
 
 	assertEqual(t, map[string]Context{"a": {"foo": 2}}, transaction.contexts)
+}
+
+// This test should be the only thing to fail when deprecated TransactionName is removed
+func TestDeprecatedSpanOptionTransactionName(t *testing.T) {
+	StartSpan(context.Background(), "op", TransactionName("name"))
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -648,7 +648,7 @@ func TestSample(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 0.0,
 	})
-	span = StartSpan(ctx, "op", WithTransactionName("name"), SpanSampled(SampledTrue))
+	span = StartSpan(ctx, "op", WithTransactionName("name"), WithSpanSampled(SampledTrue))
 	if got := span.Sampled; got != SampledTrue {
 		t.Fatalf("got %s, want %s", got, SampledTrue)
 	}
@@ -879,4 +879,9 @@ func TestDeprecatedSpanOptionTransactionName(t *testing.T) {
 // This test should be the only thing to fail when deprecated OpName is removed
 func TestDeprecatedSpanOptionOpName(t *testing.T) {
 	StartSpan(context.Background(), "op", OpName("name"))
+}
+
+// This test should be the only thing to fail when deprecated SpanSampled is removed
+func TestDeprecatedSpanOptionSpanSampled(t *testing.T) {
+	StartSpan(context.Background(), "op", SpanSampled(SampledTrue))
 }


### PR DESCRIPTION
As a follow-up to #611, let's unify the (applicable) span options by prefixing them with "With":

SpanSampled -> WithSpanSampled
OpName -> WithOpName
TransactionName -> WithTransactionName

The original names are deprecated: not removed right away, but there's a task to do it in a version or two: https://github.com/getsentry/sentry-go/issues/625

Not touching `ContinueFromRequest`, `ContinueFromHeaders`, and `ContinueFromTrace` since they have slightly different semantics.

**Why?**

1. Without the prefix some newly introduced span option names collide with existing types names and/or Span fields.
2. This is a common pattern e.g. in OpenTelemetry: https://github.com/open-telemetry/opentelemetry-go/blob/1b55281859bfaf4b03b7968a059c5239cf8c7a20/trace/config.go#L278-L333

**Note:** some docs will have to be updated after this change is released.