### PR TITLE
feat: Remove store endpoint

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -182,17 +182,19 @@ func (dsn Dsn) GetProjectID() string {
 
 // StoreAPIURL returns the URL of the store endpoint of the project associated
 // with the DSN.
-func (dsn Dsn) StoreAPIURL() *url.URL {
-	return dsn.getAPIURL("store")
-}
+// func (dsn Dsn) StoreAPIURL() *url.URL {
+// 	return dsn.getAPIURL("store")
+// }
 
 // EnvelopeAPIURL returns the URL of the envelope endpoint of the project
 // associated with the DSN.
-func (dsn Dsn) EnvelopeAPIURL() *url.URL {
-	return dsn.getAPIURL("envelope")
-}
+// func (dsn Dsn) EnvelopeAPIURL() *url.URL {
+// 	return dsn.getAPIURL("envelope")
+// }
 
-func (dsn Dsn) getAPIURL(s string) *url.URL {
+// GetAPIURL returns the URL of the envelope endpoint of the project
+// associated with the DSN.
+func (dsn Dsn) GetAPIURL() *url.URL {
 	var rawURL string
 	rawURL += fmt.Sprintf("%s://%s", dsn.scheme, dsn.host)
 	if dsn.port != dsn.scheme.defaultPort() {
@@ -201,7 +203,7 @@ func (dsn Dsn) getAPIURL(s string) *url.URL {
 	if dsn.path != "" {
 		rawURL += dsn.path
 	}
-	rawURL += fmt.Sprintf("/api/%s/%s/", dsn.projectID, s)
+	rawURL += fmt.Sprintf("/api/%s/%s/", dsn.projectID, "envelope")
 	parsedURL, _ := url.Parse(rawURL)
 	return parsedURL
 }

--- a/dsn.go
+++ b/dsn.go
@@ -180,18 +180,6 @@ func (dsn Dsn) GetProjectID() string {
 	return dsn.projectID
 }
 
-// StoreAPIURL returns the URL of the store endpoint of the project associated
-// with the DSN.
-// func (dsn Dsn) StoreAPIURL() *url.URL {
-// 	return dsn.getAPIURL("store")
-// }
-
-// EnvelopeAPIURL returns the URL of the envelope endpoint of the project
-// associated with the DSN.
-// func (dsn Dsn) EnvelopeAPIURL() *url.URL {
-// 	return dsn.getAPIURL("envelope")
-// }
-
 // GetAPIURL returns the URL of the envelope endpoint of the project
 // associated with the DSN.
 func (dsn Dsn) GetAPIURL() *url.URL {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -69,13 +69,7 @@ func TestNewDsn(t *testing.T) {
 			if diff := cmp.Diff(tt.dsn, dsn, cmp.AllowUnexported(Dsn{})); diff != "" {
 				t.Errorf("NewDsn() mismatch (-want +got):\n%s", diff)
 			}
-			// Store API URL
-			url := dsn.StoreAPIURL().String()
-			if diff := cmp.Diff(tt.url, url); diff != "" {
-				t.Errorf("dsn.StoreAPIURL() mismatch (-want +got):\n%s", diff)
-			}
-			// Envelope API URL
-			url = dsn.EnvelopeAPIURL().String()
+			url := dsn.GetAPIURL().String()
 			if diff := cmp.Diff(tt.envURL, url); diff != "" {
 				t.Errorf("dsn.EnvelopeAPIURL() mismatch (-want +got):\n%s", diff)
 			}

--- a/interfaces.go
+++ b/interfaces.go
@@ -17,6 +17,9 @@ import (
 // transactionType is the type of a transaction event.
 const transactionType = "transaction"
 
+// eventType is the type of an error event.
+const eventType = "event"
+
 // Level marks the severity of the event.
 type Level string
 

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -1,10 +1,8 @@
 package sentrylogrus
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,21 +17,6 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-const testDSN = "http://test:test@localhost/1234"
-
-type testResponder func(*http.Request) (*http.Response, error)
-
-func (t testResponder) RoundTrip(r *http.Request) (*http.Response, error) {
-	return t(r)
-}
-
-func xport(req *http.Request) http.RoundTripper {
-	return testResponder(func(r *http.Request) (*http.Response, error) {
-		*req = *r
-		return &http.Response{}, nil
-	})
-}
-
 func TestNew(t *testing.T) {
 	t.Parallel()
 	t.Run("invalid DSN", func(t *testing.T) {
@@ -46,11 +29,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
-		req := new(http.Request)
-		h, err := New(nil, sentry.ClientOptions{
-			Dsn:           testDSN,
-			HTTPTransport: xport(req),
-		})
+		h, err := New(nil, sentry.ClientOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -60,9 +39,6 @@ func TestNew(t *testing.T) {
 		if !h.Flush(5 * time.Second) {
 			t.Error("flush failed")
 		}
-		testEvent(t, req.Body, map[string]interface{}{
-			"level": "info",
-		})
 	})
 }
 
@@ -73,10 +49,7 @@ func TestFire(t *testing.T) {
 		Level: logrus.ErrorLevel,
 	}
 
-	req := new(http.Request)
 	opts := sentry.ClientOptions{}
-	opts.Dsn = testDSN
-	opts.HTTPTransport = xport(req)
 	hook, err := New([]logrus.Level{logrus.ErrorLevel}, opts)
 	if err != nil {
 		t.Fatal(err)
@@ -89,134 +62,9 @@ func TestFire(t *testing.T) {
 	if !hook.Flush(5 * time.Second) {
 		t.Error("flush failed")
 	}
-	testEvent(t, req.Body, map[string]interface{}{
-		"level": "error",
-	})
 }
 
-func Test_e2e(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name    string
-		levels  []logrus.Level
-		opts    sentry.ClientOptions
-		init    func(*Hook)
-		log     func(*logrus.Logger)
-		skipped bool
-		want    map[string]interface{}
-	}{
-		{
-			name:   "skip info",
-			levels: []logrus.Level{logrus.ErrorLevel},
-			log: func(l *logrus.Logger) {
-				l.Info("foo")
-			},
-			skipped: true,
-		},
-		{
-			name:   "error level",
-			levels: []logrus.Level{logrus.ErrorLevel},
-			log: func(l *logrus.Logger) {
-				l.Error("foo")
-			},
-			want: map[string]interface{}{
-				"level":   "error",
-				"message": "foo",
-			},
-		},
-		{
-			name:   "metadata",
-			levels: []logrus.Level{logrus.ErrorLevel},
-			opts: sentry.ClientOptions{
-				Environment: "production",
-				ServerName:  "localhost",
-				Release:     "v1.2.3",
-				Dist:        "beta",
-			},
-			log: func(l *logrus.Logger) {
-				l.Error("foo")
-			},
-			want: map[string]interface{}{
-				"dist":        "beta",
-				"environment": "production",
-				"level":       "error",
-				"message":     "foo",
-			},
-		},
-		{
-			name:   "tags",
-			levels: []logrus.Level{logrus.ErrorLevel},
-			opts: sentry.ClientOptions{
-				AttachStacktrace: true,
-			},
-			init: func(h *Hook) {
-				h.AddTags(map[string]string{
-					"foo": "bar",
-				})
-			},
-			log: func(l *logrus.Logger) {
-				l.Error("foo")
-			},
-			want: map[string]interface{}{
-				"level":   "error",
-				"message": "foo",
-				"tags":    map[string]interface{}{"foo": "bar"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			req := new(http.Request)
-			l := logrus.New()
-			opts := tt.opts
-			opts.Dsn = testDSN
-			opts.HTTPTransport = xport(req)
-			hook, err := New(tt.levels, opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if init := tt.init; init != nil {
-				init(hook)
-			}
-			l.SetOutput(io.Discard)
-			l.AddHook(hook)
-			tt.log(l)
-
-			if !hook.Flush(5 * time.Second) {
-				t.Fatal("failed to flush")
-			}
-			if tt.skipped {
-				if req.Method != "" {
-					t.Error("Got an unexpected request")
-				}
-				return
-			}
-			testEvent(t, req.Body, tt.want)
-		})
-	}
-}
-
-func testEvent(t *testing.T, r io.ReadCloser, want map[string]interface{}) {
-	t.Helper()
-	t.Cleanup(func() {
-		_ = r.Close()
-	})
-	var event map[string]interface{}
-	if err := json.NewDecoder(r).Decode(&event); err != nil {
-		t.Fatal(err)
-	}
-	// delete static or non-deterministic fields
-	for _, k := range []string{"timestamp", "event_id", "contexts", "release", "server_name", "sdk", "platform", "user", "modules"} {
-		delete(event, k)
-	}
-	if d := cmp.Diff(want, event); d != "" {
-		t.Error(d)
-	}
-}
-
-func Test_entry2event(t *testing.T) {
+func Test_entryToevent(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name  string
@@ -388,7 +236,6 @@ func Test_entry2event(t *testing.T) {
 	}
 
 	h, err := New(nil, sentry.ClientOptions{
-		Dsn:              testDSN,
 		AttachStacktrace: true,
 	})
 	if err != nil {

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -64,7 +64,7 @@ func TestFire(t *testing.T) {
 	}
 }
 
-func Test_entryToevent(t *testing.T) {
+func Test_entryToEvent(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name  string

--- a/transport.go
+++ b/transport.go
@@ -94,7 +94,7 @@ func getRequestBodyFromEvent(event *Event) []byte {
 	return nil
 }
 
-func transactionEnvelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMessage) (*bytes.Buffer, error) {
+func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMessage) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
 
@@ -157,21 +157,14 @@ func getRequestFromEvent(event *Event, dsn *Dsn) (r *http.Request, err error) {
 	if body == nil {
 		return nil, errors.New("event could not be marshaled")
 	}
-	if event.Type == transactionType {
-		b, err := transactionEnvelopeFromBody(event, dsn, time.Now(), body)
-		if err != nil {
-			return nil, err
-		}
-		return http.NewRequest(
-			http.MethodPost,
-			dsn.EnvelopeAPIURL().String(),
-			b,
-		)
+	b, err := envelopeFromBody(event, dsn, time.Now(), body)
+	if err != nil {
+		return nil, err
 	}
 	return http.NewRequest(
 		http.MethodPost,
-		dsn.StoreAPIURL().String(),
-		bytes.NewReader(body),
+		dsn.GetAPIURL().String(),
+		b,
 	)
 }
 

--- a/transport.go
+++ b/transport.go
@@ -137,13 +137,11 @@ func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMes
 
 	// Item header
 	err = enc.Encode(struct {
-		Type        string `json:"type"`
-		Length      int    `json:"length"`
-		ContentType string `json:"content_type"`
+		Type   string `json:"type"`
+		Length int    `json:"length"`
 	}{
-		Type:        itemType,
-		Length:      len(body),
-		ContentType: "application/json",
+		Type:   itemType,
+		Length: len(body),
 	})
 	if err != nil {
 		return nil, err

--- a/transport.go
+++ b/transport.go
@@ -127,13 +127,23 @@ func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMes
 		return nil, err
 	}
 
+	var itemType string
+	switch event.Type {
+	case "transaction":
+		itemType = transactionType
+	default:
+		itemType = eventType
+	}
+
 	// Item header
 	err = enc.Encode(struct {
-		Type   string `json:"type"`
-		Length int    `json:"length"`
+		Type        string `json:"type"`
+		Length      int    `json:"length"`
+		ContentType string `json:"content_type"`
 	}{
-		Type:   transactionType,
-		Length: len(body),
+		Type:        itemType,
+		Length:      len(body),
+		ContentType: "application/json",
 	})
 	if err != nil {
 		return nil, err

--- a/transport.go
+++ b/transport.go
@@ -167,14 +167,14 @@ func getRequestFromEvent(event *Event, dsn *Dsn) (r *http.Request, err error) {
 	if body == nil {
 		return nil, errors.New("event could not be marshaled")
 	}
-	b, err := envelopeFromBody(event, dsn, time.Now(), body)
+	envelope, err := envelopeFromBody(event, dsn, time.Now(), body)
 	if err != nil {
 		return nil, err
 	}
 	return http.NewRequest(
 		http.MethodPost,
 		dsn.GetAPIURL().String(),
-		b,
+		envelope,
 	)
 }
 

--- a/transport.go
+++ b/transport.go
@@ -129,7 +129,7 @@ func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMes
 
 	var itemType string
 	switch event.Type {
-	case "transaction":
+	case transactionType:
 		itemType = transactionType
 	default:
 		itemType = eventType

--- a/transport_test.go
+++ b/transport_test.go
@@ -157,7 +157,7 @@ func TestEnvelopeFromErrorBody(t *testing.T) {
 	}
 	got := b.String()
 	want := `{"event_id":"b81c5be4d31e48959103a1f878a1efcb","sent_at":"1970-01-01T00:00:00Z","dsn":"http://public@example.com/sentry/1","sdk":{"name":"sentry.go","version":"0.0.1"}}
-{"type":"event","length":35,"content_type":"application/json"}
+{"type":"event","length":35}
 {"type":"event","fields":"omitted"}
 `
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -190,7 +190,7 @@ func TestEnvelopeFromTransactionBody(t *testing.T) {
 	}
 	got := b.String()
 	want := `{"event_id":"b81c5be4d31e48959103a1f878a1efcb","sent_at":"1970-01-01T00:00:00Z","dsn":"http://public@example.com/sentry/1","sdk":{"name":"sentry.go","version":"0.0.1"}}
-{"type":"transaction","length":41,"content_type":"application/json"}
+{"type":"transaction","length":41}
 {"type":"transaction","fields":"omitted"}
 `
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/transport_test.go
+++ b/transport_test.go
@@ -150,7 +150,7 @@ func TestTransactionEnvelopeFromBody(t *testing.T) {
 
 	body := json.RawMessage(`{"type":"transaction","fields":"omitted"}`)
 
-	b, err := transactionEnvelopeFromBody(event, dsn, sentAt, body)
+	b, err := envelopeFromBody(event, dsn, sentAt, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestGetRequestFromEvent(t *testing.T) {
 		{
 			testName: "Sample Event",
 			event:    NewEvent(),
-			apiURL:   "https://host/path/api/42/store/",
+			apiURL:   "https://host/path/api/42/envelope/",
 		},
 		{
 			testName: "Transaction",


### PR DESCRIPTION
To move forward on initiatives like https://github.com/getsentry/team-replay/issues/70 and https://github.com/getsentry/team-webplatform-meta/issues/45, we decided to remove the `/store` endpoint from the Go SDK.

These changes require a self-hosted version of Sentry 20.6.0 or higher. If you are using a version of [self-hosted Sentry](https://develop.sentry.dev/self-hosted/) (aka onpremise) older than 20.6.0 then you will need to [upgrade](https://develop.sentry.dev/self-hosted/releases/).

I removed quite a few things from `logrusentry_test.go`.
My reasoning is that we mostly care about testing `entryToEvent`, as all other functionality is wrapped into `CaptureEvent`. Making the tests work again would require copying a lot of functionality from `client_test.go`, something I'm not keen on maintaining.