### PR TITLE
fix: Improve isSentryRequestUrl

### DIFF
--- a/otel/internal/utils/sentryrequest.go
+++ b/otel/internal/utils/sentryrequest.go
@@ -27,7 +27,10 @@ func IsSentryRequestSpan(ctx context.Context, s trace.ReadOnlySpan) bool {
 func isSentryRequestUrl(ctx context.Context, url string) bool {
 	hub := sentry.GetHubFromContext(ctx)
 	if hub == nil {
-		return false
+		hub = sentry.CurrentHub()
+		if hub == nil {
+			return false
+		}
 	}
 
 	client := hub.Client()
@@ -36,5 +39,5 @@ func isSentryRequestUrl(ctx context.Context, url string) bool {
 	}
 
 	dsn, _ := sentry.NewDsn(client.Options().Dsn)
-	return strings.Contains(url, dsn.GetHost())
+	return strings.Contains(url, dsn.GetHost()) && strings.Contains(url, dsn.GetProjectID())
 }

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -313,7 +313,7 @@ func TestOnEndDoesNotFinishSentryRequests(t *testing.T) {
 		emptyContextWithSentry(),
 		"POST to Sentry",
 		// Hostname is same as in Sentry DSN
-		trace.WithAttributes(attribute.String("http.url", "https://example.com/sub/route")),
+		trace.WithAttributes(attribute.String("http.url", "https://example.com/123")),
 	)
 	sentrySpan, _ := sentrySpanMap.Get(otelSpan.SpanContext().SpanID())
 	otelSpan.End()


### PR DESCRIPTION
If we can't fetch a hub from the `ctx`, we now fallback to the global hub.
I also added the project id to not solely rely on the hostname.