### PR TITLE
doc: Prepare 0.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Note: this release includes some **deprecations**, which are listed below.
   * It can be used to set or add errors to an existing `Event`.
 
 ### Bug Fixes
-* Protect from concurrent reads/writes to Span data fields ([#609](https://github.com/getsentry/sentry-go/pull/609))
+* Protect from panics while doing concurrent reads/writes to Span data fields ([#609](https://github.com/getsentry/sentry-go/pull/609))
 * [otel] Improve detection of Sentry-related spans ([#632](https://github.com/getsentry/sentry-go/pull/632))
   * Fixes cases when HTTP spans containing requests to Sentry were captured by Sentry ([#627](https://github.com/getsentry/sentry-go/issues/627))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.21.0
+
+Note: this release includes some **deprecations**, which are listed below.
+
+### Features
+* Rename three span option functions ([#624](https://github.com/getsentry/sentry-go/pull/624))
+  * `SpanSampled` -> `WithSpanSampled`
+  * `OpName` -> `WithOpName`
+  * `TransactionName` -> `WithTransactionName`
+  * Old functions `SpanSampled`, `OpName`, and `TransactionName` are still available but are now **deprecated**, and will be removed in future releases.
+* Make `client.EventFromMessage`, `client.EventFromException` methods public ([#607](https://github.com/getsentry/sentry-go/pull/607))
+* Add `client.SetException` method ([#607](https://github.com/getsentry/sentry-go/pull/607))
+  * It can be used to set or add errors to an existing `Event`.
+
+### Bug Fixes
+* Protect from concurrent reads/writes to Span data fields ([#609](https://github.com/getsentry/sentry-go/pull/609))
+* [otel] Improve detection of Sentry-related spans ([#632](https://github.com/getsentry/sentry-go/pull/632))
+  * Fixes cases when HTTP spans containing requests to Sentry were captured by Sentry ([#627](https://github.com/getsentry/sentry-go/issues/627))
+
+### Misc
+* Drop testing in (legacy) GOPATH mode ([#618](https://github.com/getsentry/sentry-go/pull/618))
+* Remove outdated documentation from https://pkg.go.dev/github.com/getsentry/sentry-go ([#623](https://github.com/getsentry/sentry-go/pull/623))
+
 ## 0.20.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.20.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,38 @@
 
 ## 0.21.0
 
-Note: this release includes some **deprecations**, which are listed below.
+The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.21.0.
+
+Note: this release includes one **breaking change** and some **deprecations**, which are listed below.
+
+### Breaking Changes
+
+**This change does not apply if you use [https://sentry.io](https://sentry.io)**
+
+- Remove support for the `/store` endpoint ([#631](https://github.com/getsentry/sentry-go/pull/631))
+  - This change requires a self-hosted version of Sentry 20.6.0 or higher. If you are using a version of [self-hosted Sentry](https://develop.sentry.dev/self-hosted/) (aka *on-premise*) older than 20.6.0, then you will need to [upgrade](https://develop.sentry.dev/self-hosted/releases/) your instance.
 
 ### Features
-* Rename three span option functions ([#624](https://github.com/getsentry/sentry-go/pull/624))
-  * `SpanSampled` -> `WithSpanSampled`
-  * `OpName` -> `WithOpName`
-  * `TransactionName` -> `WithTransactionName`
-  * Old functions `SpanSampled`, `OpName`, and `TransactionName` are still available but are now **deprecated**, and will be removed in future releases.
-* Make `client.EventFromMessage`, `client.EventFromException` methods public ([#607](https://github.com/getsentry/sentry-go/pull/607))
-* Add `client.SetException` method ([#607](https://github.com/getsentry/sentry-go/pull/607))
-  * It can be used to set or add errors to an existing `Event`.
+
+- Rename three span option functions ([#624](https://github.com/getsentry/sentry-go/pull/624))
+  - `SpanSampled` -> `WithSpanSampled`
+  - `OpName` -> `WithOpName`
+  - `TransactionName` -> `WithTransactionName`
+  - Old functions `SpanSampled`, `OpName`, and `TransactionName` are still available but are now **deprecated** and will be removed in a future release.
+- Make `client.EventFromMessage`, and `client.EventFromException` methods public ([#607](https://github.com/getsentry/sentry-go/pull/607))
+- Add `client.SetException` method ([#607](https://github.com/getsentry/sentry-go/pull/607))
+  - This allows to set or add errors to an existing `Event`.
 
 ### Bug Fixes
-* Protect from panics while doing concurrent reads/writes to Span data fields ([#609](https://github.com/getsentry/sentry-go/pull/609))
-* [otel] Improve detection of Sentry-related spans ([#632](https://github.com/getsentry/sentry-go/pull/632))
-  * Fixes cases when HTTP spans containing requests to Sentry were captured by Sentry ([#627](https://github.com/getsentry/sentry-go/issues/627))
+
+- Protect from panics while doing concurrent reads/writes to Span data fields ([#609](https://github.com/getsentry/sentry-go/pull/609))
+- [otel] Improve detection of Sentry-related spans ([#632](https://github.com/getsentry/sentry-go/pull/632)) & ([#636](https://github.com/getsentry/sentry-go/pull/636))
+  - Fixes cases when HTTP spans containing requests to Sentry were captured by Sentry ([#627](https://github.com/getsentry/sentry-go/issues/627))
 
 ### Misc
-* Drop testing in (legacy) GOPATH mode ([#618](https://github.com/getsentry/sentry-go/pull/618))
-* Remove outdated documentation from https://pkg.go.dev/github.com/getsentry/sentry-go ([#623](https://github.com/getsentry/sentry-go/pull/623))
+
+- Drop testing in (legacy) GOPATH mode ([#618](https://github.com/getsentry/sentry-go/pull/618))
+- Remove outdated documentation from https://pkg.go.dev/github.com/getsentry/sentry-go ([#623](https://github.com/getsentry/sentry-go/pull/623))
 
 ## 0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,20 @@ Note: this release includes one **breaking change** and some **deprecations**, w
 
 ### Features
 
-- Rename three span option functions ([#624](https://github.com/getsentry/sentry-go/pull/624))
+- Rename four span option functions ([#611](https://github.com/getsentry/sentry-go/pull/611), [#624](https://github.com/getsentry/sentry-go/pull/624))
+  - `TransctionSource` -> `WithTransactionSource`
   - `SpanSampled` -> `WithSpanSampled`
   - `OpName` -> `WithOpName`
   - `TransactionName` -> `WithTransactionName`
-  - Old functions `SpanSampled`, `OpName`, and `TransactionName` are still available but are now **deprecated** and will be removed in a future release.
-- Make `client.EventFromMessage`, and `client.EventFromException` methods public ([#607](https://github.com/getsentry/sentry-go/pull/607))
+  - Old functions `TransctionSource`, `SpanSampled`, `OpName`, and `TransactionName` are still available but are now **deprecated** and will be removed in a future release.
+- Make `client.EventFromMessage` and `client.EventFromException` methods public ([#607](https://github.com/getsentry/sentry-go/pull/607))
 - Add `client.SetException` method ([#607](https://github.com/getsentry/sentry-go/pull/607))
   - This allows to set or add errors to an existing `Event`.
 
 ### Bug Fixes
 
 - Protect from panics while doing concurrent reads/writes to Span data fields ([#609](https://github.com/getsentry/sentry-go/pull/609))
-- [otel] Improve detection of Sentry-related spans ([#632](https://github.com/getsentry/sentry-go/pull/632)) & ([#636](https://github.com/getsentry/sentry-go/pull/636))
+- [otel] Improve detection of Sentry-related spans ([#632](https://github.com/getsentry/sentry-go/pull/632), [#636](https://github.com/getsentry/sentry-go/pull/636))
   - Fixes cases when HTTP spans containing requests to Sentry were captured by Sentry ([#627](https://github.com/getsentry/sentry-go/issues/627))
 
 ### Misc


### PR DESCRIPTION
Before the release: 

* [ ] Update docs: https://github.com/getsentry/sentry-docs/pull/6871

Let's release it on Monday.