### PR TITLE
feat: add NewDefault to Gin

### DIFF
--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -46,6 +46,17 @@ func New(options Options) gin.HandlerFunc {
 	}).handle
 }
 
+// NewDefault uses optimized option and returns a function that satisfies gin.HandlerFunc interface
+// It can be used with Use() methods.
+func NewDefault() gin.HandlerFunc {
+	defaultOptions := Options{
+		Repanic:         true,
+		Timeout:         2 * time.Second,
+		WaitForDelivery: false,
+	}
+	return New(defaultOptions)
+}
+
 func (h *handler) handle(ctx *gin.Context) {
 	hub := sentry.GetHubFromContext(ctx.Request.Context())
 	if hub == nil {


### PR DESCRIPTION
I just found a scary (default) behavior

```
package main

import (
	"fmt"
	"net/http"

	sentrygin "github.com/getsentry/sentry-go/gin"
	"github.com/gin-gonic/gin"
)

func main() {
	r := gin.Default()
	r.Use(sentrygin.New(sentrygin.Options{}))
	r.Use(func(c *gin.Context) {
		panic(2)
	})
	r.GET("/", func(c *gin.Context) {
		c.JSON(http.StatusOK, gin.H{
			"message": "pong",
		})
	})
	r.Run("127.0.0.1:8080")
}
```

As a newcomer, I expected the `/` route to not be called when a panic occurred inside the middleware (auth middleware). However, due to Sentry's default configuration, the route continued to be called. This behavior made the c.Abort() calls inside the middleware useless, as they were no longer being used

I suggest safer function for a new comer

