### PR TITLE
ref: Improve isSentryRequestUrl

### DIFF
--- a/otel/internal/utils/sentryrequest.go
+++ b/otel/internal/utils/sentryrequest.go
@@ -40,4 +40,10 @@ func isSentryRequestUrl(ctx context.Context, url string) bool {
 
 	dsn, _ := sentry.NewDsn(client.Options().Dsn)
 	return strings.Contains(url, dsn.GetHost()) && strings.Contains(url, dsn.GetProjectID())
+	dsn, err := sentry.NewDsn(client.Options().Dsn)
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(url, dsn.GetAPIURL().String())
 }

--- a/otel/internal/utils/sentryrequest.go
+++ b/otel/internal/utils/sentryrequest.go
@@ -38,8 +38,6 @@ func isSentryRequestUrl(ctx context.Context, url string) bool {
 		return false
 	}
 
-	dsn, _ := sentry.NewDsn(client.Options().Dsn)
-	return strings.Contains(url, dsn.GetHost()) && strings.Contains(url, dsn.GetProjectID())
 	dsn, err := sentry.NewDsn(client.Options().Dsn)
 	if err != nil {
 		return false

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -313,7 +313,7 @@ func TestOnEndDoesNotFinishSentryRequests(t *testing.T) {
 		emptyContextWithSentry(),
 		"POST to Sentry",
 		// Hostname is same as in Sentry DSN
-		trace.WithAttributes(attribute.String("http.url", "https://example.com/123")),
+		trace.WithAttributes(attribute.String("http.url", "https://example.com/api/123/envelope/")),
 	)
 	sentrySpan, _ := sentrySpanMap.Get(otelSpan.SpanContext().SpanID())
 	otelSpan.End()


### PR DESCRIPTION
This is a follow-up on #632, to add better error handling as well as a better comparison of the span attribute URL.

Has to be merged after #631.