### PR TITLE
fix(tracing): Make sure a valid source is set on a transaction event

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -626,7 +626,7 @@ const (
 	SourceTask      TransactionSource = "task"
 )
 
-// A set of all valid transaction sources
+// A set of all valid transaction sources.
 var allTransactionSources = map[TransactionSource]struct{}{
 	SourceCustom:    {},
 	SourceURL:       {},

--- a/tracing.go
+++ b/tracing.go
@@ -812,7 +812,7 @@ type SpanOption func(s *Span)
 // starting a span affects the span tree as a whole, potentially overwriting a
 // name set previously.
 //
-// Deprecated: Use WithTransactionSource() instead.
+// Deprecated: Use WithTransactionName() instead.
 func TransactionName(name string) SpanOption {
 	return WithTransactionName(name)
 }
@@ -850,6 +850,10 @@ func TransctionSource(source TransactionSource) SpanOption {
 }
 
 // WithTransactionSource sets the source of the transaction name.
+//
+// Note: if the transaction source is not a valid source (as described
+// by the spec https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations),
+// it will be corrected to "custom" eventually, before the transaction is sent.
 func WithTransactionSource(source TransactionSource) SpanOption {
 	return func(s *Span) {
 		s.Source = source


### PR DESCRIPTION
Transaction source should be one of the predefined values as described by the envelopes protocol: https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations

The safest way to do for Go seems to be checking the source in `Span.toEvent()`: we don't currently have setters for `Span.Name` and `Span.Source`, so adjusting the source earlier may be not enough.

Fixes https://github.com/getsentry/sentry-go/issues/588
Related to https://github.com/getsentry/sentry-go/issues/511 
