### PR TITLE
fix: Clone scope.Context in multiple places to avoid concurrent reads/writes

### DIFF
--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -3,9 +3,9 @@
 //
 // Try it by running:
 //
-// 	go run main.go
-// 	go run main.go https://sentry.io
-// 	go run main.go bad-url
+//	go run main.go
+//	go run main.go https://sentry.io
+//	go run main.go bad-url
 //
 // To actually report events to Sentry, set the DSN either by editing the
 // appropriate line below or setting the environment variable SENTRY_DSN to

--- a/_examples/recover-repanic/main.go
+++ b/_examples/recover-repanic/main.go
@@ -5,7 +5,7 @@
 //
 // Try it by running:
 //
-//  go run main.go
+//	go run main.go
 //
 // To actually report events to Sentry, set the DSN either by editing the
 // appropriate line below or setting the environment variable SENTRY_DSN to

--- a/scope.go
+++ b/scope.go
@@ -287,7 +287,7 @@ func (scope *Scope) Clone() *Scope {
 		clone.tags[key] = value
 	}
 	for key, value := range scope.contexts {
-		clone.contexts[key] = value
+		clone.contexts[key] = cloneContext(value)
 	}
 	for key, value := range scope.extra {
 		clone.extra[key] = value
@@ -350,7 +350,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 
 			// Ensure we are not overwriting event fields
 			if _, ok := event.Contexts[key]; !ok {
-				event.Contexts[key] = value
+				event.Contexts[key] = cloneContext(value)
 			}
 		}
 	}
@@ -403,4 +403,17 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 	}
 
 	return event
+}
+
+// cloneContext returns a new context with keys and values copied from the passed one.
+//
+// Note: a new Context (map) is returned, but the function does NOT do
+// a proper deep copy: if some context values are pointer types (e.g. maps),
+// they won't be properly copied.
+func cloneContext(c Context) Context {
+	res := Context{}
+	for k, v := range c {
+		res[k] = v
+	}
+	return res
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -634,9 +634,9 @@ func TestCloneContext(t *testing.T) {
 		t.Error("original and cloned context should be different objects")
 	}
 
-	slice_original := context["key2"].([]string)
-	slice_clone := clone["key2"].([]string)
-	if &slice_original[0] != &slice_clone[0] {
+	sliceOriginal := context["key2"].([]string)
+	sliceClone := clone["key2"].([]string)
+	if &sliceOriginal[0] != &sliceClone[0] {
 		t.Error("complex values are not supposed to be copied")
 	}
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -618,3 +618,25 @@ func TestEventProcessorsAddEventProcessor(t *testing.T) {
 		t.Error("event should be dropped")
 	}
 }
+
+func TestCloneContext(t *testing.T) {
+	context := Context{
+		"key1": "value1",
+		"key2": []string{"s1", "s2"},
+	}
+
+	clone := cloneContext(context)
+
+	// Value-wise they should be identical
+	assertEqual(t, context, clone)
+	// ..but it shouldn't be the same map
+	if &context == &clone {
+		t.Error("original and cloned context should be different objects")
+	}
+
+	slice_original := context["key2"].([]string)
+	slice_clone := clone["key2"].([]string)
+	if &slice_original[0] != &slice_clone[0] {
+		t.Error("complex values are not supposed to be copied")
+	}
+}

--- a/tracing.go
+++ b/tracing.go
@@ -515,7 +515,7 @@ func (s *Span) toEvent() *Event {
 
 	contexts := map[string]Context{}
 	for k, v := range s.contexts {
-		contexts[k] = v
+		contexts[k] = cloneContext(v)
 	}
 	contexts["trace"] = s.traceContext().Map()
 

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -902,13 +902,13 @@ func TestConcurrentContextAccess(t *testing.T) {
 	})
 	hub := GetHubFromContext(ctx)
 
-	const writers_num = 200
+	const writersNum = 200
 
 	// Unbuffered channel, writing to it will be block if nobody reads
 	c := make(chan *Span)
 
 	// Start writers
-	for i := 0; i < writers_num; i++ {
+	for i := 0; i < writersNum; i++ {
 		go func() {
 			transaction := StartTransaction(ctx, "test")
 			c <- transaction
@@ -917,7 +917,7 @@ func TestConcurrentContextAccess(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(writers_num)
+	wg.Add(writersNum)
 
 	// Start readers
 	go func() {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -934,7 +934,7 @@ func TestConcurrentContextAccess(t *testing.T) {
 
 	wg.Wait()
 }
-  
+
 func TestAdjustingTransactionSourceBeforeSending(t *testing.T) {
 	tests := []struct {
 		name                   string


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-go/issues/570

Here we introduce `cloneContext` that should be used in multiple places to avoid issues like in https://github.com/getsentry/sentry-go/issues/570. 

Note: `cloneContext` does not do a deep copy of `Context` values (which are of type `interface{}`), so there are cases where it's still possible to catch panics if you do weird things with `Context` values. But this, I believe, is out of scope of the SDK responsibility.