### PR TITLE
fix: stack-trace `in_app` false being omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fix frames recognized as not being in-app still showing as in-app ([#647](https://github.com/getsentry/sentry-go/pull/647))
+
 ## 0.21.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.21.0.

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -174,7 +174,7 @@ type Frame struct {
 	PreContext  []string               `json:"pre_context,omitempty"`
 	ContextLine string                 `json:"context_line,omitempty"`
 	PostContext []string               `json:"post_context,omitempty"`
-	InApp       bool                   `json:"in_app,omitempty"`
+	InApp       bool                   `json:"in_app"`
 	Vars        map[string]interface{} `json:"vars,omitempty"`
 	// Package and the below are not used for Go stack trace frames.  In
 	// other platforms it refers to a container where the Module can be

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -230,6 +230,7 @@ func TestEventWithExceptionStacktraceMarshalJSON(t *testing.T) {
 		`"vars":{"fooint":25,"foostr":"bar"}` +
 		`},{` +
 		`"symbol":"nativesym",` +
+		`"in_app":false,` +
 		`"package":"my.dylib",` +
 		`"instruction_addr":"0xabcd0010",` +
 		`"addr_mode":"abs",` +


### PR DESCRIPTION
The stack trace in-app field had `omitempty` so it wouldn't be sent in JSON when it was false. This wasn't correct as that would actually lead to exactly the opposite behaviour in sentry.io where the frame would show as `in-app=true` (the default when the field is not present on the frame).