### PR TITLE
refactor: use client.options internally to avoid copying

### DIFF
--- a/client.go
+++ b/client.go
@@ -397,7 +397,7 @@ func (client *Client) AddEventProcessor(processor EventProcessor) {
 
 // Options return ClientOptions for the current Client.
 func (client Client) Options() ClientOptions {
-	// Note: internally, use `client.options` instead of `client.Options()` to avoid creating the object copy each time.
+	// Note: internally, consider using `client.options` instead of `client.Options()` to avoid copying the object each time.
 	return client.options
 }
 

--- a/dynamic_sampling_context.go
+++ b/dynamic_sampling_context.go
@@ -52,8 +52,6 @@ func DynamicSamplingContextFromTransaction(span *Span) DynamicSamplingContext {
 		}
 	}
 
-	options := client.Options()
-
 	if traceID := span.TraceID.String(); traceID != "" {
 		entries["trace_id"] = traceID
 	}
@@ -66,10 +64,10 @@ func DynamicSamplingContextFromTransaction(span *Span) DynamicSamplingContext {
 			entries["public_key"] = publicKey
 		}
 	}
-	if release := options.Release; release != "" {
+	if release := client.options.Release; release != "" {
 		entries["release"] = release
 	}
-	if environment := options.Environment; environment != "" {
+	if environment := client.options.Environment; environment != "" {
 		entries["environment"] = environment
 	}
 

--- a/hub.go
+++ b/hub.go
@@ -280,17 +280,16 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 		return
 	}
 
-	options := client.Options()
-	max := options.MaxBreadcrumbs
+	max := client.options.MaxBreadcrumbs
 	if max < 0 {
 		return
 	}
 
-	if options.BeforeBreadcrumb != nil {
+	if client.options.BeforeBreadcrumb != nil {
 		if hint == nil {
 			hint = &BreadcrumbHint{}
 		}
-		if breadcrumb = options.BeforeBreadcrumb(breadcrumb, hint); breadcrumb == nil {
+		if breadcrumb = client.options.BeforeBreadcrumb(breadcrumb, hint); breadcrumb == nil {
 			Logger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
 			return
 		}

--- a/integrations.go
+++ b/integrations.go
@@ -130,7 +130,7 @@ func (iei *ignoreErrorsIntegration) Name() string {
 }
 
 func (iei *ignoreErrorsIntegration) SetupOnce(client *Client) {
-	iei.ignoreErrors = transformStringsIntoRegexps(client.Options().IgnoreErrors)
+	iei.ignoreErrors = transformStringsIntoRegexps(client.options.IgnoreErrors)
 	client.AddEventProcessor(iei.processor)
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -175,7 +175,7 @@ func NewRequest(r *http.Request) *Request {
 	var env map[string]string
 	headers := map[string]string{}
 
-	if client := CurrentHub().Client(); client != nil && client.Options().SendDefaultPII {
+	if client := CurrentHub().Client(); client != nil && client.options.SendDefaultPII {
 		// We read only the first Cookie header because of the specification:
 		// https://tools.ietf.org/html/rfc6265#section-5.4
 		// When the user agent generates an HTTP request, the user agent MUST NOT

--- a/span_recorder.go
+++ b/span_recorder.go
@@ -17,7 +17,7 @@ type spanRecorder struct {
 func (r *spanRecorder) record(s *Span) {
 	maxSpans := defaultMaxSpans
 	if client := CurrentHub().Client(); client != nil {
-		maxSpans = client.Options().MaxSpans
+		maxSpans = client.options.MaxSpans
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
Removes use of `client.Options()` from the internal code to avoid copying the options object.

#skip-changelog
