### PR TITLE
Read release info from build info

### DIFF
--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -63,6 +64,15 @@ func defaultRelease() (release string) {
 		if release = os.Getenv(e); release != "" {
 			Logger.Printf("Using release from environment variable %s: %s", e, release)
 			return release
+		}
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" && setting.Value != "" {
+				Logger.Printf("Using release from debug info: %s", setting.Value)
+				return setting.Value
+			}
 		}
 	}
 


### PR DESCRIPTION
Since go1.18, vcs.revision gets compiled into the binary and can be read.

Conveniently, debug.ReadBuildInfo has been around since go1.12, so there's no need to conditionally compile this unless sentry-go needs to support < go1.12 for some reason.

So in builds newer than 1.18, this key just simply won't exist and effectively will do nothing.

This is much more convenient to detect in anything go1.18 since it's much more common to have this compiled in.