### PR TITLE
test: real ticker profiling in CI with a long duration

### DIFF
--- a/profiler_test.go
+++ b/profiler_test.go
@@ -40,22 +40,24 @@ func restoreProfilerTicker() {
 }
 
 func TestProfilerCollection(t *testing.T) {
-	if !isCI() {
-		t.Run("RealTicker", func(t *testing.T) {
-			var require = require.New(t)
-			var goID = getCurrentGoID()
+	t.Run("RealTicker", func(t *testing.T) {
+		var require = require.New(t)
+		var goID = getCurrentGoID()
 
-			start := time.Now()
-			stopFn := startProfiling(start)
+		start := time.Now()
+		stopFn := startProfiling(start)
+		if isCI() {
+			doWorkFor(5 * time.Second)
+		} else {
 			doWorkFor(35 * time.Millisecond)
-			result := stopFn()
-			elapsed := time.Since(start)
-			require.NotNil(result)
-			require.Greater(result.callerGoID, uint64(0))
-			require.Equal(goID, result.callerGoID)
-			validateProfile(t, result.trace, elapsed)
-		})
-	}
+		}
+		result := stopFn()
+		elapsed := time.Since(start)
+		require.NotNil(result)
+		require.Greater(result.callerGoID, uint64(0))
+		require.Equal(goID, result.callerGoID)
+		validateProfile(t, result.trace, elapsed)
+	})
 
 	t.Run("CustomTicker", func(t *testing.T) {
 		var require = require.New(t)


### PR DESCRIPTION
Enables the TestProfilerCollection/RealTicker test in CI but with a long duration, in hopes it won't be flaky in CI.

Requested in https://github.com/getsentry/sentry-go/pull/626/files/c3ce952783a3b8d68042fd8367add1dad837e5b9#r1213167528

#skip-changelog