### PR TITLE
Single profiler goroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Run single profiler even when profiling from multiple parallel goroutines ([#655](https://github.com/getsentry/sentry-go/pull/655))
+
 ### Bug fixes
 
 - Fix trace function name parsing in profiler on go1.21+ ([#695](https://github.com/getsentry/sentry-go/pull/695))
@@ -11,6 +15,7 @@
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.23.0.
 
 ### Features
+
 - Initial support for [Cron Monitoring](https://docs.sentry.io/product/crons/) ([#661](https://github.com/getsentry/sentry-go/pull/661))
 
   This is how the basic usage of the feature looks like:
@@ -62,6 +67,7 @@ The Sentry SDK team is happy to announce the immediate availability of Sentry Go
 - Expose SpanFromContext function ([#672](https://github.com/getsentry/sentry-go/pull/672))
 
 ### Bug fixes
+
 - Make `Span.Finish` a no-op when the span is already finished ([#660](https://github.com/getsentry/sentry-go/pull/660))
 
 ## 0.22.0

--- a/profile_sample.go
+++ b/profile_sample.go
@@ -41,10 +41,10 @@ type (
 	profileStack []int
 
 	profileTrace struct {
-		Frames         []*Frame                         `json:"frames"`
-		Samples        []*profileSample                 `json:"samples"`
-		Stacks         []profileStack                   `json:"stacks"`
-		ThreadMetadata map[string]profileThreadMetadata `json:"thread_metadata"`
+		Frames         []*Frame                          `json:"frames"`
+		Samples        []*profileSample                  `json:"samples"`
+		Stacks         []profileStack                    `json:"stacks"`
+		ThreadMetadata map[string]*profileThreadMetadata `json:"thread_metadata"`
 	}
 
 	profileInfo struct {

--- a/profile_sample.go
+++ b/profile_sample.go
@@ -41,7 +41,7 @@ type (
 
 	profileTrace struct {
 		Frames         []*Frame                          `json:"frames"`
-		Samples        []*profileSample                  `json:"samples"`
+		Samples        []profileSample                   `json:"samples"`
 		Stacks         []profileStack                    `json:"stacks"`
 		ThreadMetadata map[string]*profileThreadMetadata `json:"thread_metadata"`
 	}

--- a/profile_sample.go
+++ b/profile_sample.go
@@ -28,8 +28,8 @@ type (
 
 	profileSample struct {
 		ElapsedSinceStartNS uint64 `json:"elapsed_since_start_ns"`
-		StackID  int    `json:"stack_id"`
-		ThreadID uint64 `json:"thread_id"`
+		StackID             int    `json:"stack_id"`
+		ThreadID            uint64 `json:"thread_id"`
 	}
 
 	profileThreadMetadata struct {

--- a/profile_sample.go
+++ b/profile_sample.go
@@ -33,8 +33,9 @@ type (
 	}
 
 	profileThreadMetadata struct {
-		Name     string `json:"name,omitempty"`
-		Priority int    `json:"priority,omitempty"`
+		Name          string `json:"name,omitempty"`
+		Priority      int    `json:"priority,omitempty"`
+		LastUseTimeNS uint64 `json:"-"`
 	}
 
 	profileStack []int
@@ -43,7 +44,7 @@ type (
 		Frames         []*Frame                          `json:"frames"`
 		Samples        []profileSample                   `json:"samples"`
 		Stacks         []profileStack                    `json:"stacks"`
-		ThreadMetadata map[string]*profileThreadMetadata `json:"thread_metadata"`
+		ThreadMetadata map[uint64]*profileThreadMetadata `json:"thread_metadata"`
 	}
 
 	profileInfo struct {

--- a/profile_sample.go
+++ b/profile_sample.go
@@ -28,9 +28,8 @@ type (
 
 	profileSample struct {
 		ElapsedSinceStartNS uint64 `json:"elapsed_since_start_ns"`
-		QueueAddress        string `json:"queue_address,omitempty"`
-		StackID             int    `json:"stack_id"`
-		ThreadID            uint64 `json:"thread_id"`
+		StackID  int    `json:"stack_id"`
+		ThreadID uint64 `json:"thread_id"`
 	}
 
 	profileThreadMetadata struct {

--- a/profile_sample.go
+++ b/profile_sample.go
@@ -33,9 +33,8 @@ type (
 	}
 
 	profileThreadMetadata struct {
-		Name          string `json:"name,omitempty"`
-		Priority      int    `json:"priority,omitempty"`
-		LastUseTimeNS uint64 `json:"-"`
+		Name     string `json:"name,omitempty"`
+		Priority int    `json:"priority,omitempty"`
 	}
 
 	profileStack []int

--- a/profiler.go
+++ b/profiler.go
@@ -199,7 +199,6 @@ func (p *profileRecorder) GetSlice(startTime, endTime time.Time) *profilerResult
 					Name: "Goroutine " + strconv.FormatUint(goID, 10),
 				}
 			}
-
 		}
 	}
 

--- a/profiler.go
+++ b/profiler.go
@@ -23,6 +23,7 @@ func startProfiling(startTime time.Time) profiler {
 }
 
 type profiler interface {
+	// GetSlice returns a slice of the profiled data between the given times.
 	GetSlice(startTime, endTime time.Time) *profilerResult
 	Stop(wait bool)
 }
@@ -160,7 +161,6 @@ func (p *profileRecorder) Stop(wait bool) {
 	}
 }
 
-// GetSlice returns a slice of the profiled data between the given times.
 func (p *profileRecorder) GetSlice(startTime, endTime time.Time) *profilerResult {
 	// Unlikely edge cases - profiler wasn't running at all or the given times are invalid in relation to each other.
 	if p.startTime.After(endTime) || startTime.After(endTime) {

--- a/profiler.go
+++ b/profiler.go
@@ -311,8 +311,7 @@ func (p *profileRecorder) processRecords(elapsedNs uint64, stacksBuffer []byte) 
 
 	for i := 0; i < length; i++ {
 		var stack = traces.Item(i)
-		var stackIndex = p.addStackTrace(stack)
-		bucket.stackIDs[i] = stackIndex
+		bucket.stackIDs[i] = p.addStackTrace(stack)
 		bucket.goIDs[i] = stack.GoID()
 	}
 

--- a/profiler.go
+++ b/profiler.go
@@ -36,7 +36,9 @@ type profilerResult struct {
 func getCurrentGoID() uint64 {
 	// We shouldn't panic but let's be super safe.
 	defer func() {
-		_ = recover()
+		if err := recover(); err != nil {
+			Logger.Printf("Profiler panic in getCurrentGoID(): %v\n", err)
+		}
 	}()
 
 	// Buffer to read the stack trace into. We should be good with a small buffer because we only need the first line.
@@ -120,7 +122,9 @@ func (p *profileRecorder) run() {
 
 	// We shouldn't panic but let's be super safe.
 	defer func() {
-		_ = recover()
+		if err := recover(); err != nil {
+			Logger.Printf("Profiler panic in run(): %v\n", err)
+		}
 		atomic.StoreInt64(&testProfilerPanic, 0)
 		atomic.StoreInt64(&profilerRunning, 0)
 	}()

--- a/profiler.go
+++ b/profiler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/getsentry/sentry-go/internal/traceparser"
 )
 
-// Start a profiler that collects samples continously, with a buffer of up to 30 seconds.
+// Start a profiler that collects samples continuously, with a buffer of up to 30 seconds.
 // Later, you can collect a slice from this buffer, producing a Trace.
 func startProfiling(startTime time.Time) profiler {
 	onProfilerStart()
@@ -227,7 +227,7 @@ func (p *profileRecorder) getBuckets(relativeStartNS, relativeEndNS uint64) (sam
 		Stacks:         p.stacks,
 		ThreadMetadata: p.routines,
 	}
-	return
+	return samplesCount, buckets, trace
 }
 
 func (p *profileRecorder) onTick() {

--- a/profiler.go
+++ b/profiler.go
@@ -139,6 +139,7 @@ func (p *profileRecorder) run(started chan struct{}) {
 
 	p.testProfilerPanic = atomic.LoadInt64(&testProfilerPanic)
 	if p.testProfilerPanic < 0 {
+		Logger.Printf("Profiler panicking during startup because testProfilerPanic == %v\n", p.testProfilerPanic)
 		panic("This is an expected panic in profilerGoroutine() during tests")
 	}
 
@@ -262,7 +263,9 @@ func (p *profileRecorder) onTick() {
 	elapsedNs := time.Since(p.startTime).Nanoseconds()
 
 	if p.testProfilerPanic > 0 {
+		Logger.Printf("Profiler testProfilerPanic == %v\n", p.testProfilerPanic)
 		if p.testProfilerPanic == 1 {
+			Logger.Println("Profiler panicking onTick()")
 			panic("This is an expected panic in Profiler.OnTick() during tests")
 		}
 		p.testProfilerPanic--

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -294,13 +294,17 @@ func TestProfilerSamplingRate(t *testing.T) {
 	var samplesByThread = map[uint64]uint64{}
 	var outliersByThread = map[uint64]uint64{}
 	var outliers = 0
+	var lastLogTime = uint64(0)
 	for _, sample := range result.trace.Samples {
 		count := samplesByThread[sample.ThreadID]
 
 		var lowerBound = count * uint64(profilerSamplingRate.Nanoseconds())
 		var upperBound = (count + 1 + outliersByThread[sample.ThreadID]) * uint64(profilerSamplingRate.Nanoseconds())
 
-		t.Logf("Routine %2d, sample %d (%d) should be between %d and %d", sample.ThreadID, count, sample.ElapsedSinceStartNS, lowerBound, upperBound)
+		if lastLogTime != sample.ElapsedSinceStartNS {
+			t.Logf("Sample %d (%d) should be between %d and %d", count, sample.ElapsedSinceStartNS, lowerBound, upperBound)
+			lastLogTime = sample.ElapsedSinceStartNS
+		}
 
 		// We can check the lower bound explicitly, but the upper bound is problematic as some samples may get delayed.
 		// Therefore, we collect the number of outliers and check if it's reasonably low.

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -272,7 +271,7 @@ func validateProfile(t *testing.T, trace *profileTrace, duration time.Duration) 
 		require.GreaterOrEqual(uint64(duration.Nanoseconds()), sample.ElapsedSinceStartNS)
 		require.GreaterOrEqual(sample.StackID, 0)
 		require.Less(sample.StackID, len(trace.Stacks))
-		require.Contains(trace.ThreadMetadata, strconv.Itoa(int(sample.ThreadID)))
+		require.Contains(trace.ThreadMetadata, sample.ThreadID)
 	}
 
 	for _, thread := range trace.ThreadMetadata {

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -492,12 +492,12 @@ func TestProfilerTimeSleep(t *testing.T) {
 // goarch: amd64
 // pkg: github.com/getsentry/sentry-go
 // cpu: 12th Gen Intel(R) Core(TM) i7-12700K
-// BenchmarkProfilerStartStop/Wait-20                 12313            100383 ns/op          130459 B/op       3163 allocs/op
-// BenchmarkProfilerStartStop/NoWait-20                8964            118605 ns/op          130783 B/op       3163 allocs/op
-// BenchmarkProfilerOnTick-20                         61993             18999 ns/op            1088 B/op         10 allocs/op
-// BenchmarkProfilerCollect-20                        61149             18824 ns/op               0 B/op          0 allocs/op
-// BenchmarkProfilerProcess-20                       872079              1195 ns/op            1040 B/op         10 allocs/op
-// BenchmarkProfilerGetSlice-20                       31327             34156 ns/op           79050 B/op         19 allocs/op
+// BenchmarkProfilerStartStop/Wait-20                 12507             94991 ns/op          130506 B/op       3166 allocs/op
+// BenchmarkProfilerStartStop/NoWait-20                9600            112354 ns/op          131125 B/op       3166 allocs/op
+// BenchmarkProfilerOnTick-20                         65040             17771 ns/op            1008 B/op          8 allocs/op
+// BenchmarkProfilerCollect-20                        64430             18223 ns/op               0 B/op          0 allocs/op
+// BenchmarkProfilerProcess-20                       972006              1118 ns/op             960 B/op          8 allocs/op
+// BenchmarkProfilerGetSlice-20                       37144             31289 ns/op           75813 B/op         19 allocs/op
 
 func BenchmarkProfilerStartStop(b *testing.B) {
 	var bench = func(name string, wait bool) {

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -187,7 +187,7 @@ func TestProfilerPanicOnTick(t *testing.T) {
 		t.Skip("Skipping in short mode because of the timeout we wait for in Tick() after the panic.")
 	}
 
-	var require = require.New(t)
+	var assert = assert.New(t)
 
 	ticker := setupProfilerTestTicker(t.Log)
 	defer restoreProfilerTicker()
@@ -198,14 +198,14 @@ func TestProfilerPanicOnTick(t *testing.T) {
 	start := time.Now()
 	profiler := startProfiling(start)
 	defer profiler.Stop(false)
-	require.True(ticker.Tick())
-	require.False(ticker.Tick())
+	assert.True(ticker.Tick())
+	assert.False(ticker.Tick())
 
 	end := time.Now()
 	result := profiler.GetSlice(start, end)
 
-	require.Zero(atomic.LoadInt64(&testProfilerPanic))
-	require.NotNil(result)
+	assert.Zero(atomic.LoadInt64(&testProfilerPanic))
+	assert.NotNil(result)
 	validateProfile(t, result.trace, end.Sub(start))
 }
 

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -50,10 +50,9 @@ func (t *profilerTestTicker) Tick() bool {
 		if ok {
 			t.logger("Ticker: tick acknowledged by the profiler.") // logged on the test goroutine
 			return true
-		} else {
-			t.logger("Ticker: tick not acknowledged (ticker stopped).")
-			return false
 		}
+		t.logger("Ticker: tick not acknowledged (ticker stopped).")
+		return false
 	case <-time.After(1 * time.Second):
 		t.logger("Ticker: timed out waiting for Tick ACK.")
 		return false

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -353,7 +353,7 @@ func TestProfilerStackBufferGrowth(t *testing.T) {
 func countSamples(profiler *profileRecorder) (value int) {
 	profiler.samplesBucketsHead.Do(func(bucket interface{}) {
 		if bucket != nil {
-			value += len(bucket.(profileSamplesBucket))
+			value += len(bucket.(*profileSamplesBucket).goIDs)
 		}
 	})
 	return value
@@ -597,7 +597,7 @@ func TestProfilerOverhead(t *testing.T) {
 		t.Skip("Skipping on CI because the machines are too overloaded to run the test properly - they show between 3 and 30 %% overhead....")
 	}
 
-	// first, find large-enough argument so that findPrimeNumber(arg) takes more than 100ms
+	// First, find a large-enough argument so that findPrimeNumber(arg) takes more than 100ms.
 	var arg = 10000
 	for {
 		start := time.Now()

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -162,6 +162,9 @@ func TestProfilerCollectsOnStart(t *testing.T) {
 func TestProfilerPanicDuringStartup(t *testing.T) {
 	var require = require.New(t)
 
+	_ = setupProfilerTestTicker(t)
+	defer restoreProfilerTicker()
+
 	atomic.StoreInt64(&testProfilerPanic, -1)
 
 	start := time.Now()

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -546,7 +546,7 @@ func profilerBenchmark(t *testing.T, b *testing.B, withProfiling bool) {
 		wg.Add(numRoutines)
 		for j := 0; j < numRoutines; j++ {
 			go func() {
-				_ = findPrimeNumber(10000)
+				_ = findPrimeNumber(30000)
 				wg.Done()
 			}()
 		}

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -184,15 +184,7 @@ func TestProfilerPanicDuringStartup(t *testing.T) {
 
 	start := time.Now()
 	profiler := startProfiling(start)
-	defer profiler.Stop(false)
-	// wait until the profiler has panicked
-	for i := 0; i < 100 && atomic.LoadInt64(&testProfilerPanic) != 0; i++ {
-		doWorkFor(10 * time.Millisecond)
-	}
-	result := profiler.GetSlice(start, time.Now())
-
-	require.Zero(atomic.LoadInt64(&testProfilerPanic))
-	require.Nil(result)
+	require.Nil(profiler)
 }
 
 func TestProfilerPanicOnTick(t *testing.T) {

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -379,7 +379,6 @@ func TestProfilerInternalMaps(t *testing.T) {
 	assert.Zero(len(profiler.stacks))
 	assert.Zero(len(profiler.stackIndexes))
 	assert.Zero(len(profiler.newStacks))
-	assert.Zero(len(profiler.routines))
 	assert.Zero(countSamples(profiler))
 	assert.Equal(ringBufferSize, profiler.samplesBucketsHead.Len())
 
@@ -391,7 +390,6 @@ func TestProfilerInternalMaps(t *testing.T) {
 	assert.NotZero(len(profiler.stacks))
 	assert.NotZero(len(profiler.stackIndexes))
 	assert.NotZero(len(profiler.newStacks))
-	assert.NotZero(len(profiler.routines))
 	assert.NotZero(countSamples(profiler))
 	assert.Equal(ringBufferSize, profiler.samplesBucketsHead.Len())
 
@@ -399,7 +397,6 @@ func TestProfilerInternalMaps(t *testing.T) {
 	frameIndexesLen := len(profiler.frameIndexes)
 	stacksLen := len(profiler.stacks)
 	stackIndexesLen := len(profiler.stackIndexes)
-	routinesLen := len(profiler.routines)
 	samplesLen := countSamples(profiler)
 
 	// On another tick, we will have the same data plus one frame and stack representing the profiler.onTick() call on the next line.
@@ -410,7 +407,6 @@ func TestProfilerInternalMaps(t *testing.T) {
 	assert.Equal(stacksLen+1, len(profiler.stacks))
 	assert.Equal(stackIndexesLen+1, len(profiler.stackIndexes))
 	assert.Equal(1, len(profiler.newStacks))
-	assert.Equal(routinesLen, len(profiler.routines))
 	assert.Equal(samplesLen*2, countSamples(profiler))
 	assert.Equal(ringBufferSize, profiler.samplesBucketsHead.Len())
 
@@ -422,7 +418,6 @@ func TestProfilerInternalMaps(t *testing.T) {
 	assert.Equal(stacksLen+2, len(profiler.stacks))
 	assert.Equal(stackIndexesLen+2, len(profiler.stackIndexes))
 	assert.Equal(1, len(profiler.newStacks))
-	assert.Equal(routinesLen, len(profiler.routines))
 	assert.Equal(samplesLen*3, countSamples(profiler))
 	assert.Equal(ringBufferSize, profiler.samplesBucketsHead.Len())
 }
@@ -570,7 +565,6 @@ func profilerBenchmark(t *testing.T, b *testing.B, withProfiling bool, arg int) 
 		p.Stop(true)
 		// Let's captured data so we can see what has been profiled if there's an error.
 		// Previously, there have been tests that have started (and left running) global Sentry instance and goroutines.
-		t.Logf("Profiler captured %d goroutines.", len(p.(*profileRecorder).routines))
 		t.Log("Captured frames related to the profiler benchmark:")
 		isRelatedToProfilerBenchmark := func(f *Frame) bool {
 			return strings.Contains(f.AbsPath, "profiler") || strings.Contains(f.AbsPath, "benchmark.go") || strings.Contains(f.AbsPath, "testing.go")

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -573,11 +573,12 @@ func setupProfilerSliceBenchmark(b *testing.B) {
 	}
 
 	end := time.Now()
-	if end.Compare(start) <= 0 {
+	if end.Sub(start) <= 0 {
 		b.Fatal("Unexpected end time")
 	}
 
 	// Prepare a set of spans we will be collecting.
+	//nolint:gosec // We don't need a secure random number generator here.
 	random := rand.New(rand.NewSource(42))
 	collected := 0
 	for i := 0; i < len(profilerSliceBenchmarkData.spans); i++ {

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -35,7 +35,7 @@ func (t *profilerTestTicker) Ticked() {
 }
 
 func (t *profilerTestTicker) Stop() {
-	t.log("Ticker: stopped.\n")
+	t.log("Ticker: stopping.\n")
 	close(t.ticked)
 }
 
@@ -48,7 +48,7 @@ func (t *profilerTestTicker) Tick() bool {
 	select {
 	case _, ok := <-t.ticked:
 		if ok {
-			t.log("Ticker: tick acknowledged by the profiler.\n") // logged on the test goroutine
+			t.log("Ticker: tick acknowledged (received on the test goroutine).\n") // logged on the test goroutine
 			return true
 		}
 		t.log("Ticker: tick not acknowledged (ticker stopped).\n")
@@ -83,7 +83,7 @@ func TestProfilerCollection(t *testing.T) {
 
 		start := time.Now()
 		profiler := startProfiling(start)
-		defer profiler.Stop(false)
+		defer profiler.Stop(true)
 		if isCI() {
 			doWorkFor(5 * time.Second)
 		} else {
@@ -106,7 +106,7 @@ func TestProfilerCollection(t *testing.T) {
 
 		start := time.Now()
 		profiler := startProfiling(start)
-		defer profiler.Stop(false)
+		defer profiler.Stop(true)
 		require.True(ticker.Tick())
 		end := time.Now()
 		result := profiler.GetSlice(start, end)
@@ -134,7 +134,7 @@ func TestProfilerStackTrace(t *testing.T) {
 
 	start := time.Now()
 	profiler := startProfiling(start)
-	defer profiler.Stop(false)
+	defer profiler.Stop(true)
 	require.True(ticker.Tick())
 	result := profiler.GetSlice(start, time.Now())
 	require.NotNil(result)
@@ -203,7 +203,7 @@ func TestProfilerPanicOnTick(t *testing.T) {
 
 	start := time.Now()
 	profiler := startProfiling(start)
-	defer profiler.Stop(false)
+	defer profiler.Stop(true)
 	assert.True(ticker.Tick())
 	assert.False(ticker.Tick())
 
@@ -307,7 +307,7 @@ func TestProfilerSamplingRate(t *testing.T) {
 
 	start := time.Now()
 	profiler := startProfiling(start)
-	defer profiler.Stop(false)
+	defer profiler.Stop(true)
 	doWorkFor(500 * time.Millisecond)
 	end := time.Now()
 	result := profiler.GetSlice(start, end)

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -540,18 +540,15 @@ func profilerBenchmark(t *testing.T, b *testing.B, withProfiling bool) {
 	}
 	b.ResetTimer()
 
-	const numRoutines = 1000
+	var wg sync.WaitGroup
+	wg.Add(b.N)
 	for i := 0; i < b.N; i++ {
-		var wg sync.WaitGroup
-		wg.Add(numRoutines)
-		for j := 0; j < numRoutines; j++ {
-			go func() {
-				_ = findPrimeNumber(30000)
-				wg.Done()
-			}()
-		}
-		wg.Wait()
+		go func() {
+			_ = findPrimeNumber(30000)
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 
 	b.StopTimer()
 	if withProfiling {

--- a/profiler_windows.go
+++ b/profiler_windows.go
@@ -17,8 +17,8 @@ func setTimeTickerResolution() {
 	}
 }
 
-var runOnce sync.Once
+var setupTickerResolutionOnce sync.Once
 
 func onProfilerStart() {
-	runOnce.Do(setTimeTickerResolution)
+	setupTickerResolutionOnce.Do(setTimeTickerResolution)
 }

--- a/traces_profiler.go
+++ b/traces_profiler.go
@@ -11,12 +11,16 @@ func (span *Span) sampleTransactionProfile() {
 	var sampleRate = span.clientOptions().ProfilesSampleRate
 	switch {
 	case sampleRate < 0.0 || sampleRate > 1.0:
-		Logger.Printf("Skipping transaction profiling: ProfilesSampleRate out of range [0.0, 1.0]: %f", sampleRate)
+		Logger.Printf("Skipping transaction profiling: ProfilesSampleRate out of range [0.0, 1.0]: %f\n", sampleRate)
 	case sampleRate == 0.0 || rng.Float64() >= sampleRate:
-		Logger.Printf("Skipping transaction profiling: ProfilesSampleRate is: %f", sampleRate)
+		Logger.Printf("Skipping transaction profiling: ProfilesSampleRate is: %f\n", sampleRate)
 	default:
 		startProfilerOnce.Do(startGlobalProfiler)
-		span.collectProfile = collectTransactionProfile
+		if globalProfiler == nil {
+			Logger.Println("Skipping transaction profiling: the profiler couldn't be started")
+		} else {
+			span.collectProfile = collectTransactionProfile
+		}
 	}
 }
 

--- a/traces_profiler_test.go
+++ b/traces_profiler_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func testTraceProfiling(t *testing.T, rate float64) (*Span, *Event) {
-	ticker := setupProfilerTestTicker()
+	ticker := setupProfilerTestTicker(t)
 	defer restoreProfilerTicker()
 
 	transport := &TransportMock{}
@@ -49,6 +49,10 @@ func TestTraceProfiling(t *testing.T) {
 }
 
 func TestTraceProfilingDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping in short mode because of the timeout we wait for in Tick().")
+	}
+
 	var require = require.New(t)
 	_, event := testTraceProfiling(t, 0)
 	require.Equal(transactionType, event.Type)

--- a/traces_profiler_test.go
+++ b/traces_profiler_test.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -9,7 +10,7 @@ import (
 )
 
 func testTraceProfiling(t *testing.T, rate float64) (*Span, *Event) {
-	ticker := setupProfilerTestTicker(t.Log)
+	ticker := setupProfilerTestTicker(io.Discard)
 	defer restoreProfilerTicker()
 
 	transport := &TransportMock{}

--- a/traces_profiler_test.go
+++ b/traces_profiler_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testTraceProfiling(t *testing.T, rate float64) (*Span, *Event) {
-	ticker := setupProfilerTestTicker(t)
+	ticker := setupProfilerTestTicker(t.Log)
 	defer restoreProfilerTicker()
 
 	transport := &TransportMock{}

--- a/tracing.go
+++ b/tracing.go
@@ -58,8 +58,8 @@ type Span struct { //nolint: maligned // prefer readability over optimal memory 
 	recorder *spanRecorder
 	// span context, can only be set on transactions
 	contexts map[string]Context
-	// profiler instance if attached, nil otherwise.
-	profiler transactionProfiler
+	// collectProfile is a function that collects a profile of the current transaction. May be nil.
+	collectProfile transactionProfiler
 }
 
 // TraceParentContext describes the context of a (remote) parent span.
@@ -212,8 +212,8 @@ func (s *Span) Finish() {
 		return
 	}
 
-	if s.profiler != nil {
-		event.sdkMetaData.transactionProfile = s.profiler.Finish(s)
+	if s.collectProfile != nil {
+		event.sdkMetaData.transactionProfile = s.collectProfile(s)
 	}
 
 	// TODO(tracing): add breadcrumbs

--- a/tracing.go
+++ b/tracing.go
@@ -200,12 +200,6 @@ func (s *Span) Finish() {
 	// TODO(tracing): maybe make Finish run at most once, such that
 	// (incorrectly) calling it twice never double sends to Sentry.
 
-	// For the timing to be correct, the profiler must be stopped before s.EndTime.
-	var profile *profileInfo
-	if s.profiler != nil {
-		profile = s.profiler.Finish(s)
-	}
-
 	if s.EndTime.IsZero() {
 		s.EndTime = monotonicTimeSince(s.StartTime)
 	}
@@ -218,7 +212,9 @@ func (s *Span) Finish() {
 		return
 	}
 
-	event.sdkMetaData.transactionProfile = profile
+	if s.profiler != nil {
+		event.sdkMetaData.transactionProfile = s.profiler.Finish(s)
+	}
 
 	// TODO(tracing): add breadcrumbs
 	// (see https://github.com/getsentry/sentry-python/blob/f6f3525f8812f609/sentry_sdk/tracing.py#L372)

--- a/transport_test.go
+++ b/transport_test.go
@@ -204,7 +204,7 @@ func TestEnvelopeFromTransactionWithProfile(t *testing.T) {
 					Colno:    24,
 				},
 			},
-			Samples: []*profileSample{
+			Samples: []profileSample{
 				{
 					ElapsedSinceStartNS: 10,
 					StackID:             2,

--- a/transport_test.go
+++ b/transport_test.go
@@ -212,7 +212,7 @@ func TestEnvelopeFromTransactionWithProfile(t *testing.T) {
 				},
 			},
 			Stacks: []profileStack{{0}},
-			ThreadMetadata: map[string]profileThreadMetadata{
+			ThreadMetadata: map[string]*profileThreadMetadata{
 				"1": {Name: "GO 1"},
 			},
 		},

--- a/transport_test.go
+++ b/transport_test.go
@@ -212,8 +212,8 @@ func TestEnvelopeFromTransactionWithProfile(t *testing.T) {
 				},
 			},
 			Stacks: []profileStack{{0}},
-			ThreadMetadata: map[string]*profileThreadMetadata{
-				"1": {Name: "GO 1"},
+			ThreadMetadata: map[uint64]*profileThreadMetadata{
+				1: {Name: "GO 1"},
 			},
 		},
 		Transaction: profileTransaction{


### PR DESCRIPTION
Follow up on #626 - run a single profiler continuously (instead of a new profiler for each profiled transaction) and slice its data as needed. 

The `profileRecorder` starts when a first transaction would be sampled and then runs until the app is stopped.  I was thinking about starting/stopping when there's no transaction running but it would get more complicated and I'm not sure it's worth it because it would also make overall app performance less predictable (would differ when there's a transaction being profiled and when it's not). On the other hand, for very low sampling rate, it would be beneficial to only run when needed. In any case, the change to make the profiler start & pause on demand would be an incremental change that can be done in the future when the need arises (based on user feedback).

Example of a captured profile: https://sentry-sdks.sentry.io/profiling/profile/sentry-go/7f41d10eeb8749a68d760e89c9ae8a8a/flamechart/?colorCoding=by+system+vs+application+frame&query=&sorting=call+order&tid=16&view=top+down

## Additional remarks

The changes this PR makes are not going to be faster for an app with a low number of concurrent transactions. It just has to do more to serve the same purpose. On the other hand, you should see a difference when the number of parallel profiled transactions raises. Unless there's a way to tune this in the demo, it may not be suitable for the evaluation. 

For example, the `TestProfilerOverhead` would fail on the `main` branch after adapting it to run parallel goroutines. The overhead on this branch for 100 parallel goroutines is about 3 % on this PR, while the "same" code running on the original implementation (current status of the `master` branch), i.e. the one that launches a different profiler for each goroutine ended up failing with an overhead of over 30 % for the same number of goroutines.

<details>
<summary>Benchmark code from this branch adapted to `master`</summary>

```go
func profilerBenchmark(t *testing.T, b *testing.B, withProfiling bool, arg int) {
	var wg sync.WaitGroup
	const numRoutines = 100
	wg.Add(numRoutines)
	for i := 0; i < numRoutines; i++ {
		go func() {
			var stopFn func() *profilerResult
			if withProfiling {
				stopFn = startProfiling(time.Now())
			}
			_ = findPrimeNumber(arg)
			if withProfiling {
				stopFn()
			}
			wg.Done()
		}()
	}
	wg.Wait()
}

func TestProfilerOverhead(t *testing.T) {
	if testing.Short() {
		t.Skip("Skipping overhead benchmark in short mode.")
	}
	if isCI() {
		t.Skip("Skipping on CI because the machines are too overloaded to run the test properly - they show between 3 and 30 %% overhead....")
	}

	// First, find a large-enough argument so that findPrimeNumber(arg) takes more than 100ms.
	var arg = 10000
	for {
		start := time.Now()
		_ = findPrimeNumber(arg)
		end := time.Now()
		if end.Sub(start) > 100*time.Millisecond {
			t.Logf("Found arg = %d that takes %d ms to process.", arg, end.Sub(start).Milliseconds())
			break
		}
		arg += 10000
	}

	var assert = assert.New(t)
	var baseline = testing.Benchmark(func(b *testing.B) { profilerBenchmark(t, b, false, arg) })
	var profiling = testing.Benchmark(func(b *testing.B) { profilerBenchmark(t, b, true, arg) })

	t.Logf("Without profiling: %v\n", baseline.String())
	t.Logf("With profiling:    %v\n", profiling.String())

	var overhead = float64(profiling.NsPerOp())/float64(baseline.NsPerOp())*100 - 100
	var maxOverhead = 5.0
	t.Logf("Profiling overhead: %f percent\n", overhead)
	assert.Less(overhead, maxOverhead)
}
```
</details>
