### PR TITLE
fix: Increase flush timeout in TestHTTPTransport

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -367,7 +367,7 @@ func TestHTTPTransport(t *testing.T) {
 	transportMustFlush := func(t *testing.T, id string) {
 		t.Helper()
 
-		ok := transport.Flush(100 * time.Millisecond)
+		ok := transport.Flush(500 * time.Millisecond)
 		if !ok {
 			t.Fatalf("[CLIENT] {%.4s} Flush() timed out", id)
 		}


### PR DESCRIPTION
This test got increasingly flake lately, specifically on Windows. Let's see if it makes things better. 