### PR TITLE
feat: Attachments support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -79,7 +79,7 @@ func TestCaptureMessageEmptyString(t *testing.T) {
 	}
 	got := transport.lastEvent
 	opts := cmp.Options{
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "attachments"),
 		cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 			return &Event{
 				Exception: e.Exception,
@@ -286,7 +286,7 @@ func TestCaptureEvent(t *testing.T) {
 		},
 	}
 	got := transport.lastEvent
-	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release", "sdkMetaData")}
+	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release", "sdkMetaData", "attachments")}
 	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Errorf("Event mismatch (-want +got):\n%s", diff)
 	}
@@ -314,7 +314,7 @@ func TestCaptureEventNil(t *testing.T) {
 	}
 	got := transport.lastEvent
 	opts := cmp.Options{
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "attachments"),
 		cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 			return &Event{
 				Exception: e.Exception,
@@ -639,7 +639,7 @@ func TestRecover(t *testing.T) {
 		}
 		got := events[0]
 		opts := cmp.Options{
-			cmpopts.IgnoreFields(Event{}, "sdkMetaData"),
+			cmpopts.IgnoreFields(Event{}, "sdkMetaData", "attachments"),
 			cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 				return &Event{
 					Message:   e.Message,

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -207,7 +207,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Event{},
 			"Contexts", "EventID", "Extra", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
-			"sdkMetaData",
+			"sdkMetaData", "attachments",
 		),
 		cmpopts.IgnoreMapEntries(func(k string, v string) bool {
 			// fasthttp changed Content-Length behavior in

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -330,7 +330,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Event{},
 			"Contexts", "EventID", "Extra", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
-			"sdkMetaData",
+			"sdkMetaData", "attachments",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
@@ -354,7 +354,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Event{},
 			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
-			"sdkMetaData", "StartTime", "Spans",
+			"sdkMetaData", "StartTime", "Spans", "attachments",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -210,7 +210,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Event{},
 			"Contexts", "EventID", "Extra", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
-			"sdkMetaData",
+			"sdkMetaData", "attachments",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/interfaces.go
+++ b/interfaces.go
@@ -108,6 +108,14 @@ func (b *Breadcrumb) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*breadcrumb)(b))
 }
 
+// Attachment allows associating files with your events to aid in investigation.
+// An event may contain one or more attachments.
+type Attachment struct {
+	Filename    string
+	ContentType string
+	Payload     []byte
+}
+
 // User describes the user associated with an Event. If this is used, at least
 // an ID or an IP address should be provided.
 type User struct {
@@ -326,6 +334,7 @@ type Event struct {
 	// The fields below are not part of the final JSON payload.
 
 	sdkMetaData SDKMetaData
+	attachments []*Attachment
 }
 
 // SetException appends the unwrapped errors to the event's exception list.

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -249,7 +249,7 @@ func Test_entryToEvent(t *testing.T) {
 			got := h.entryToEvent(tt.entry)
 			opts := cmp.Options{
 				cmpopts.IgnoreFields(sentry.Event{},
-					"sdkMetaData",
+					"sdkMetaData", "attachments",
 				),
 			}
 			if d := cmp.Diff(tt.want, got, opts); d != "" {

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -54,6 +54,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.SetLevel(sentry.LevelDebug)
 	scope.SetFingerprint([]string{"foo"})
 	scope.AddBreadcrumb(&sentry.Breadcrumb{Message: "foo"}, 100)
+	scope.AddAttachment(&sentry.Attachment{Filename: "foo.txt"})
 	scope.SetUser(sentry.User{ID: "foo"})
 	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
 

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -157,7 +157,7 @@ func TestStartSpan(t *testing.T) {
 		cmpopts.IgnoreFields(Event{},
 			"Contexts", "EventID", "Level", "Platform",
 			"Release", "Sdk", "ServerName", "Modules",
-			"sdkMetaData",
+			"sdkMetaData", "attachments",
 		),
 		cmpopts.EquateEmpty(),
 	}
@@ -221,7 +221,7 @@ func TestStartChild(t *testing.T) {
 		cmpopts.IgnoreFields(Event{},
 			"EventID", "Level", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp", "StartTime",
-			"sdkMetaData",
+			"sdkMetaData", "attachments",
 		),
 		cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
 			return k != "trace"
@@ -302,7 +302,7 @@ func TestStartTransaction(t *testing.T) {
 		cmpopts.IgnoreFields(Event{},
 			"Contexts", "EventID", "Level", "Platform",
 			"Release", "Sdk", "ServerName", "Modules",
-			"sdkMetaData",
+			"sdkMetaData", "attachments",
 		),
 		cmpopts.EquateEmpty(),
 	}

--- a/transport.go
+++ b/transport.go
@@ -94,6 +94,38 @@ func getRequestBodyFromEvent(event *Event) []byte {
 	return nil
 }
 
+func encodeAttachment(enc *json.Encoder, b io.Writer, attachment *Attachment) error {
+	// Attachment header
+	err := enc.Encode(struct {
+		Type        string `json:"type"`
+		Length      int    `json:"length"`
+		Filename    string `json:"filename"`
+		ContentType string `json:"content_type,omitempty"`
+	}{
+		Type:        "attachment",
+		Length:      len(attachment.Payload),
+		Filename:    attachment.Filename,
+		ContentType: attachment.ContentType,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Attachment payload
+	if _, err = b.Write(attachment.Payload); err != nil {
+		return err
+	}
+
+	// "Envelopes should be terminated with a trailing newline."
+	//
+	// [1]: https://develop.sentry.dev/sdk/envelopes/#envelopes
+	if _, err := b.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func encodeEnvelopeItem(enc *json.Encoder, itemType string, body json.RawMessage) error {
 	// Item header
 	err := enc.Encode(struct {
@@ -150,6 +182,13 @@ func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMes
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	// Attachments
+	for _, attachment := range event.attachments {
+		if err := encodeAttachment(enc, &b, attachment); err != nil {
+			return nil, err
+		}
 	}
 
 	// Profile data


### PR DESCRIPTION
This is similar to how [`sentry-rust` supports attachments](https://docs.rs/sentry/0.31.5/sentry/struct.Scope.html#method.add_attachment).

Resolves #574.