### PR TITLE
Expose SpanFromContext

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -956,27 +956,9 @@ func TransactionFromContext(ctx context.Context) *Span {
 	return nil
 }
 
-// spanFromContext returns the last span stored in the context or a dummy
+// SpanFromContext returns the last span stored in the context or a dummy
 // non-nil span.
-//
-// TODO(tracing): consider exporting this. Without this, users cannot retrieve a
-// span from a context since spanContextKey is not exported.
-//
-// This can be added retroactively, and in the meantime think better whether it
-// should return nil (like GetHubFromContext), always non-nil (like
-// HubFromContext), or both: two exported functions.
-//
-// Note the equivalence:
-//
-//	SpanFromContext(ctx).StartChild(...) === StartSpan(ctx, ...)
-//
-// So we don't aim spanFromContext at creating spans, but mutating existing
-// spans that you'd have no access otherwise (because it was created in code you
-// do not control, for example SDK auto-instrumentation).
-//
-// For now we provide TransactionFromContext, which solves the more common case
-// of setting tags, etc, on the current transaction.
-func spanFromContext(ctx context.Context) *Span {
+func SpanFromContext(ctx context.Context) *Span {
 	if span, ok := ctx.Value(spanContextKey{}).(*Span); ok {
 		return span
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -956,8 +956,8 @@ func TransactionFromContext(ctx context.Context) *Span {
 	return nil
 }
 
-// SpanFromContext returns the last span stored in the context or a dummy
-// non-nil span.
+// SpanFromContext returns the last span stored in the context, or nil if no span
+// is set on the context.
 func SpanFromContext(ctx context.Context) *Span {
 	if span, ok := ctx.Value(spanContextKey{}).(*Span); ok {
 		return span

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -389,7 +389,7 @@ func (c SpanCheck) Check(t *testing.T, span *Span) {
 		t.Errorf("original context value lost")
 	}
 	// Invariant: SpanFromContext(span.Context) == span
-	if spanFromContext(gotCtx) != span {
+	if SpanFromContext(gotCtx) != span {
 		t.Errorf("span not in its context")
 	}
 
@@ -586,7 +586,7 @@ func TestSpanFromContext(t *testing.T) {
 	// SpanFromContext(ctx).StartChild(...) === StartSpan(ctx, ...)
 
 	ctx := NewTestContext(ClientOptions{})
-	span := spanFromContext(ctx)
+	span := SpanFromContext(ctx)
 
 	_ = span
 


### PR DESCRIPTION
I'm working on integration [pgx](https://github.com/jackc/pgx) with Sentry. 

The new version of pgx provides an [interface](https://github.com/jackc/pgx/blob/master/tracer.go#L10) for tracing, which work in the way when you need to implement two different methods: TraceQueryStart & TraceQueryEnd.   

To implement `TraceQueryEnd`, I need to get access to span in context and call `Finish` on it.   

It would be great to provide a method to get span from context.   
Current workaround: 
```go
func SpanFromContext(ctx interface{}) (*sentry.Span, bool) {
	values := reflect.ValueOf(ctx).Elem()

	for i := 0; i < values.NumField(); i++ {
		reflectValue := values.Field(i)
		reflectValue = reflect.NewAt(reflectValue.Type(), unsafe.Pointer(reflectValue.UnsafeAddr())).Elem()
		span, ok := reflectValue.Interface().(*sentry.Span)
		if !ok {
			continue
		}
		return span, true
	}
	return nil, false
}
```
