### PR TITLE
fix(crons): Pass correct event types, fix checkin_margin field, add example

### DIFF
--- a/_examples/crons/main.go
+++ b/_examples/crons/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func runTask(monitorSlug string, duration time.Duration, shouldFail bool) {
+	checkinId := sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			MonitorSlug: monitorSlug,
+			Status:      sentry.CheckInStatusInProgress,
+		},
+		&sentry.MonitorConfig{
+			Schedule:      sentry.CrontabSchedule("* * * * *"),
+			MaxRuntime:    2,
+			CheckInMargin: 1,
+		},
+	)
+	task := fmt.Sprintf("Task[monitor_slug=%s,id=%s]", monitorSlug, *checkinId)
+	fmt.Printf("Task started: %s\n", task)
+
+	time.Sleep(duration)
+
+	var status sentry.CheckInStatus
+	if shouldFail {
+		status = sentry.CheckInStatusError
+	} else {
+		status = sentry.CheckInStatusOK
+	}
+
+	sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			ID:          *checkinId,
+			MonitorSlug: monitorSlug,
+			Status:      status,
+		},
+		nil,
+	)
+	fmt.Printf("Task finished: %s; Status: %s\n", task, status)
+}
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn:   "",
+		Debug: true,
+	})
+
+	// Start a task that runs every minute and always succeeds
+	go func() {
+		for {
+			go runTask("sentry-go-periodic-task-success", time.Second, false)
+			time.Sleep(time.Minute)
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+
+	// Start a task that runs every minute and fails every second time
+	go func() {
+		shouldFail := true
+		for {
+			go runTask("sentry-go-periodic-task-sometimes-fail", 2*time.Second, shouldFail)
+			time.Sleep(time.Minute)
+			shouldFail = !shouldFail
+		}
+	}()
+
+	select {}
+}

--- a/check_in.go
+++ b/check_in.go
@@ -80,7 +80,7 @@ type MonitorConfig struct { //nolint: maligned // prefer readability over optima
 	Schedule MonitorSchedule `json:"schedule,omitempty"`
 	// The allowed margin of minutes after the expected check-in time that
 	// the monitor will not be considered missed for.
-	CheckInMargin int64 `json:"check_in_margin,omitempty"`
+	CheckInMargin int64 `json:"checkin_margin,omitempty"`
 	// The allowed duration in minutes that the monitor may be `in_progress`
 	// for before being considered failed due to timeout.
 	MaxRuntime int64 `json:"max_runtime,omitempty"`

--- a/testdata/json/checkin/001.json
+++ b/testdata/json/checkin/001.json
@@ -11,7 +11,7 @@
       "value": 1,
       "unit": "day"
     },
-    "check_in_margin": 5,
+    "checkin_margin": 5,
     "max_runtime": 30,
     "timezone": "America/Los_Angeles"
   }

--- a/testdata/json/checkin/002.json
+++ b/testdata/json/checkin/002.json
@@ -10,7 +10,7 @@
       "type": "crontab",
       "value": "0 * * * *"
     },
-    "check_in_margin": 5,
+    "checkin_margin": 5,
     "max_runtime": 30,
     "timezone": "America/Los_Angeles"
   }

--- a/transport.go
+++ b/transport.go
@@ -143,8 +143,8 @@ func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMes
 		return nil, err
 	}
 
-	if event.Type == transactionType {
-		err = encodeEnvelopeItem(enc, transactionType, body)
+	if event.Type == transactionType || event.Type == checkInType {
+		err = encodeEnvelopeItem(enc, event.Type, body)
 	} else {
 		err = encodeEnvelopeItem(enc, eventType, body)
 	}


### PR DESCRIPTION
Follow-up to #661 that fixes a few issues and also adds an E2E example.

* `check_in_margin` -> `checkin_margin` (https://develop.sentry.dev/sdk/check-ins/#monitor-upsert-support)
* When creating the event, set the type to `checkinType`
* Do not force event and check-in IDs to be the same