### PR TITLE
ref(otel): Add `ClientOptions.Instrumenter`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ TODO.md
 # IDE system files
 .idea
 .vscode
+
+/go.work*

--- a/client.go
+++ b/client.go
@@ -133,6 +133,9 @@ type ClientOptions struct {
 	TracesSampleRate float64
 	// Used to customize the sampling of traces, overrides TracesSampleRate.
 	TracesSampler TracesSampler
+	// Which instrumentation to use for tracing. Either "sentry" (default) or "otel" are supported.
+	// Setting this to "otel" will ignore TracesSampleRate and TracesSampler and assume sampling is performed by otel.
+	Instrumenter string
 	// The sample rate for profiling traces in the range [0.0, 1.0].
 	// This is relative to TracesSampleRate - it is a ratio of profiled traces out of all sampled traces.
 	ProfilesSampleRate float64
@@ -299,6 +302,19 @@ func NewClient(options ClientOptions) (*Client, error) {
 
 	if options.MaxSpans == 0 {
 		options.MaxSpans = defaultMaxSpans
+	}
+
+	switch options.Instrumenter {
+	case "":
+		options.Instrumenter = "sentry"
+	case "sentry":
+		// noop
+	case "otel":
+		// sampling is performed by the OpenTelemetry SDK
+		options.TracesSampleRate = 1.0
+		options.TracesSampler = nil
+	default:
+		return nil, fmt.Errorf("invalid value for TracesInstrumenter (supported are 'sentry' and 'otel'): %q", options.Instrumenter)
 	}
 
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar

--- a/client.go
+++ b/client.go
@@ -309,7 +309,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		options.Instrumenter = "sentry"
 	case "sentry", "otel": // noop
 	default:
-		return nil, fmt.Errorf("invalid value for TracesInstrumenter (supported are 'sentry' and 'otel'): %q", options.Instrumenter)
+		return nil, fmt.Errorf("invalid value for Instrumenter (supported are 'sentry' and 'otel'): %q", options.Instrumenter)
 	}
 
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar

--- a/client.go
+++ b/client.go
@@ -307,12 +307,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 	switch options.Instrumenter {
 	case "":
 		options.Instrumenter = "sentry"
-	case "sentry":
-		// noop
-	case "otel":
-		// sampling is performed by the OpenTelemetry SDK
-		options.TracesSampleRate = 1.0
-		options.TracesSampler = nil
+	case "sentry", "otel": // noop
 	default:
 		return nil, fmt.Errorf("invalid value for TracesInstrumenter (supported are 'sentry' and 'otel'): %q", options.Instrumenter)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	pkgErrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -870,4 +871,17 @@ func TestClientSetsUpTransport(t *testing.T) {
 
 	client, _ = NewClient(ClientOptions{})
 	require.IsType(t, &noopTransport{}, client.Transport)
+}
+
+func TestClientSetupInstrumenter(t *testing.T) {
+	client, err := NewClient(ClientOptions{Dsn: ""})
+	require.NoError(t, err)
+	assert.Equal(t, "sentry", client.Options().Instrumenter)
+
+	_, err = NewClient(ClientOptions{Dsn: "", Instrumenter: "foo"})
+	require.Error(t, err)
+
+	client, err = NewClient(ClientOptions{Dsn: "", Instrumenter: "otel"})
+	require.NoError(t, err)
+	assert.Equal(t, "otel", client.Options().Instrumenter)
 }

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -41,7 +41,7 @@ func emptyContextWithSentry() context.Context {
 		Environment:      "testing",
 		Release:          "1.2.3",
 		EnableTracing:    true,
-		TracesSampleRate: 1.0,
+		TracesSampleRate: 0.0, // we want to ensure otel's sampling decision (AlwaysSample) is used instead
 		Transport:        &TransportMock{},
 	})
 	hub := sentry.NewHub(client, sentry.NewScope())


### PR DESCRIPTION
<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->

This small PR is a first attempt to fix the perceived issue in #678.

It extends `sentry.ClientOptions` with the `Instrumenter` parameter, analogous to other language SDKs. This can be optionally set to "otel" or "sentry" (the default).  

This new option is then respected by middlewares to optionally skip creating a sentry transaction, allowing the consumer to only use "pure" otel for traces.

### Considered alternatives:

Another option would be making the transaction created by the otel [span processor](https://pkg.go.dev/github.com/getsentry/sentry-go/otel#NewSentrySpanProcessor) visible to the middlewares. However, since the span processor cannot easily modify the request context, it becomes necessary to add additional helpers (e.g. a new "adapter" middleware) with the single task of injecting the otel-created transaction into the request context.


Fixes: #678 #788
