### PR TITLE
fix(test): Increase Flush timeout for TestKeepAlive test

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -547,7 +547,7 @@ func testKeepAlive(t *testing.T, tr Transport) {
 	checkLastConnReuse := func(reused bool) {
 		t.Helper()
 		reqCount++
-		if !tr.Flush(time.Second) {
+		if !tr.Flush(2 * time.Second) {
 			t.Fatal("Flush timed out")
 		}
 		if len(rt.reusedConn) != reqCount {


### PR DESCRIPTION
A lazy attempt to fix this:

<img width="860" alt="image" src="https://github.com/getsentry/sentry-go/assets/1120468/688189ea-7f32-4913-ac87-6b2788135f03">
