### PR TITLE
ci: merge test & test-coverage steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,11 @@ jobs:
         run: make mod-tidy
         if: ${{ matrix.go == '1.20' }}
       - name: Test
-        run: make test
+        run: make test-coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: .coverage
       - name: Test (with race detection)
         run: make test-race
         # The race detector adds considerable runtime overhead. To save time on
@@ -56,12 +60,6 @@ jobs:
         # all other workflow triggers (e.g., pushes to a release branch) run
         # this step for the whole matrix.
         if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.20' && matrix.os == 'ubuntu') }}
-      - name: Collect coverage
-        run: make test-coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          directory: .coverage
     timeout-minutes: 15
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-coverage: $(COVERAGE_REPORT_DIR) clean-report-dir  ## Test with coverage en
 	  DIR_ABS=$$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $${dir}) ; \
 	  REPORT_NAME=$$(basename $${DIR_ABS}); \
 	  (cd "$${dir}" && \
-	    $(GO) test -count=1 -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" ./... && \
+	    $(GO) test -count=1 -timeout $(TIMEOUT)s -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" ./... && \
 		cp $(COVERAGE_PROFILE) "$(COVERAGE_REPORT_DIR_ABS)/$${REPORT_NAME}_$(COVERAGE_PROFILE)" && \
 	    $(GO) tool cover -html=$(COVERAGE_PROFILE) -o coverage.html); \
 	done;


### PR DESCRIPTION
This merges `test` and `test-coverate` steps in CI - there's no point in running both as they do the same thing and it just adds waiting time for the CI to finish (especially on Windows).