### PR TITLE
test: use mock transport to avoid many hanging worker routines

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -609,6 +609,7 @@ func TestSampleRate(t *testing.T) {
 func BenchmarkProcessEvent(b *testing.B) {
 	c, err := NewClient(ClientOptions{
 		SampleRate: 0.25,
+		Transport:  &TransportMock{},
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -708,7 +709,8 @@ func TestCustomMaxSpansProperty(t *testing.T) {
 	assertEqual(t, client.Options().MaxSpans, 2000)
 
 	properClient, _ := NewClient(ClientOptions{
-		MaxSpans: 3000,
+		MaxSpans:  3000,
+		Transport: &TransportMock{},
 	})
 
 	assertEqual(t, properClient.Options().MaxSpans, 3000)

--- a/hub_test.go
+++ b/hub_test.go
@@ -13,7 +13,7 @@ import (
 const testDsn = "http://whatever@example.com/1337"
 
 func setupHubTest() (*Hub, *Client, *Scope) {
-	client, _ := NewClient(ClientOptions{Dsn: testDsn})
+	client, _ := NewClient(ClientOptions{Dsn: testDsn, Transport: &TransportMock{}})
 	scope := NewScope()
 	hub := NewHub(client, scope)
 	return hub, client, scope
@@ -95,7 +95,7 @@ func TestPopScopeCannotLeaveStackEmpty(t *testing.T) {
 func TestBindClient(t *testing.T) {
 	hub, client, _ := setupHubTest()
 	hub.PushScope()
-	newClient, _ := NewClient(ClientOptions{Dsn: testDsn})
+	newClient, _ := NewClient(ClientOptions{Dsn: testDsn, Transport: &TransportMock{}})
 	hub.BindClient(newClient)
 
 	if (*hub.stack)[0].client == (*hub.stack)[1].client {
@@ -123,7 +123,7 @@ func TestWithScopeBindClient(t *testing.T) {
 	hub, client, _ := setupHubTest()
 
 	hub.WithScope(func(scope *Scope) {
-		newClient, _ := NewClient(ClientOptions{Dsn: testDsn})
+		newClient, _ := NewClient(ClientOptions{Dsn: testDsn, Transport: &TransportMock{}})
 		hub.BindClient(newClient)
 		if hub.stackTop().client != newClient {
 			t.Error("should use newly bound client")

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -362,6 +362,9 @@ type testContextKey struct{}
 type testContextValue struct{}
 
 func NewTestContext(options ClientOptions) context.Context {
+	if options.Transport == nil {
+		options.Transport = &TransportMock{}
+	}
 	client, err := NewClient(options)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I've noticed there are many HTTP transport worker goroutines running during tests (34 currently), and it was causing me some trouble when debugging profiling tests. 
This PR reduces the use of actual HTTP transport to tests that need to test it. Replaces with mock transport elsewhere.