### PR TITLE
test: fix hanging waitgroups

### DIFF
--- a/_examples/profiling/main.go
+++ b/_examples/profiling/main.go
@@ -43,6 +43,7 @@ func main() {
 	wg.Add(10)
 	for i := 0; i < 10; i++ {
 		go func(num int) {
+			defer wg.Done()
 			span := tx.StartChild(fmt.Sprintf("Goroutine %d", num))
 			defer span.Finish()
 			for i := 0; i < num; i++ {
@@ -50,7 +51,6 @@ func main() {
 				runtime.Gosched() // we need to manually yield this busy loop
 			}
 			fmt.Printf("routine %d done\n", num)
-			wg.Done()
 		}(i)
 	}
 	wg.Wait()

--- a/transport_test.go
+++ b/transport_test.go
@@ -448,8 +448,6 @@ func TestHTTPTransport(t *testing.T) {
 		}
 	}
 
-	// Actual tests
-
 	testSendSingleEvent := func(t *testing.T) {
 		// Sending a single event should increase the server event count by
 		// exactly one.
@@ -467,6 +465,8 @@ func TestHTTPTransport(t *testing.T) {
 		transportMustFlush(t, id)
 		serverEventCountMustBe(t, initialCount+1)
 	}
+
+	// Actual tests
 	t.Run("SendSingleEvent", testSendSingleEvent)
 
 	t.Run("FlushMultipleTimes", func(t *testing.T) {
@@ -485,12 +485,12 @@ func TestHTTPTransport(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
+			defer wg.Done()
 			testSendSingleEvent(t)
-			wg.Done()
 		}()
 		go func() {
+			defer wg.Done()
 			transportMustFlush(t, "from goroutine")
-			wg.Done()
 		}()
 		wg.Wait()
 	})


### PR DESCRIPTION
Makes sure `wg.Done()` is called even if the test code in transport test fails. 

With the original code, a test failure in `testSendSignalEvent()` [would result in a timeout](https://github.com/getsentry/sentry-go/actions/runs/5855059551/job/15872114963) because `wg.Done()` was never called and thus the subsequent `wg.Fail()` would get blocked indefinitely.

In the new version, the actual test failure will be reported instead.
