### PR TITLE
test: increase flush timeout in CI tests

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -433,7 +433,12 @@ func TestHTTPTransport(t *testing.T) {
 	transportMustFlush := func(t *testing.T, id string) {
 		t.Helper()
 
-		ok := transport.Flush(500 * time.Millisecond)
+		timeout := 100 * time.Millisecond
+		if isCI() {
+			// CI is very overloaded so we need to allow for a long wait time.
+			timeout = 5 * time.Second
+		}
+		ok := transport.Flush(timeout)
 		if !ok {
 			t.Fatalf("[CLIENT] {%.4s} Flush() timed out", id)
 		}


### PR DESCRIPTION
Transport `Flush()` test still fails even with the timeout increased recently in #663.

Let's go overboard here to 5 seconds in CI. I don't see any other way to make the test independent of timing...