### PR TITLE
Attach the `X-Sentry-Auth` header to /envelope requests

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -18,7 +18,6 @@ const SDKIdentifier = "sentry.go"
 
 // apiVersion is the minimum version of the Sentry API compatible with the
 // sentry-go SDK.
-// Deprecated: To be removed in 0.25.0.
 const apiVersion = "7"
 
 // Init initializes the SDK with options. The returned error is non-nil if

--- a/transport.go
+++ b/transport.go
@@ -211,6 +211,15 @@ func getRequestFromEvent(event *Event, dsn *Dsn) (r *http.Request, err error) {
 		if r != nil {
 			r.Header.Set("User-Agent", fmt.Sprintf("%s/%s", event.Sdk.Name, event.Sdk.Version))
 			r.Header.Set("Content-Type", "application/x-sentry-envelope")
+
+			auth := fmt.Sprintf("Sentry sentry_version=%s, "+
+				"sentry_client=%s/%s, sentry_key=%s", apiVersion, event.Sdk.Name, event.Sdk.Version, dsn.publicKey)
+
+			if dsn.secretKey != "" {
+				auth = fmt.Sprintf("%s, sentry_secret=%s", auth, dsn.secretKey)
+			}
+
+			r.Header.Set("X-Sentry-Auth", auth)
 		}
 	}()
 	body := getRequestBodyFromEvent(event)


### PR DESCRIPTION
After internal discussions, we're adding back the `X-Sentry-Auth` header to requests to the `/envelope` endpoint as it's more efficient than the envelope header auth.