### PR TITLE
fix(otel): prevent panic in shutdown

### DIFF
--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -103,6 +103,10 @@ func (ssp *sentrySpanProcessor) ForceFlush(ctx context.Context) error {
 
 func flushSpanProcessor(ctx context.Context) error {
 	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
+
 	// TODO(michi) should we make this configurable?
 	defer hub.Flush(2 * time.Second)
 	return nil

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -72,7 +72,7 @@ func TestNewSentrySpanProcessor(t *testing.T) {
 
 func TestSpanProcessorShutdown(t *testing.T) {
 	spanProcessor, _, tracer := setupSpanProcessorTest()
-	ctx := emptyContextWithSentry()
+	ctx := context.Background()
 	tracer.Start(emptyContextWithSentry(), "spanName")
 
 	assertEqual(t, sentrySpanMap.Len(), 1)


### PR DESCRIPTION
Shutdown panics when passed a background context, or any context which doesn't contain a hub. Returning the current hub if no hub is found on the context prevents this.

Fixes #692 