### PR TITLE
fix: Guard against a nil client when setting the SDK identifer

### DIFF
--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -53,7 +53,9 @@ func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 			hub = sentry.CurrentHub().Clone()
 		}
 
-		hub.Client().SetSDKIdentifier(sdkIdentifier)
+		if client := hub.Client(); client == nil {
+			client.SetSDKIdentifier(sdkIdentifier)
+		}
 
 		hub.Scope().SetRequest(ctx.Request())
 		ctx.Set(valuesKey, hub)

--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -53,7 +53,7 @@ func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 			hub = sentry.CurrentHub().Clone()
 		}
 
-		if client := hub.Client(); client == nil {
+		if client := hub.Client(); client != nil {
 			client.SetSDKIdentifier(sdkIdentifier)
 		}
 

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -62,7 +62,7 @@ func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandle
 		// context.Context but requires string keys.
 		hub := sentry.CurrentHub().Clone()
 
-		if client := hub.Client(); client == nil {
+		if client := hub.Client(); client != nil {
 			client.SetSDKIdentifier(sdkIdentifier)
 		}
 

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -62,7 +62,9 @@ func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandle
 		// context.Context but requires string keys.
 		hub := sentry.CurrentHub().Clone()
 
-		hub.Client().SetSDKIdentifier(sdkIdentifier)
+		if client := hub.Client(); client == nil {
+			client.SetSDKIdentifier(sdkIdentifier)
+		}
 
 		scope := hub.Scope()
 		scope.SetRequest(convert(ctx))

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -58,7 +58,7 @@ func (h *handler) handle(c *gin.Context) {
 		ctx = sentry.SetHubOnContext(ctx, hub)
 	}
 
-	if client := hub.Client(); client == nil {
+	if client := hub.Client(); client != nil {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -58,7 +58,9 @@ func (h *handler) handle(c *gin.Context) {
 		ctx = sentry.SetHubOnContext(ctx, hub)
 	}
 
-	hub.Client().SetSDKIdentifier(sdkIdentifier)
+	if client := hub.Client(); client == nil {
+		client.SetSDKIdentifier(sdkIdentifier)
+	}
 
 	var transactionName string
 	var transactionSource sentry.TransactionSource

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -90,7 +90,9 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
-		hub.Client().SetSDKIdentifier(sdkIdentifier)
+		if client := hub.Client(); client == nil {
+			client.SetSDKIdentifier(sdkIdentifier)
+		}
 
 		options := []sentry.SpanOption{
 			sentry.WithOpName("http.server"),

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -90,7 +90,7 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
-		if client := hub.Client(); client == nil {
+		if client := hub.Client(); client != nil {
 			client.SetSDKIdentifier(sdkIdentifier)
 		}
 

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -55,7 +55,7 @@ func (h *handler) handle(ctx iris.Context) {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client == nil {
+	if client := hub.Client(); client != nil {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -55,7 +55,9 @@ func (h *handler) handle(ctx iris.Context) {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	hub.Client().SetSDKIdentifier(sdkIdentifier)
+	if client := hub.Client(); client == nil {
+		client.SetSDKIdentifier(sdkIdentifier)
+	}
 
 	hub.Scope().SetRequest(ctx.Request())
 	ctx.Values().Set(valuesKey, hub)

--- a/martini/sentrymartini.go
+++ b/martini/sentrymartini.go
@@ -50,7 +50,9 @@ func (h *handler) handle(rw http.ResponseWriter, r *http.Request, ctx martini.Co
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	hub.Client().SetSDKIdentifier(sdkIdentifier)
+	if client := hub.Client(); client == nil {
+		client.SetSDKIdentifier(sdkIdentifier)
+	}
 
 	hub.Scope().SetRequest(r)
 	ctx.Map(hub)

--- a/martini/sentrymartini.go
+++ b/martini/sentrymartini.go
@@ -50,7 +50,7 @@ func (h *handler) handle(rw http.ResponseWriter, r *http.Request, ctx martini.Co
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client == nil {
+	if client := hub.Client(); client != nil {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -51,7 +51,7 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.H
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client == nil {
+	if client := hub.Client(); client != nil {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -51,7 +51,9 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.H
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	hub.Client().SetSDKIdentifier(sdkIdentifier)
+	if client := hub.Client(); client == nil {
+		client.SetSDKIdentifier(sdkIdentifier)
+	}
 
 	hub.Scope().SetRequest(r)
 	ctx = sentry.SetHubOnContext(


### PR DESCRIPTION
Fixes #714