### PR TITLE
feat: support IgnoreTransactions client option

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -137,9 +136,9 @@ type ClientOptions struct {
 	// The sample rate for profiling traces in the range [0.0, 1.0].
 	// This is relative to TracesSampleRate - it is a ratio of profiled traces out of all sampled traces.
 	ProfilesSampleRate float64
-	// List of regexp strings that will be used to match against an event's
-	// message and if applicable, the caught error's type and value.  If a match
-	// is found, then the whole event will be dropped.
+	// List of regexp strings that will be used to match against event's message
+	// and if applicable, caught errors type and value.
+	// If the match is found, then a whole event will be dropped.
 	IgnoreErrors []string
 	// List of regexp strings that will be used to match against a transaction's
 	// name.  If a match is found, then the transaction  will be dropped.
@@ -230,15 +229,13 @@ type ClientOptions struct {
 // Client is the underlying processor that is used by the main API and Hub
 // instances. It must be created with NewClient.
 type Client struct {
-	mu                 sync.RWMutex
-	options            ClientOptions
-	dsn                *Dsn
-	eventProcessors    []EventProcessor
-	integrations       []Integration
-	sdkIdentifier      string
-	sdkVersion         string
-	ignoreErrors       []*regexp.Regexp
-	ignoreTransactions []*regexp.Regexp
+	mu              sync.RWMutex
+	options         ClientOptions
+	dsn             *Dsn
+	eventProcessors []EventProcessor
+	integrations    []Integration
+	sdkIdentifier   string
+	sdkVersion      string
 	// Transport is read-only. Replacing the transport of an existing client is
 	// not supported, create a new client instead.
 	Transport Transport
@@ -334,31 +331,11 @@ func NewClient(options ClientOptions) (*Client, error) {
 		}
 	}
 
-	ignoreErrorsRegexes := make([]*regexp.Regexp, len(options.IgnoreErrors))
-	for i, re := range options.IgnoreErrors {
-		compiled, err := regexp.Compile(re)
-		if err != nil {
-			return nil, err
-		}
-		ignoreErrorsRegexes[i] = compiled
-	}
-
-	ignoreTransactionsRegexes := make([]*regexp.Regexp, len(options.IgnoreTransactions))
-	for i, re := range options.IgnoreTransactions {
-		compiled, err := regexp.Compile(re)
-		if err != nil {
-			return nil, err
-		}
-		ignoreTransactionsRegexes[i] = compiled
-	}
-
 	client := Client{
-		options:            options,
-		dsn:                dsn,
-		sdkIdentifier:      sdkIdentifier,
-		sdkVersion:         SDKVersion,
-		ignoreErrors:       ignoreErrorsRegexes,
-		ignoreTransactions: ignoreTransactionsRegexes,
+		options:       options,
+		dsn:           dsn,
+		sdkIdentifier: sdkIdentifier,
+		sdkVersion:    SDKVersion,
 	}
 
 	client.setupTransport()
@@ -397,6 +374,7 @@ func (client *Client) setupIntegrations() {
 		new(environmentIntegration),
 		new(modulesIntegration),
 		new(ignoreErrorsIntegration),
+		new(ignoreTransactionsIntegration),
 	}
 
 	if client.options.Integrations != nil {
@@ -650,22 +628,6 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 		if event = client.options.BeforeSend(event, hint); event == nil {
 			Logger.Println("Event dropped due to BeforeSend callback.")
 			return nil
-		}
-	}
-
-	if event.Type == transactionType {
-		for _, re := range client.ignoreTransactions {
-			if re.MatchString(event.Transaction) {
-				Logger.Println("Transaction dropped due to IgnoreTransactions match.")
-				return nil
-			}
-		}
-	} else {
-		for _, re := range client.ignoreErrors {
-			if re.MatchString(event.Message) {
-				Logger.Println("Event dropped due to IgnoreErrors match.")
-				return nil
-			}
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -659,7 +659,6 @@ func TestIgnoreTransactions(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestSampleRate(t *testing.T) {

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -173,6 +173,39 @@ func TestIgnoreErrorsIntegration(t *testing.T) {
 	}
 }
 
+func TestIgnoreTransactionsIntegration(t *testing.T) {
+	iei := ignoreTransactionsIntegration{
+		ignoreTransactions: []*regexp.Regexp{
+			regexp.MustCompile("foo"),
+			regexp.MustCompile("(?i)bar"),
+		},
+	}
+
+	dropped := &Event{
+		Transaction: "foo",
+	}
+
+	alsoDropped := &Event{
+		Transaction: "Bar",
+	}
+
+	notDropped := &Event{
+		Transaction: "dont",
+	}
+
+	if iei.processor(dropped, &EventHint{}) != nil {
+		t.Error("Transaction should be dropped")
+	}
+
+	if iei.processor(alsoDropped, &EventHint{}) != nil {
+		t.Error("Transaction should be dropped")
+	}
+
+	if iei.processor(notDropped, &EventHint{}) == nil {
+		t.Error("Transaction should not be dropped")
+	}
+}
+
 func TestContextifyFrames(t *testing.T) {
 	cfi := contextifyFramesIntegration{
 		sr:           newSourceReader(),


### PR DESCRIPTION
Adds support for ignoring transactions by using the `IgnoreTransactions` client option. This requires a slice of regex strings that are matched against a transaction's name. If there's a match the transaction is dropped.

Fixes #628 