### PR TITLE
feat: global tags

### DIFF
--- a/client.go
+++ b/client.go
@@ -224,7 +224,7 @@ type ClientOptions struct {
 	// is not optimized for long chains either. The top-level error together with a
 	// stack trace is often the most useful information.
 	MaxErrorDepth int
-	// Optional global tags
+	// Default event tags. These are overriden by tags set on a scope.
 	Tags map[string]string
 }
 

--- a/client.go
+++ b/client.go
@@ -224,7 +224,7 @@ type ClientOptions struct {
 	// is not optimized for long chains either. The top-level error together with a
 	// stack trace is often the most useful information.
 	MaxErrorDepth int
-	// Default event tags. These are overriden by tags set on a scope.
+	// Default event tags. These are overridden by tags set on a scope.
 	Tags map[string]string
 }
 

--- a/client.go
+++ b/client.go
@@ -224,6 +224,8 @@ type ClientOptions struct {
 	// is not optimized for long chains either. The top-level error together with a
 	// stack trace is often the most useful information.
 	MaxErrorDepth int
+	// Optional global tags
+	Tags map[string]string
 }
 
 // Client is the underlying processor that is used by the main API and Hub
@@ -375,6 +377,7 @@ func (client *Client) setupIntegrations() {
 		new(modulesIntegration),
 		new(ignoreErrorsIntegration),
 		new(ignoreTransactionsIntegration),
+		new(globalTagsIntegration),
 	}
 
 	if client.options.Integrations != nil {

--- a/integrations.go
+++ b/integrations.go
@@ -343,8 +343,13 @@ func (ti *globalTagsIntegration) Name() string {
 }
 
 func (ti *globalTagsIntegration) SetupOnce(client *Client) {
-	ti.tags = client.options.Tags
+	ti.tags = make(map[string]string, len(client.options.Tags))
+	for k, v := range client.options.Tags {
+		ti.tags[k] = v
+	}
+
 	ti.envTags = loadEnvTags()
+
 	client.AddEventProcessor(ti.processor)
 }
 

--- a/integrations.go
+++ b/integrations.go
@@ -385,7 +385,6 @@ func loadEnvTags() map[string]string {
 			continue
 		}
 		tag := strings.TrimPrefix(parts[0], envTagsPrefix)
-		tag = strings.ToLower(tag)
 		tags[tag] = parts[1]
 	}
 	return tags

--- a/integrations.go
+++ b/integrations.go
@@ -349,6 +349,10 @@ func (ti *globalTagsIntegration) SetupOnce(client *Client) {
 }
 
 func (ti *globalTagsIntegration) processor(event *Event, hint *EventHint) *Event {
+	if len(ti.tags) == 0 && len(ti.envTags) == 0 {
+		return event
+	}
+
 	if event.Tags == nil {
 		event.Tags = make(map[string]string, len(ti.tags)+len(ti.envTags))
 	}

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
@@ -420,4 +421,51 @@ func TestEnvironmentIntegrationDoesNotOverrideExistingContexts(t *testing.T) {
 	if contexts["custom"]["key"] != "value" {
 		t.Errorf(`contexts["custom"]["key"] = %#v, want "value"`, contexts["custom"]["key"])
 	}
+}
+
+func TestGlobalTagsIntegration(t *testing.T) {
+	os.Setenv("SENTRY_TAGS_FOO", "foo_value_env")
+	os.Setenv("SENTRY_TAGS_BAR", "bar_value_env")
+	os.Setenv("SENTRY_TAGS_BAZ", "baz_value_env")
+	defer os.Unsetenv("SENTRY_TAGS_FOO")
+	defer os.Unsetenv("SENTRY_TAGS_BAR")
+	defer os.Unsetenv("SENTRY_TAGS_BAZ")
+
+	transport := &TransportMock{}
+	client, err := NewClient(ClientOptions{
+		Transport: transport,
+		Tags: map[string]string{
+			"foo": "foo_value_client_options",
+			"baz": "baz_value_client_options",
+		},
+		Integrations: func([]Integration) []Integration {
+			return []Integration{new(globalTagsIntegration)}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scope := NewScope()
+	scope.SetTags(map[string]string{"foo": "foo_value_scope"})
+
+	event := NewEvent()
+	event.Message = "event message"
+	client.CaptureEvent(event, nil, scope)
+
+	assertEqual(t,
+		transport.lastEvent.Tags["foo"],
+		"foo_value_scope",
+		"scope tag should override any global tag",
+	)
+	assertEqual(t,
+		transport.lastEvent.Tags["bar"],
+		"bar_value_env",
+		"env tag present if not overriden by scope or client options tags",
+	)
+	assertEqual(t,
+		transport.lastEvent.Tags["baz"],
+		"baz_value_client_options",
+		"client options tag present if not overriden by scope and overrides env tag",
+	)
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -461,11 +461,11 @@ func TestGlobalTagsIntegration(t *testing.T) {
 	assertEqual(t,
 		transport.lastEvent.Tags["bar"],
 		"bar_value_env",
-		"env tag present if not overriden by scope or client options tags",
+		"env tag present if not overridden by scope or client options tags",
 	)
 	assertEqual(t,
 		transport.lastEvent.Tags["baz"],
 		"baz_value_client_options",
-		"client options tag present if not overriden by scope and overrides env tag",
+		"client options tag present if not overridden by scope and overrides env tag",
 	)
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -424,12 +424,12 @@ func TestEnvironmentIntegrationDoesNotOverrideExistingContexts(t *testing.T) {
 }
 
 func TestGlobalTagsIntegration(t *testing.T) {
-	os.Setenv("SENTRY_TAGS_FOO", "foo_value_env")
-	os.Setenv("SENTRY_TAGS_BAR", "bar_value_env")
-	os.Setenv("SENTRY_TAGS_BAZ", "baz_value_env")
-	defer os.Unsetenv("SENTRY_TAGS_FOO")
-	defer os.Unsetenv("SENTRY_TAGS_BAR")
-	defer os.Unsetenv("SENTRY_TAGS_BAZ")
+	os.Setenv("SENTRY_TAGS_foo", "foo_value_env")
+	os.Setenv("SENTRY_TAGS_bar", "bar_value_env")
+	os.Setenv("SENTRY_TAGS_baz", "baz_value_env")
+	defer os.Unsetenv("SENTRY_TAGS_foo")
+	defer os.Unsetenv("SENTRY_TAGS_bar")
+	defer os.Unsetenv("SENTRY_TAGS_baz")
 
 	transport := &TransportMock{}
 	client, err := NewClient(ClientOptions{


### PR DESCRIPTION
Add global tags support.

Tags can be passed via client options or via environment variables by prefixing them with "SENTRY_TAGS_".

Setting scope tags overrides global tags.

Client option tags override environment variable tags.

Fixes: #331 