### PR TITLE
RFC: implement per event sample rates.

### DIFF
--- a/client.go
+++ b/client.go
@@ -607,7 +607,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	// Transactions are sampled by options.TracesSampleRate or
 	// options.TracesSampler when they are started. All other events
 	// (errors, messages) are sampled here.
-	if event.Type != transactionType && !sample(client.options.SampleRate) {
+	if event.Type != transactionType && !sample(firstNonNegativeRate(event.sampleRate, client.options.SampleRate)) {
 		Logger.Println("Event dropped due to SampleRate hit.")
 		return nil
 	}
@@ -737,4 +737,14 @@ func (client *Client) integrationAlreadyInstalled(name string) bool {
 // [0.0, 1.0].
 func sample(probability float64) bool {
 	return rng.Float64() < probability
+}
+
+func firstNonNegativeRate(rates ...float64) float64 {
+	for _, r := range rates {
+		if r >= 0.0 {
+			return r
+		}
+	}
+
+	return 0.0
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -335,6 +335,13 @@ type Event struct {
 
 	sdkMetaData SDKMetaData
 	attachments []*Attachment
+	sampleRate  float64 `json:"-"`
+}
+
+// SetSampleRate allows setting a per event sample rate that takes
+// precendence over the global sample rate.
+func (e *Event) SetSampleRate(r float64) {
+	e.sampleRate = r
 }
 
 // SetException appends the unwrapped errors to the event's exception list.
@@ -494,10 +501,11 @@ func (e *Event) checkInMarshalJSON() ([]byte, error) {
 // NewEvent creates a new Event.
 func NewEvent() *Event {
 	event := Event{
-		Contexts: make(map[string]Context),
-		Extra:    make(map[string]interface{}),
-		Tags:     make(map[string]string),
-		Modules:  make(map[string]string),
+		sampleRate: -1.0,
+		Contexts:   make(map[string]Context),
+		Extra:      make(map[string]interface{}),
+		Tags:       make(map[string]string),
+		Modules:    make(map[string]string),
 	}
 	return &event
 }


### PR DESCRIPTION
opening this to move discussion forward on #686 which i felt was closed without adequately addressing the problem being brought forth. if the idea is acceptable i'll gladly add tests etc.

pros:
- allows setting sample rates per event. meaning we don't need complicated interactions between sample rates and beforesend.
- no need for a global filter to do basic sampling.
- maintains default behavior.
