### PR TITLE
Update changelog to mention Breaking Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.25.0.
 
-### Deprecations
+### Breaking Changes
 
 As previously announced, this release removes two global constants from the SDK.
 


### PR DESCRIPTION
Copy & Paste error, this was actually a breaking change.
I updated https://github.com/getsentry/sentry-go/releases/tag/v0.25.0 accordingly.