### PR TITLE
fix(stacktrace): support package name parsing for Go 1.20+

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -355,9 +355,7 @@ func callerFunctionName() string {
 // It replicates https://golang.org/pkg/debug/gosym/#Sym.PackageName, avoiding a
 // dependency on debug/gosym.
 func packageName(name string) string {
-	// A prefix of "type." and "go." is a compiler-generated symbol that doesn't belong to any package.
-	// See variable reservedimports in cmd/compile/internal/gc/subr.go
-	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
+	if isCompilerGeneratedSymbol(name) {
 		return ""
 	}
 

--- a/stacktrace_below_go1.20.go
+++ b/stacktrace_below_go1.20.go
@@ -1,0 +1,15 @@
+//go:build !go1.20
+
+package sentry
+
+import "strings"
+
+// In versions of Go below 1.20 a prefix of "type." and "go." is a
+// compiler-generated symbol that doesn't belong to any package.
+// See variable reservedimports in cmd/compile/internal/gc/subr.go
+func isCompilerGeneratedSymbol(name string) bool {
+	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
+		return true
+	}
+	return false
+}

--- a/stacktrace_below_go1.20.go
+++ b/stacktrace_below_go1.20.go
@@ -4,10 +4,10 @@ package sentry
 
 import "strings"
 
-// In versions of Go below 1.20 a prefix of "type." and "go." is a
-// compiler-generated symbol that doesn't belong to any package.
-// See variable reservedimports in cmd/compile/internal/gc/subr.go
 func isCompilerGeneratedSymbol(name string) bool {
+	// In versions of Go below 1.20 a prefix of "type." and "go." is a
+	// compiler-generated symbol that doesn't belong to any package.
+	// See variable reservedimports in cmd/compile/internal/gc/subr.go
 	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
 		return true
 	}

--- a/stacktrace_below_go1.20_test.go
+++ b/stacktrace_below_go1.20_test.go
@@ -1,0 +1,32 @@
+//go:build !go1.20
+
+package sentry
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterCompilerGeneratedSymbols(t *testing.T) {
+	tests := []struct {
+		symbol              string
+		expectedPackageName string
+	}{
+		{"type..eq.[9]debug/elf.intName", ""},
+		{"type..hash.debug/elf.ProgHeader", ""},
+		{"type..eq.runtime._panic", ""},
+		{"type..hash.struct { runtime.gList; runtime.n int32 }", ""},
+		{"go.(*struct { sync.Mutex; math/big.table [64]math/big", ""},
+		{"github.com/getsentry/sentry-go.Test.func2.1.1", "github.com/getsentry/sentry-go"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.symbol, func(t *testing.T) {
+			packageName := packageName(tt.symbol)
+			if diff := cmp.Diff(tt.expectedPackageName, packageName); diff != "" {
+				t.Errorf("Package name mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/stacktrace_go1.20.go
+++ b/stacktrace_go1.20.go
@@ -4,10 +4,10 @@ package sentry
 
 import "strings"
 
-// In versions of Go 1.20 and above a prefix of "type:" and "go:" is a
-// compiler-generated symbol that doesn't belong to any package.
-// See variable reservedimports in cmd/compile/internal/gc/subr.go
 func isCompilerGeneratedSymbol(name string) bool {
+	// In versions of Go 1.20 and above a prefix of "type:" and "go:" is a
+	// compiler-generated symbol that doesn't belong to any package.
+	// See variable reservedimports in cmd/compile/internal/gc/subr.go
 	if strings.HasPrefix(name, "go:") || strings.HasPrefix(name, "type:") {
 		return true
 	}

--- a/stacktrace_go1.20.go
+++ b/stacktrace_go1.20.go
@@ -1,0 +1,15 @@
+//go:build go1.20
+
+package sentry
+
+import "strings"
+
+// In versions of Go 1.20 and above a prefix of "type:" and "go:" is a
+// compiler-generated symbol that doesn't belong to any package.
+// See variable reservedimports in cmd/compile/internal/gc/subr.go
+func isCompilerGeneratedSymbol(name string) bool {
+	if strings.HasPrefix(name, "go:") || strings.HasPrefix(name, "type:") {
+		return true
+	}
+	return false
+}

--- a/stacktrace_go1.20_test.go
+++ b/stacktrace_go1.20_test.go
@@ -1,0 +1,32 @@
+//go:build go1.20
+
+package sentry
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterCompilerGeneratedSymbols(t *testing.T) {
+	tests := []struct {
+		symbol              string
+		expectedPackageName string
+	}{
+		{"type:.eq.[9]debug/elf.intName", ""},
+		{"type:.hash.debug/elf.ProgHeader", ""},
+		{"type:.eq.runtime._panic", ""},
+		{"type:.hash.struct { runtime.gList; runtime.n int32 }", ""},
+		{"go:(*struct { sync.Mutex; math/big.table [64]math/big", ""},
+		{"go.uber.org/zap/buffer.(*Buffer).AppendString", "go.uber.org/zap/buffer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.symbol, func(t *testing.T) {
+			packageName := packageName(tt.symbol)
+			if diff := cmp.Diff(tt.expectedPackageName, packageName); diff != "" {
+				t.Errorf("Package name mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Go 1.20+ changed reserved prefixes for compiler-generated symbols from "go." and "type." to "go:" and "type:" respectively.

See: https://github.com/golang/go/commit/0f8dffd0aa71ed996d32e77701ac5ec0bc7cde01a

This adds support for both kinds of compiler-generated symbols depending on the Go version by taking advantage of build tags.

Fixes #180 

Inspired by and continued on from: https://github.com/getsentry/sentry-go/pull/707