### PR TITLE
ref: remove deprecated span options

### DIFF
--- a/span_recorder_test.go
+++ b/span_recorder_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_spanRecorder_record(t *testing.T) {
-	testRootSpan := StartSpan(context.Background(), "test", TransactionName("test transaction"))
+	testRootSpan := StartSpan(context.Background(), "test", WithTransactionName("test transaction"))
 
 	for _, tt := range []struct {
 		name           string

--- a/tracing.go
+++ b/tracing.go
@@ -829,17 +829,6 @@ func (s Sampled) Bool() bool {
 // A SpanOption is a function that can modify the properties of a span.
 type SpanOption func(s *Span)
 
-// The TransactionName option sets the name of the current transaction.
-//
-// A span tree has a single transaction name, therefore using this option when
-// starting a span affects the span tree as a whole, potentially overwriting a
-// name set previously.
-//
-// Deprecated: To be removed in 0.26.0. Use WithTransactionName() instead.
-func TransactionName(name string) SpanOption {
-	return WithTransactionName(name)
-}
-
 // WithTransactionName option sets the name of the current transaction.
 //
 // A span tree has a single transaction name, therefore using this option when
@@ -851,25 +840,11 @@ func WithTransactionName(name string) SpanOption {
 	}
 }
 
-// OpName sets the operation name for a given span.
-//
-// Deprecated: To be removed in 0.26.0. Use WithOpName() instead.
-func OpName(name string) SpanOption {
-	return WithOpName(name)
-}
-
 // WithOpName sets the operation name for a given span.
 func WithOpName(name string) SpanOption {
 	return func(s *Span) {
 		s.Op = name
 	}
-}
-
-// TransctionSource sets the source of the transaction name.
-//
-// Deprecated: To be removed in 0.26.0. Use WithTransactionSource() instead.
-func TransctionSource(source TransactionSource) SpanOption {
-	return WithTransactionSource(source)
 }
 
 // WithTransactionSource sets the source of the transaction name.
@@ -881,13 +856,6 @@ func WithTransactionSource(source TransactionSource) SpanOption {
 	return func(s *Span) {
 		s.Source = source
 	}
-}
-
-// SpanSampled updates the sampling flag for a given span.
-//
-// Deprecated: To be removed in 0.26.0. Use WithSpanSampled() instead.
-func SpanSampled(sampled Sampled) SpanOption {
-	return WithSpanSampled(sampled)
 }
 
 // WithSpanSampled updates the sampling flag for a given span.

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -875,26 +875,6 @@ func TestSpanSetContextOverrides(t *testing.T) {
 	assertEqual(t, map[string]Context{"a": {"foo": 2}}, transaction.contexts)
 }
 
-// This test should be the only thing to fail when deprecated TransactionName is removed.
-func TestDeprecatedSpanOptionTransactionName(t *testing.T) {
-	StartSpan(context.Background(), "op", TransactionName("name"))
-}
-
-// This test should be the only thing to fail when deprecated OpName is removed.
-func TestDeprecatedSpanOptionOpName(t *testing.T) {
-	StartSpan(context.Background(), "op", OpName("name"))
-}
-
-// This test should be the only thing to fail when deprecated SpanSampled is removed.
-func TestDeprecatedSpanOptionSpanSampled(t *testing.T) {
-	StartSpan(context.Background(), "op", SpanSampled(SampledTrue))
-}
-
-// This test should be the only thing to fail when deprecated TransctionSource is removed.
-func TestDeprecatedSpanOptionTransctionSource(t *testing.T) {
-	StartSpan(context.Background(), "op", TransctionSource("src"))
-}
-
 // This test checks that there are no concurrent reads/writes to
 // substructures in scope.contexts.
 // See https://github.com/getsentry/sentry-go/issues/570 for more details.


### PR DESCRIPTION
Remove the SpanSampled, OpName, TransactionName, Transaction Source span options which are now deprecated and superseded by their "With" prefixed variants.

Fixes: #625 