### PR TITLE
feat(tracing without performance): add propagation context to scope

### DIFF
--- a/propagation_context.go
+++ b/propagation_context.go
@@ -1,0 +1,92 @@
+package sentry
+
+import (
+	"crypto/rand"
+	"encoding/json"
+)
+
+type PropagationContext struct {
+	TraceID                TraceID                `json:"trace_id"`
+	SpanID                 SpanID                 `json:"span_id"`
+	ParentSpanID           SpanID                 `json:"parent_span_id"`
+	DynamicSamplingContext DynamicSamplingContext `json:"-"`
+}
+
+func (p PropagationContext) MarshalJSON() ([]byte, error) {
+	type propagationContext PropagationContext
+	var parentSpanID string
+	if p.ParentSpanID != zeroSpanID {
+		parentSpanID = p.ParentSpanID.String()
+	}
+	return json.Marshal(struct {
+		*propagationContext
+		ParentSpanID string `json:"parent_span_id,omitempty"`
+	}{
+		propagationContext: (*propagationContext)(&p),
+		ParentSpanID:       parentSpanID,
+	})
+}
+
+func (p PropagationContext) Map() map[string]interface{} {
+	m := map[string]interface{}{
+		"trace_id": p.TraceID,
+		"span_id":  p.SpanID,
+	}
+
+	if p.ParentSpanID != zeroSpanID {
+		m["parent_span_id"] = p.ParentSpanID
+	}
+
+	return m
+}
+
+func NewPropagationContext() PropagationContext {
+	p := PropagationContext{}
+
+	if _, err := rand.Read(p.TraceID[:]); err != nil {
+		panic(err)
+	}
+
+	if _, err := rand.Read(p.SpanID[:]); err != nil {
+		panic(err)
+	}
+
+	p.DynamicSamplingContext = DynamicSamplingContext{}
+
+	return p
+}
+
+func PropagationContextFromHeaders(trace, baggage string) (PropagationContext, error) {
+	p := NewPropagationContext()
+
+	if _, err := rand.Read(p.SpanID[:]); err != nil {
+		panic(err)
+	}
+
+	hasTrace := false
+	if trace != "" {
+		if tpc, valid := ParseTraceParentContext([]byte(trace)); valid {
+			hasTrace = true
+			p.TraceID = tpc.TraceID
+			p.ParentSpanID = tpc.ParentSpanID
+		}
+	}
+
+	if baggage != "" {
+		dsc, err := DynamicSamplingContextFromHeader([]byte(baggage))
+		if err != nil {
+			return PropagationContext{}, err
+		}
+		p.DynamicSamplingContext = dsc
+	}
+
+	// In case a sentry-trace header is present but there are no sentry-related
+	// values in the baggage, create an empty, frozen DynamicSamplingContext.
+	if hasTrace && !p.DynamicSamplingContext.HasEntries() {
+		p.DynamicSamplingContext = DynamicSamplingContext{
+			Frozen: true,
+		}
+	}
+
+	return p, nil
+}

--- a/propagation_context.go
+++ b/propagation_context.go
@@ -51,8 +51,6 @@ func NewPropagationContext() PropagationContext {
 		panic(err)
 	}
 
-	p.DynamicSamplingContext = DynamicSamplingContext{}
-
 	return p
 }
 

--- a/propagation_context_test.go
+++ b/propagation_context_test.go
@@ -1,0 +1,133 @@
+package sentry
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestPropagationContextMarshalJSON(t *testing.T) {
+	v := NewPropagationContext()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte("parent_span_id")) {
+		t.Fatalf("unwanted parent_span_id: %s", b)
+	}
+
+	v.ParentSpanID = SpanIDFromHex("b72fa28504b07285")
+	b2, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b2, []byte("parent_span_id")) {
+		t.Fatalf("missing parent_span_id: %s", b)
+	}
+}
+
+func TestPropagationContextMap(t *testing.T) {
+	p := NewPropagationContext()
+	assertEqual(t,
+		p.Map(),
+		map[string]interface{}{
+			"trace_id": p.TraceID,
+			"span_id":  p.SpanID,
+		},
+		"without parent span id")
+
+	p.ParentSpanID = SpanIDFromHex("b72fa28504b07285")
+	assertEqual(t,
+		p.Map(),
+		map[string]interface{}{
+			"trace_id":       p.TraceID,
+			"span_id":        p.SpanID,
+			"parent_span_id": p.ParentSpanID,
+		},
+		"without praent span id")
+}
+
+func TestPropagationContextFromHeaders(t *testing.T) {
+	tests := []struct {
+		traceStr   string
+		baggageStr string
+		want       PropagationContext
+	}{
+		{
+			// No sentry-trace or baggage => nothing to do, unfrozen DSC
+			traceStr:   "",
+			baggageStr: "",
+			want: PropagationContext{
+				DynamicSamplingContext: DynamicSamplingContext{
+					Frozen:  false,
+					Entries: nil,
+				},
+			},
+		},
+		{
+			// Third-party baggage => nothing to do, unfrozen DSC
+			traceStr:   "",
+			baggageStr: "other-vendor-key1=value1;value2, other-vendor-key2=value3",
+			want: PropagationContext{
+				DynamicSamplingContext: DynamicSamplingContext{
+					Frozen:  false,
+					Entries: map[string]string{},
+				},
+			},
+		},
+		{
+			// sentry-trace and no baggage => we should create a new DSC and freeze it
+			// immediately.
+			traceStr:   "bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1",
+			baggageStr: "",
+			want: PropagationContext{
+				TraceID:      TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4"),
+				ParentSpanID: SpanIDFromHex("b72fa28504b07285"),
+				DynamicSamplingContext: DynamicSamplingContext{
+					Frozen: true,
+				},
+			},
+		},
+		{
+			traceStr:   "bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1",
+			baggageStr: "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1",
+			want: PropagationContext{
+				TraceID:      TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4"),
+				ParentSpanID: SpanIDFromHex("b72fa28504b07285"),
+				DynamicSamplingContext: DynamicSamplingContext{
+					Frozen: true,
+					Entries: map[string]string{
+						"public_key":  "public",
+						"sample_rate": "1",
+						"trace_id":    "d49d9bf66f13450b81f65bc51cf49c03",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		p, err := PropagationContextFromHeaders(tt.traceStr, tt.baggageStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if tt.want.TraceID != zeroTraceID && p.TraceID != tt.want.TraceID {
+			t.Errorf("got TraceID = %s, want %s", p.TraceID, tt.want.TraceID)
+		}
+
+		if p.TraceID == zeroTraceID {
+			t.Errorf("got TraceID = %s, want non-zero", p.TraceID)
+		}
+
+		if p.ParentSpanID != tt.want.ParentSpanID {
+			t.Errorf("got ParentSpanID = %s, want %s", p.ParentSpanID, tt.want.ParentSpanID)
+		}
+
+		if p.SpanID == zeroSpanID {
+			t.Errorf("got SpanID = %s, want non-zero", p.SpanID)
+		}
+
+		assertEqual(t, p.DynamicSamplingContext, tt.want.DynamicSamplingContext)
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -43,6 +43,8 @@ type Scope struct {
 		Overflow() bool
 	}
 	eventProcessors []EventProcessor
+
+	propagationContext PropagationContext
 }
 
 // NewScope creates a new Scope.
@@ -292,6 +294,14 @@ func (scope *Scope) SetLevel(level Level) {
 	scope.level = level
 }
 
+// SetPropagationContext sets the propagation context for the current scope.
+func (scope *Scope) SetPropagationContext(propagationContext PropagationContext) {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+
+	scope.propagationContext = propagationContext
+}
+
 // Clone returns a copy of the current scope with all data copied over.
 func (scope *Scope) Clone() *Scope {
 	scope.mu.RLock()
@@ -318,6 +328,7 @@ func (scope *Scope) Clone() *Scope {
 	clone.request = scope.request
 	clone.requestBody = scope.requestBody
 	clone.eventProcessors = scope.eventProcessors
+	clone.propagationContext = scope.propagationContext
 	return clone
 }
 

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -57,6 +57,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.AddAttachment(&sentry.Attachment{Filename: "foo.txt"})
 	scope.SetUser(sentry.User{ID: "foo"})
 	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
+	scope.SetPropagationContext(sentry.NewPropagationContext())
 
 	sentry.CaptureException(fmt.Errorf("error %d", x))
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -29,6 +29,7 @@ func fillScopeWithData(scope *Scope) *Scope {
 	scope.fingerprint = []string{"scopeFingerprintOne", "scopeFingerprintTwo"}
 	scope.level = LevelDebug
 	scope.request = httptest.NewRequest("GET", "/wat", nil)
+	scope.propagationContext = NewPropagationContext()
 	return scope
 }
 


### PR DESCRIPTION
This is the start of a series of PRs for implementing tracing without performance.

This initial PR adds a `PropagationContext` field to the scope.