### PR TITLE
Allowing platform and SDK overrides

### DIFF
--- a/client.go
+++ b/client.go
@@ -673,15 +673,19 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		event.Environment = client.options.Environment
 	}
 
-	event.Platform = "go"
-	event.Sdk = SdkInfo{
-		Name:         client.GetSDKIdentifier(),
-		Version:      SDKVersion,
-		Integrations: client.listIntegrations(),
-		Packages: []SdkPackage{{
-			Name:    "sentry-go",
-			Version: SDKVersion,
-		}},
+	if event.Platform == "" {
+		event.Platform = "go"
+	}
+	if event.Sdk.Name == "" {
+		event.Sdk = SdkInfo{
+			Name:         client.GetSDKIdentifier(),
+			Version:      SDKVersion,
+			Integrations: client.listIntegrations(),
+			Packages: []SdkPackage{{
+				Name:    "sentry-go",
+				Version: SDKVersion,
+			}},
+		}
 	}
 
 	if scope != nil {

--- a/interfaces.go
+++ b/interfaces.go
@@ -337,6 +337,18 @@ type Event struct {
 	attachments []*Attachment
 }
 
+// AddAttachment adds an Event-specific Attachment
+//
+// Scope attachments will still be added to this event
+func (e *Event) AddAttachment(attachment *Attachment) {
+	e.attachments = append(e.attachments, attachment)
+}
+
+// ClearAttachments clears all Event-specific attachments from the event.
+func (e *Event) ClearAttachments() {
+	e.attachments = []*Attachment{}
+}
+
 // SetException appends the unwrapped errors to the event's exception list.
 //
 // maxErrorDepth is the maximum depth of the error chain we will look


### PR DESCRIPTION
This change will allow overrides to the reported platform and SDK.  This is useful if you're using the go library to convert and push other kinds of crashes (i.e. not go program crashes).  Additionally, this allows you to add Event-specific attachments beyond the shared scope's.