### PR TITLE
feat(tracing without performance): set span on scope

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -45,6 +45,7 @@ type Scope struct {
 	eventProcessors []EventProcessor
 
 	propagationContext PropagationContext
+	span               *Span
 }
 
 // NewScope creates a new Scope.
@@ -302,6 +303,14 @@ func (scope *Scope) SetPropagationContext(propagationContext PropagationContext)
 	scope.propagationContext = propagationContext
 }
 
+// SetSpan sets a span for the current scope.
+func (scope *Scope) SetSpan(span *Span) {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+
+	scope.span = span
+}
+
 // Clone returns a copy of the current scope with all data copied over.
 func (scope *Scope) Clone() *Scope {
 	scope.mu.RLock()
@@ -329,6 +338,7 @@ func (scope *Scope) Clone() *Scope {
 	clone.requestBody = scope.requestBody
 	clone.eventProcessors = scope.eventProcessors
 	clone.propagationContext = scope.propagationContext
+	clone.span = scope.span
 	return clone
 }
 

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -58,6 +58,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.SetUser(sentry.User{ID: "foo"})
 	scope.SetRequest(httptest.NewRequest("GET", "/foo", nil))
 	scope.SetPropagationContext(sentry.NewPropagationContext())
+	scope.SetSpan(&sentry.Span{TraceID: sentry.TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03")})
 
 	sentry.CaptureException(fmt.Errorf("error %d", x))
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -419,6 +419,8 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 	clone.SetRequest(r1)
 	p1 := NewPropagationContext()
 	clone.SetPropagationContext(p1)
+	s1 := &Span{TraceID: TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")}
+	clone.SetSpan(s1)
 
 	scope.SetTag("foo", "baz")
 	scope.SetContext("foo", Context{"foo": "baz"})
@@ -432,6 +434,8 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 	scope.SetRequest(r2)
 	p2 := NewPropagationContext()
 	scope.SetPropagationContext(p2)
+	s2 := &Span{TraceID: TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03")}
+	scope.SetSpan(s2)
 
 	assertEqual(t, map[string]string{"foo": "bar"}, clone.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "bar"}}, clone.contexts)
@@ -443,6 +447,7 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 	assertEqual(t, User{ID: "foo"}, clone.user)
 	assertEqual(t, r1, clone.request)
 	assertEqual(t, p1, clone.propagationContext)
+	assertEqual(t, s1, clone.span)
 
 	assertEqual(t, map[string]string{"foo": "baz"}, scope.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "baz"}}, scope.contexts)
@@ -453,7 +458,7 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 	assertEqual(t, []*Attachment{{Filename: "bar.txt", Payload: []byte("bar")}}, scope.attachments)
 	assertEqual(t, User{ID: "bar"}, scope.user)
 	assertEqual(t, r2, scope.request)
-	assertEqual(t, p2, scope.propagationContext)
+	assertEqual(t, s2, scope.span)
 }
 
 func TestScopeChildOverrideInheritance(t *testing.T) {
@@ -474,6 +479,8 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	})
 	p1 := NewPropagationContext()
 	scope.SetPropagationContext(p1)
+	s1 := &Span{TraceID: TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")}
+	scope.SetSpan(s1)
 
 	clone := scope.Clone()
 	clone.SetTag("foo", "bar")
@@ -491,6 +498,8 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	})
 	p2 := NewPropagationContext()
 	clone.SetPropagationContext(p2)
+	s2 := &Span{TraceID: TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03")}
+	clone.SetSpan(s2)
 
 	assertEqual(t, map[string]string{"foo": "bar"}, clone.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "bar"}}, clone.contexts)
@@ -508,6 +517,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	assertEqual(t, User{ID: "foo"}, clone.user)
 	assertEqual(t, r2, clone.request)
 	assertEqual(t, p2, clone.propagationContext)
+	assertEqual(t, s2, clone.span)
 
 	assertEqual(t, map[string]string{"foo": "baz"}, scope.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "baz"}}, scope.contexts)
@@ -519,6 +529,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	assertEqual(t, User{ID: "bar"}, scope.user)
 	assertEqual(t, r1, scope.request)
 	assertEqual(t, p1, scope.propagationContext)
+	assertEqual(t, s1, scope.span)
 
 	assertEqual(t, len(scope.eventProcessors), 1)
 	assertEqual(t, len(clone.eventProcessors), 2)
@@ -538,6 +549,7 @@ func TestClear(t *testing.T) {
 	assertEqual(t, Level(""), scope.level)
 	assertEqual(t, (*http.Request)(nil), scope.request)
 	assertEqual(t, PropagationContext{}, scope.propagationContext)
+	assertEqual(t, (*Span)(nil), scope.span)
 }
 
 func TestClearAndReconfigure(t *testing.T) {
@@ -556,6 +568,8 @@ func TestClearAndReconfigure(t *testing.T) {
 	scope.SetRequest(r)
 	p := NewPropagationContext()
 	scope.SetPropagationContext(p)
+	s := &Span{TraceID: TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")}
+	scope.SetSpan(s)
 
 	assertEqual(t, map[string]string{"foo": "bar"}, scope.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "bar"}}, scope.contexts)
@@ -567,6 +581,7 @@ func TestClearAndReconfigure(t *testing.T) {
 	assertEqual(t, User{ID: "foo"}, scope.user)
 	assertEqual(t, r, scope.request)
 	assertEqual(t, p, scope.propagationContext)
+	assertEqual(t, s, scope.span)
 }
 
 func TestClearBreadcrumbs(t *testing.T) {
@@ -719,4 +734,12 @@ func TestScopeSetPropagationContext(t *testing.T) {
 	scope.SetPropagationContext(p)
 
 	assertEqual(t, scope.propagationContext, p)
+}
+
+func TestScopeSetSpan(t *testing.T) {
+	scope := NewScope()
+	s := &Span{TraceID: TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")}
+	scope.SetSpan(s)
+
+	assertEqual(t, scope.span, s)
 }


### PR DESCRIPTION
This is part of a series of PRs for the "tracing without performance" feature.

For the case where performance is enabled we need to be able to get the tracing context from the active transaction and use that instead of the propagation context. So we need to way to access the span. 

This PR adds support for setting a span on a scope. We can then access the span and get the current tracing context to pass through.