### PR TITLE
feat(tracing): Add WithDescription SpanOption

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -834,6 +834,13 @@ func WithTransactionName(name string) SpanOption {
 	}
 }
 
+// WithDescription sets the description of a span.
+func WithDescription(description string) SpanOption {
+	return func(s *Span) {
+		s.Description = description
+	}
+}
+
 // WithOpName sets the operation name for a given span.
 func WithOpName(name string) SpanOption {
 	return func(s *Span) {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -346,7 +346,7 @@ func TestWithDescription(t *testing.T) {
 	})
 	span := StartSpan(ctx, "Test Span", WithDescription("span desc"))
 	if span.Description != "span desc" {
-		t.Fatalf("Description mismatch, expected span desc, got %v", span.Description)
+		t.Fatalf("Description mismatch, got %v", span.Description)
 	}
 }
 

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -345,7 +345,7 @@ func TestWithDescription(t *testing.T) {
 		EnableTracing: true,
 	})
 	span := StartSpan(ctx, "Test Span", WithDescription("span desc"))
-	if (span.Description!= "span desc") {
+	if span.Description != "span desc" {
 		t.Fatalf("Description mismatch, expected span desc, got %v", span.Description)
 	}
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -340,6 +340,16 @@ func TestSetData(t *testing.T) {
 	}
 }
 
+func TestWithDescription(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing: true,
+	})
+	span := StartSpan(ctx, "Test Span", WithDescription("span desc"))
+	if (span.Description!= "span desc") {
+		t.Fatalf("Description mismatch, expected span desc, got %v", span.Description)
+	}
+}
+
 func TestIsTransaction(t *testing.T) {
 	ctx := NewTestContext(ClientOptions{
 		EnableTracing: true,


### PR DESCRIPTION
## Summary

This pull request adds `WithDescription` span option! Closes #739, thank you to @moneymikemd for the issue.

## Changes

- Disclaimer: I was just diving into the go SDK codebase, and was looking through the issue list for an easy way in. Please feel free to tell me to gtfo if that pull request is not all that useful. 
- I've added the `WithDescription` `SpanOption` that works similar to the existing `WithTransactionName` and friends.

## TODO
- [x] Unit tests into `tracing_test.go`. Wait a sec, will do in a couple hours.

/cc @greywolve 