### PR TITLE
Only apply `SampleRate ` to errors/messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -605,9 +605,9 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	}
 
 	// Transactions are sampled by options.TracesSampleRate or
-	// options.TracesSampler when they are started. All other events
-	// (errors, messages) are sampled here.
-	if event.Type != transactionType && !sample(client.options.SampleRate) {
+	// options.TracesSampler when they are started. Other events
+	// (errors, messages) are sampled here. Does not apply to check-ins.
+	if event.Type != transactionType && event.Type != checkInType && !sample(client.options.SampleRate) {
 		Logger.Println("Event dropped due to SampleRate hit.")
 		return nil
 	}
@@ -626,7 +626,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 			Logger.Println("Transaction dropped due to BeforeSendTransaction callback.")
 			return nil
 		}
-	} else if event.Type != transactionType && client.options.BeforeSend != nil {
+	} else if event.Type != transactionType && event.Type != checkInType && client.options.BeforeSend != nil {
 		// All other events
 		if event = client.options.BeforeSend(event, hint); event == nil {
 			Logger.Println("Event dropped due to BeforeSend callback.")

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,15 +11,14 @@ import (
 	"time"
 )
 
-// Protocol Docs (kinda)
-// https://github.com/getsentry/rust-sentry-types/blob/master/src/protocol/v7.rs
+// eventType is the type of an error event.
+const eventType = "event"
 
 // transactionType is the type of a transaction event.
 const transactionType = "transaction"
 
-// eventType is the type of an error event.
-const eventType = "event"
-
+// profileType is the type of a profile event.
+// currently, profiles are always sent as part of a transaction event.
 const profileType = "profile"
 
 // checkInType is the type of a check in event.


### PR DESCRIPTION
We should only sample errors/messages. This fixes the `SampleRate` being applied to `check_in` as well.