### PR TITLE
Allow custom attachments to be added to Events

### DIFF
--- a/client.go
+++ b/client.go
@@ -673,19 +673,15 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		event.Environment = client.options.Environment
 	}
 
-	if event.Platform == "" {
-		event.Platform = "go"
-	}
-	if event.Sdk.Name == "" {
-		event.Sdk = SdkInfo{
-			Name:         client.GetSDKIdentifier(),
-			Version:      SDKVersion,
-			Integrations: client.listIntegrations(),
-			Packages: []SdkPackage{{
-				Name:    "sentry-go",
-				Version: SDKVersion,
-			}},
-		}
+	event.Platform = "go"
+	event.Sdk = SdkInfo{
+		Name:         client.GetSDKIdentifier(),
+		Version:      SDKVersion,
+		Integrations: client.listIntegrations(),
+		Packages: []SdkPackage{{
+			Name:    "sentry-go",
+			Version: SDKVersion,
+		}},
 	}
 
 	if scope != nil {

--- a/client.go
+++ b/client.go
@@ -673,15 +673,19 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		event.Environment = client.options.Environment
 	}
 
-	event.Platform = "go"
-	event.Sdk = SdkInfo{
-		Name:         client.GetSDKIdentifier(),
-		Version:      SDKVersion,
-		Integrations: client.listIntegrations(),
-		Packages: []SdkPackage{{
-			Name:    "sentry-go",
-			Version: SDKVersion,
-		}},
+	if event.Platform == "" {
+		event.Platform = "go"
+	}
+	if event.Sdk.Name == "" {
+		event.Sdk = SdkInfo{
+			Name:         client.GetSDKIdentifier(),
+			Version:      SDKVersion,
+			Integrations: client.listIntegrations(),
+			Packages: []SdkPackage{{
+				Name:    "sentry-go",
+				Version: SDKVersion,
+			}},
+		}
 	}
 
 	if scope != nil {

--- a/interfaces.go
+++ b/interfaces.go
@@ -337,6 +337,18 @@ type Event struct {
 	attachments []*Attachment
 }
 
+// AddAttachment adds an Event-specific Attachment
+//
+// Scope attachments will still be added to this event
+func (e *Event) AddAttachment(attachment *Attachment) {
+	e.attachments = append(e.attachments, attachment)
+}
+
+// ClearAttachments clears all Event-specific attachments from the event.
+func (e *Event) ClearAttachments() {
+	e.attachments = []*Attachment{}
+}
+
 // SetException appends the unwrapped errors to the event's exception list.
 //
 // maxErrorDepth is the maximum depth of the error chain we will look


### PR DESCRIPTION
This change allows you to add specific attachments to the Event (without solely relying on scope-based attachments)
