### PR TITLE
Replace godoc links with pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![Build Status](https://github.com/getsentry/sentry-go/workflows/go-workflow/badge.svg)](https://github.com/getsentry/sentry-go/actions?query=workflow%3Ago-workflow)
 [![Go Report Card](https://goreportcard.com/badge/github.com/getsentry/sentry-go)](https://goreportcard.com/report/github.com/getsentry/sentry-go)
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/Ww9hbqr)
-[![GoDoc](https://godoc.org/github.com/getsentry/sentry-go?status.svg)](https://godoc.org/github.com/getsentry/sentry-go)
 [![go.dev](https://img.shields.io/badge/go.dev-pkg-007d9c.svg?style=flat)](https://pkg.go.dev/github.com/getsentry/sentry-go)
 
 `sentry-go` provides a Sentry client implementation for the Go programming
@@ -85,7 +84,6 @@ checkout the official documentation:
 
 - [Bug Tracker](https://github.com/getsentry/sentry-go/issues)
 - [GitHub Project](https://github.com/getsentry/sentry-go)
-- [![GoDoc](https://godoc.org/github.com/getsentry/sentry-go?status.svg)](https://godoc.org/github.com/getsentry/sentry-go)
 - [![go.dev](https://img.shields.io/badge/go.dev-pkg-007d9c.svg?style=flat)](https://pkg.go.dev/github.com/getsentry/sentry-go)
 - [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/go/)
 - [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-go.svg)](https://github.com/getsentry/sentry-go/discussions)

--- a/echo/README.md
+++ b/echo/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Echo Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/echo
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/echo
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/echo
 
@@ -73,7 +73,7 @@ Timeout time.Duration
 
 ## Usage
 
-`sentryecho` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the `echo.Context`, which makes it available throughout the rest of the request's lifetime.
+`sentryecho` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the `echo.Context`, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentryecho.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 

--- a/echo/README.md
+++ b/echo/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Echo Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/echo
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/echo
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/echo
 

--- a/fasthttp/README.md
+++ b/fasthttp/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry fasthttp Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/fasthttp
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/fasthttp
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/fasthttp
 

--- a/fasthttp/README.md
+++ b/fasthttp/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry fasthttp Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/fasthttp
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/fasthttp
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/fasthttp
 
@@ -69,7 +69,7 @@ Timeout time.Duration
 
 ## Usage
 
-`sentryfasthttp` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
+`sentryfasthttp` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentryfasthttp.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 

--- a/gin/README.md
+++ b/gin/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Gin Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/gin
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/gin
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/gin
 

--- a/gin/README.md
+++ b/gin/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Gin Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/gin
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/gin
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/gin
 
@@ -69,7 +69,7 @@ Timeout         time.Duration
 
 ## Usage
 
-`sentrygin` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the `*gin.Context`, which makes it available throughout the rest of the request's lifetime.
+`sentrygin` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the `*gin.Context`, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentrygin.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 

--- a/http/README.md
+++ b/http/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry net/http Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/http
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/http
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/http
 
@@ -69,7 +69,7 @@ Timeout         time.Duration
 
 ## Usage
 
-`sentryhttp` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
+`sentryhttp` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentry.GetHubFromContext()` method on the request itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 

--- a/http/README.md
+++ b/http/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry net/http Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/http
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/http
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/http
 

--- a/iris/README.md
+++ b/iris/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry [Iris](https://github.com/kataras/iris) Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/iris
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/iris
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/iris
 

--- a/iris/README.md
+++ b/iris/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry [Iris](https://github.com/kataras/iris) Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/iris
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/iris
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/iris
 
@@ -68,7 +68,7 @@ Timeout         time.Duration
 
 ## Usage
 
-`sentryiris` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the `iris.Context`, which makes it available throughout the rest of the request's lifetime.
+`sentryiris` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the `iris.Context`, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentryiris.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 

--- a/martini/README.md
+++ b/martini/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Martini Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/martini
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/martini
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/martini
 
@@ -68,7 +68,7 @@ Timeout         time.Duration
 
 ## Usage
 
-`sentrymartini` maps an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) as one of the services available throughout the rest of the request's lifetime.
+`sentrymartini` maps an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) as one of the services available throughout the rest of the request's lifetime.
 You can access it through providing a `hub *sentry.Hub` parameter in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 

--- a/martini/README.md
+++ b/martini/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Martini Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/martini
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/martini
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/martini
 

--- a/negroni/README.md
+++ b/negroni/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Negroni Handler for Sentry-go SDK
 
-**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/negroni
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/negroni
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/negroni
 

--- a/negroni/README.md
+++ b/negroni/README.md
@@ -7,7 +7,7 @@
 
 # Official Sentry Negroni Handler for Sentry-go SDK
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/negroni
+**Godoc:** https://pkg.go.dev/github.com/getsentry/sentry-go/negroni
 
 **Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/negroni
 
@@ -73,7 +73,7 @@ Timeout         time.Duration
 
 ## Usage
 
-`sentrynegroni` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
+`sentrynegroni` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentry.GetHubFromContext()` method on the request itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
 


### PR DESCRIPTION
Updated all godoc.org links to pkg.go.dev, as they are already redirected anyway.