### PR TITLE
Move exception group fields to mechanism

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -165,10 +165,8 @@ func TestCaptureException(t *testing.T) {
 					Type:  "*sentry.customErr",
 					Value: "wat",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"is_exception_group": true,
-							"exception_id":       0,
-						},
+						ExceptionID:      0,
+						IsExceptionGroup: true,
 					},
 				},
 				{
@@ -176,11 +174,9 @@ func TestCaptureException(t *testing.T) {
 					Value:      "wat",
 					Stacktrace: &Stacktrace{Frames: []Frame{}},
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       1,
-							"is_exception_group": true,
-							"parent_id":          0,
-						},
+						ExceptionID:      1,
+						ParentID:         Pointer(0),
+						IsExceptionGroup: true,
 					},
 				},
 			},
@@ -204,10 +200,8 @@ func TestCaptureException(t *testing.T) {
 					Type:  "*sentry.customErr",
 					Value: "wat",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"is_exception_group": true,
-							"exception_id":       0,
-						},
+						ExceptionID:      0,
+						IsExceptionGroup: true,
 					},
 				},
 				{
@@ -215,11 +209,9 @@ func TestCaptureException(t *testing.T) {
 					Value:      "err",
 					Stacktrace: &Stacktrace{Frames: []Frame{}},
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       1,
-							"is_exception_group": true,
-							"parent_id":          0,
-						},
+						ExceptionID:      1,
+						ParentID:         Pointer(0),
+						IsExceptionGroup: true,
 					},
 				},
 			},
@@ -232,10 +224,8 @@ func TestCaptureException(t *testing.T) {
 					Type:  "*errors.errorString",
 					Value: "original",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"is_exception_group": true,
-							"exception_id":       0,
-						},
+						ExceptionID:      0,
+						IsExceptionGroup: true,
 					},
 				},
 				{
@@ -243,11 +233,9 @@ func TestCaptureException(t *testing.T) {
 					Value:      "wrapped: original",
 					Stacktrace: &Stacktrace{Frames: []Frame{}},
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       1,
-							"is_exception_group": true,
-							"parent_id":          0,
-						},
+						ExceptionID:      1,
+						ParentID:         Pointer(0),
+						IsExceptionGroup: true,
 					},
 				},
 			},

--- a/interfaces.go
+++ b/interfaces.go
@@ -223,12 +223,15 @@ func NewRequest(r *http.Request) *Request {
 
 // Mechanism is the mechanism by which an exception was generated and handled.
 type Mechanism struct {
-	Type        string         `json:"type,omitempty"`
-	Description string         `json:"description,omitempty"`
-	HelpLink    string         `json:"help_link,omitempty"`
-	Source      string         `json:"source,omitempty"`
-	Handled     *bool          `json:"handled,omitempty"`
-	Data        map[string]any `json:"data,omitempty"`
+	Type             string         `json:"type,omitempty"`
+	Description      string         `json:"description,omitempty"`
+	HelpLink         string         `json:"help_link,omitempty"`
+	Source           string         `json:"source,omitempty"`
+	Handled          *bool          `json:"handled,omitempty"`
+	ParentID         *int           `json:"parent_id,omitempty"`
+	ExceptionID      int            `json:"exception_id,omitempty"`
+	IsExceptionGroup bool           `json:"is_exception_group,omitempty"`
+	Data             map[string]any `json:"data,omitempty"`
 }
 
 // SetUnhandled indicates that the exception is an unhandled exception, i.e.
@@ -396,15 +399,13 @@ func (e *Event) SetException(exception error, maxErrorDepth int) {
 
 	for i := range e.Exception {
 		e.Exception[i].Mechanism = &Mechanism{
-			Data: map[string]any{
-				"is_exception_group": true,
-				"exception_id":       i,
-			},
+			IsExceptionGroup: true,
+			ExceptionID:      i,
 		}
 		if i == 0 {
 			continue
 		}
-		e.Exception[i].Mechanism.Data["parent_id"] = i - 1
+		e.Exception[i].Mechanism.ParentID = &e.Exception[i-1].Mechanism.ExceptionID
 	}
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -405,7 +405,7 @@ func (e *Event) SetException(exception error, maxErrorDepth int) {
 		if i == 0 {
 			continue
 		}
-		e.Exception[i].Mechanism.ParentID = &e.Exception[i-1].Mechanism.ExceptionID
+		e.Exception[i].Mechanism.ParentID = Pointer(i - 1)
 	}
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -229,7 +229,7 @@ type Mechanism struct {
 	Source           string         `json:"source,omitempty"`
 	Handled          *bool          `json:"handled,omitempty"`
 	ParentID         *int           `json:"parent_id,omitempty"`
-	ExceptionID      int            `json:"exception_id,omitempty"`
+	ExceptionID      int            `json:"exception_id"`
 	IsExceptionGroup bool           `json:"is_exception_group,omitempty"`
 	Data             map[string]any `json:"data,omitempty"`
 }

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -257,21 +257,17 @@ func TestSetException(t *testing.T) {
 					Value: "base error",
 					Type:  "*errors.errorString",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"is_exception_group": true,
-							"exception_id":       0,
-						},
+						ExceptionID:      0,
+						IsExceptionGroup: true,
 					},
 				},
 				{
 					Value: "level 1: base error",
 					Type:  "*fmt.wrapError",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       1,
-							"is_exception_group": true,
-							"parent_id":          0,
-						},
+						ExceptionID:      1,
+						ParentID:         Pointer(0),
+						IsExceptionGroup: true,
 					},
 				},
 				{
@@ -279,11 +275,9 @@ func TestSetException(t *testing.T) {
 					Type:       "*fmt.wrapError",
 					Stacktrace: &Stacktrace{Frames: []Frame{}},
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       2,
-							"is_exception_group": true,
-							"parent_id":          1,
-						},
+						ExceptionID:      2,
+						ParentID:         Pointer(1),
+						IsExceptionGroup: true,
 					},
 				},
 			},
@@ -312,21 +306,17 @@ func TestSetException(t *testing.T) {
 					Value: "the cause",
 					Type:  "*errors.errorString",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"is_exception_group": true,
-							"exception_id":       0,
-						},
+						ExceptionID:      0,
+						IsExceptionGroup: true,
 					},
 				},
 				{
 					Value: "error with cause",
 					Type:  "*sentry.withCause",
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       1,
-							"is_exception_group": true,
-							"parent_id":          0,
-						},
+						ExceptionID:      1,
+						ParentID:         Pointer(0),
+						IsExceptionGroup: true,
 					},
 				},
 				{
@@ -334,11 +324,9 @@ func TestSetException(t *testing.T) {
 					Type:       "*fmt.wrapError",
 					Stacktrace: &Stacktrace{Frames: []Frame{}},
 					Mechanism: &Mechanism{
-						Data: map[string]any{
-							"exception_id":       2,
-							"is_exception_group": true,
-							"parent_id":          1,
-						},
+						ExceptionID:      2,
+						ParentID:         Pointer(1),
+						IsExceptionGroup: true,
 					},
 				},
 			},

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -368,7 +368,7 @@ func TestMechanismMarshalJSON(t *testing.T) {
 	}
 
 	want := `{"type":"some type","description":"some description","help_link":"some help link",` +
-		`"data":{"some data":"some value","some numeric data":12345}}`
+		`"exception_id":0,"data":{"some data":"some value","some numeric data":12345}}`
 
 	if diff := cmp.Diff(want, string(got)); diff != "" {
 		t.Errorf("Event mismatch (-want +got):\n%s", diff)
@@ -393,7 +393,7 @@ func TestMechanismMarshalJSON_withHandled(t *testing.T) {
 	}
 
 	want := `{"type":"some type","description":"some description","help_link":"some help link",` +
-		`"handled":false,"data":{"some data":"some value","some numeric data":12345}}`
+		`"handled":false,"exception_id":0,"data":{"some data":"some value","some numeric data":12345}}`
 
 	if diff := cmp.Diff(want, string(got)); diff != "" {
 		t.Errorf("Event mismatch (-want +got):\n%s", diff)

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -175,10 +175,8 @@ func Test_entryToEvent(t *testing.T) {
 						Type:  "*errors.errorString",
 						Value: "failure",
 						Mechanism: &sentry.Mechanism{
-							Data: map[string]any{
-								"exception_id":       0,
-								"is_exception_group": true,
-							},
+							ExceptionID:      0,
+							IsExceptionGroup: true,
 						},
 					},
 					{
@@ -188,11 +186,9 @@ func Test_entryToEvent(t *testing.T) {
 							Frames: []sentry.Frame{},
 						},
 						Mechanism: &sentry.Mechanism{
-							Data: map[string]any{
-								"exception_id":       1,
-								"is_exception_group": true,
-								"parent_id":          0,
-							},
+							ExceptionID:      1,
+							IsExceptionGroup: true,
+							ParentID:         sentry.Pointer(0),
 						},
 					},
 				},

--- a/util.go
+++ b/util.go
@@ -112,3 +112,7 @@ func revisionFromBuildInfo(info *debug.BuildInfo) string {
 
 	return ""
 }
+
+func Pointer[T any](v T) *T {
+	return &v
+}

--- a/util_test.go
+++ b/util_test.go
@@ -91,3 +91,9 @@ func TestRevisionFromBuildInfoNoVcsInformation(t *testing.T) {
 
 	assertEqual(t, revisionFromBuildInfo(info), "")
 }
+
+func TestPointer(t *testing.T) {
+	i := 5
+	v := Pointer(i)
+	assertEqual(t, *v, i)
+}


### PR DESCRIPTION
While updating `develop` for [#1204](https://github.com/getsentry/develop/issues/1204), noticed that the new mechanism fields were at the wrong place.

[RFC 0079](https://github.com/getsentry/rfcs/blob/main/text/0079-exception-groups.md#new-mechanism-fields) specifies these fields (is_exception_group, parent_id, exception_id) to be in the mechanism.

This is how I initially implemented it, but for some reason (UI being broken?) I moved them to Data which is wrong according to RFC and other SDKs.

This is how it looks like on the UI.

![CleanShot 2024-03-26 at 19 56 42@2x](https://github.com/getsentry/sentry-go/assets/5403700/26911b84-1287-4395-90ce-d0affd59975e)

#skip-changelog
