### PR TITLE
Use set for sensitiveHeaders

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -37,15 +37,6 @@ const (
 	LevelFatal   Level = "fatal"
 )
 
-func getSensitiveHeaders() map[string]bool {
-	return map[string]bool{
-		"Authorization":   true,
-		"Cookie":          true,
-		"X-Forwarded-For": true,
-		"X-Real-Ip":       true,
-	}
-}
-
 // SdkInfo contains all metadata about about the SDK being used.
 type SdkInfo struct {
 	Name         string       `json:"name,omitempty"`
@@ -171,6 +162,13 @@ type Request struct {
 	Env         map[string]string `json:"env,omitempty"`
 }
 
+var sensitiveHeaders = map[string]struct{}{
+	"Authorization":   {},
+	"Cookie":          {},
+	"X-Forwarded-For": {},
+	"X-Real-Ip":       {},
+}
+
 // NewRequest returns a new Sentry Request from the given http.Request.
 //
 // NewRequest avoids operations that depend on network access. In particular, it
@@ -201,7 +199,6 @@ func NewRequest(r *http.Request) *Request {
 			env = map[string]string{"REMOTE_ADDR": addr, "REMOTE_PORT": port}
 		}
 	} else {
-		sensitiveHeaders := getSensitiveHeaders()
 		for k, v := range r.Header {
 			if _, ok := sensitiveHeaders[k]; !ok {
 				headers[k] = strings.Join(v, ",")


### PR DESCRIPTION
Replaced bool with empty struct to better represent a set, which is what SensitiveHeaders is.

```
func BenchmarkNewRequest(b *testing.B) {
	const payload = `{"test_data": true}`
	r := httptest.NewRequest("POST", "/test/?q=sentry", strings.NewReader(payload))
	r.Header.Add("Authorization", "Bearer 1234567890")
	r.Header.Add("Cookie", "foo=bar")
	r.Header.Add("X-Forwarded-For", "127.0.0.1")
	r.Header.Add("X-Real-Ip", "127.0.0.1")
	r.Header.Add("Some-Header", "some-header value")

	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		NewRequest(r)
	}
}
```

**Before:**
```
BenchmarkNewRequest-10    	 2724643	       430.9 ns/op	     504 B/op	       7 allocs/op
```

**After:**
```
BenchmarkNewRequest-10    	 2993946	       394.1 ns/op	     504 B/op	       7 allocs/op
```

#skip-changelog

