### PR TITLE
Normalize http.response.status_code

### DIFF
--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -65,6 +65,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "GET", "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -87,6 +88,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "GET", "http.response.status_code": 404},
 			},
 		},
 		{
@@ -133,6 +135,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "POST", "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -170,6 +173,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "GET", "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -216,6 +220,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "POST", "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -260,6 +265,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "POST", "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -283,6 +289,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				Extra:           map[string]any{"http.request.method": "GET", "http.response.status_code": 400},
 			},
 			WantEvent: nil,
 		},

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -80,7 +80,9 @@ func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandle
 			options...,
 		)
 		defer func() {
-			transaction.Status = sentry.HTTPtoSpanStatus(ctx.Response.StatusCode())
+			status := ctx.Response.StatusCode()
+			transaction.Status = sentry.HTTPtoSpanStatus(status)
+			transaction.SetData("http.response.status_code", status)
 			transaction.Finish()
 		}()
 

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -58,7 +58,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]any{"http.request.method": http.MethodGet},
+				Extra:           map[string]any{"http.request.method": http.MethodGet, "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]any{"http.request.method": http.MethodPost},
+				Extra:           map[string]any{"http.request.method": http.MethodPost, "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]any{"http.request.method": http.MethodGet},
+				Extra:           map[string]any{"http.request.method": http.MethodGet, "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -169,7 +169,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]any{"http.request.method": http.MethodPost},
+				Extra:           map[string]any{"http.request.method": http.MethodPost, "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]any{"http.request.method": http.MethodPost},
+				Extra:           map[string]any{"http.request.method": http.MethodPost, "http.response.status_code": http.StatusOK},
 			},
 		},
 	}

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -85,7 +85,9 @@ func (h *handler) handle(c *gin.Context) {
 	)
 	transaction.SetData("http.request.method", c.Request.Method)
 	defer func() {
-		transaction.Status = sentry.HTTPtoSpanStatus(c.Writer.Status())
+		status := c.Writer.Status()
+		transaction.Status = sentry.HTTPtoSpanStatus(status)
+		transaction.SetData("http.response.status_code", status)
 		transaction.Finish()
 	}()
 

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -53,7 +53,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]interface{}{"http.request.method": string("GET")},
+				Extra:           map[string]any{"http.request.method": string("GET"), "http.response.status_code": http.StatusOK},
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
@@ -87,7 +87,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
-				Extra:           map[string]interface{}{"http.request.method": string("GET")},
+				Extra:           map[string]any{"http.request.method": string("GET"), "http.response.status_code": 404},
 			},
 			WantEvent: nil,
 		},
@@ -121,7 +121,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]interface{}{"http.request.method": string("POST")},
+				Extra:           map[string]any{"http.request.method": string("POST"), "http.response.status_code": http.StatusOK},
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
@@ -161,7 +161,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]interface{}{"http.request.method": string("GET")},
+				Extra:           map[string]any{"http.request.method": string("GET"), "http.response.status_code": http.StatusOK},
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
@@ -204,7 +204,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]interface{}{"http.request.method": string("POST")},
+				Extra:           map[string]any{"http.request.method": string("POST"), "http.response.status_code": http.StatusOK},
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
@@ -248,7 +248,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]interface{}{"http.request.method": string("POST")},
+				Extra:           map[string]any{"http.request.method": string("POST"), "http.response.status_code": http.StatusOK},
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
@@ -287,7 +287,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
-				Extra:           map[string]interface{}{"http.request.method": string("GET")},
+				Extra:           map[string]any{"http.request.method": string("GET"), "http.response.status_code": 400},
 			},
 			WantEvent: nil,
 		},
@@ -303,6 +303,7 @@ func TestIntegration(t *testing.T) {
 			return event
 		},
 		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			fmt.Println("BeforeSendTransaction")
 			transactionsCh <- tx
 			return tx
 		},

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -63,6 +63,22 @@ func New(options Options) *Handler {
 	}
 }
 
+// responseWriter is a wrapper around http.ResponseWriter that captures the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+// WriteHeader captures the status code and calls the original WriteHeader method.
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+}
+
 // Handle works as a middleware that wraps an existing http.Handler. A wrapped
 // handler will recover from and report panics to Sentry, and provide access to
 // a request-specific hub to report messages and errors.
@@ -83,6 +99,7 @@ func (h *Handler) HandleFunc(handler http.HandlerFunc) http.HandlerFunc {
 
 func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+
 		ctx := r.Context()
 		hub := sentry.GetHubFromContext(ctx)
 		if hub == nil {
@@ -99,24 +116,29 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 			sentry.ContinueFromRequest(r),
 			sentry.WithTransactionSource(sentry.SourceURL),
 		}
-		// We don't mind getting an existing transaction back so we don't need to
-		// check if it is.
+
 		transaction := sentry.StartTransaction(ctx,
 			fmt.Sprintf("%s %s", r.Method, r.URL.Path),
 			options...,
 		)
 		transaction.SetData("http.request.method", r.Method)
-		defer transaction.Finish()
+
+		rw := newResponseWriter(w)
+
+		defer func() {
+			status := rw.statusCode
+			transaction.Status = sentry.HTTPtoSpanStatus(status)
+			transaction.SetData("http.response.status_code", status)
+			transaction.Finish()
+		}()
+
 		// TODO(tracing): if the next handler.ServeHTTP panics, store
 		// information on the transaction accordingly (status, tag,
 		// level?, ...).
 		r = r.WithContext(transaction.Context())
 		hub.Scope().SetRequest(r)
 		defer h.recoverWithSentry(hub, r)
-		// TODO(tracing): use custom response writer to intercept
-		// response. Use HTTP status to add tag to transaction; set span
-		// status.
-		handler.ServeHTTP(w, r)
+		handler.ServeHTTP(rw, r)
 	}
 }
 

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -25,7 +25,9 @@ func TestIntegration(t *testing.T) {
 		Body    string
 		Handler http.Handler
 
-		WantEvent *sentry.Event
+		WantStatus      int
+		WantEvent       *sentry.Event
+		WantTransaction *sentry.Event
 	}{
 		{
 			Path: "/panic",
@@ -33,6 +35,7 @@ func TestIntegration(t *testing.T) {
 				panic("test")
 			}),
 
+			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
@@ -44,6 +47,21 @@ func TestIntegration(t *testing.T) {
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
+			},
+			WantTransaction: &sentry.Event{
+				Level:       sentry.LevelInfo,
+				Type:        "transaction",
+				Transaction: "GET /panic",
+				Request: &sentry.Request{
+					URL:    "/panic",
+					Method: "GET",
+					Headers: map[string]string{
+						"Accept-Encoding": "gzip",
+						"User-Agent":      "Go-http-client/1.1",
+					},
+				},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
+				Extra:           map[string]any{"http.request.method": http.MethodGet, "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -59,6 +77,7 @@ func TestIntegration(t *testing.T) {
 				hub.CaptureMessage("post: " + string(body))
 			}),
 
+			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
 				Message: "post: payload",
@@ -73,6 +92,23 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
+			WantTransaction: &sentry.Event{
+				Level:       sentry.LevelInfo,
+				Transaction: "POST /post",
+				Type:        "transaction",
+				Request: &sentry.Request{
+					URL:    "/post",
+					Method: "POST",
+					Data:   "payload",
+					Headers: map[string]string{
+						"Accept-Encoding": "gzip",
+						"Content-Length":  "7",
+						"User-Agent":      "Go-http-client/1.1",
+					},
+				},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
+				Extra:           map[string]any{"http.request.method": http.MethodPost, "http.response.status_code": http.StatusOK},
+			},
 		},
 		{
 			Path: "/get",
@@ -81,6 +117,7 @@ func TestIntegration(t *testing.T) {
 				hub.CaptureMessage("get")
 			}),
 
+			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
 				Message: "get",
@@ -92,6 +129,21 @@ func TestIntegration(t *testing.T) {
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
+			},
+			WantTransaction: &sentry.Event{
+				Level:       sentry.LevelInfo,
+				Transaction: "GET /get",
+				Type:        "transaction",
+				Request: &sentry.Request{
+					URL:    "/get",
+					Method: "GET",
+					Headers: map[string]string{
+						"Accept-Encoding": "gzip",
+						"User-Agent":      "Go-http-client/1.1",
+					},
+				},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
+				Extra:           map[string]any{"http.request.method": http.MethodGet, "http.response.status_code": http.StatusOK},
 			},
 		},
 		{
@@ -107,6 +159,7 @@ func TestIntegration(t *testing.T) {
 				hub.CaptureMessage(fmt.Sprintf("post: %d KB", len(body)/1024))
 			}),
 
+			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
 				Message: "post: 15 KB",
@@ -122,6 +175,24 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
+			WantTransaction: &sentry.Event{
+				Level:       sentry.LevelInfo,
+				Transaction: "POST /post/large",
+				Type:        "transaction",
+				Request: &sentry.Request{
+					URL:    "/post/large",
+					Method: "POST",
+					// Actual request body omitted because too large.
+					Data: "",
+					Headers: map[string]string{
+						"Accept-Encoding": "gzip",
+						"Content-Length":  "15360",
+						"User-Agent":      "Go-http-client/1.1",
+					},
+				},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
+				Extra:           map[string]any{"http.request.method": http.MethodPost, "http.response.status_code": http.StatusOK},
+			},
 		},
 		{
 			Path:   "/post/body-ignored",
@@ -132,6 +203,7 @@ func TestIntegration(t *testing.T) {
 				hub.CaptureMessage("body ignored")
 			}),
 
+			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
 				Message: "body ignored",
@@ -147,14 +219,39 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
+			WantTransaction: &sentry.Event{
+				Level:       sentry.LevelInfo,
+				Transaction: "POST /post/body-ignored",
+				Type:        "transaction",
+				Request: &sentry.Request{
+					URL:    "/post/body-ignored",
+					Method: "POST",
+					// Actual request body omitted because not read.
+					Data: "",
+					Headers: map[string]string{
+						"Accept-Encoding": "gzip",
+						"Content-Length":  "46",
+						"User-Agent":      "Go-http-client/1.1",
+					},
+				},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
+				Extra:           map[string]any{"http.request.method": http.MethodPost, "http.response.status_code": http.StatusOK},
+			},
 		},
 	}
 
 	eventsCh := make(chan *sentry.Event, len(tests))
+	transactionsCh := make(chan *sentry.Event, len(tests))
 	err := sentry.Init(sentry.ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
+		},
+		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			transactionsCh <- tx
+			return tx
 		},
 	})
 	if err != nil {
@@ -178,11 +275,20 @@ func TestIntegration(t *testing.T) {
 	c.Timeout = time.Second
 
 	var want []*sentry.Event
+	var wantTrans []*sentry.Event
+	var wantCodes []sentry.SpanStatus
+
 	for _, tt := range tests {
 		wantRequest := tt.WantEvent.Request
 		wantRequest.URL = srv.URL + wantRequest.URL
 		wantRequest.Headers["Host"] = srv.Listener.Addr().String()
 		want = append(want, tt.WantEvent)
+
+		wantTransaction := tt.WantTransaction.Request
+		wantTransaction.URL = srv.URL + wantTransaction.URL
+		wantTransaction.Headers["Host"] = srv.Listener.Addr().String()
+		wantTrans = append(wantTrans, tt.WantTransaction)
+		wantCodes = append(wantCodes, sentry.HTTPtoSpanStatus(tt.WantStatus))
 
 		req, err := http.NewRequest(tt.Method, srv.URL+tt.Path, strings.NewReader(tt.Body))
 		if err != nil {
@@ -220,5 +326,33 @@ func TestIntegration(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Fatalf("Events mismatch (-want +got):\n%s", diff)
+	}
+
+	close(transactionsCh)
+	var gott []*sentry.Event
+	var statusCodes []sentry.SpanStatus
+	for e := range transactionsCh {
+		gott = append(gott, e)
+		statusCodes = append(statusCodes, e.Contexts["trace"]["status"].(sentry.SpanStatus))
+	}
+
+	optstrans := cmp.Options{
+		cmpopts.IgnoreFields(
+			sentry.Event{},
+			"Contexts", "EventID", "Platform", "Modules",
+			"Release", "Sdk", "ServerName", "Timestamp",
+			"sdkMetaData", "StartTime", "Spans",
+		),
+		cmpopts.IgnoreFields(
+			sentry.Request{},
+			"Env",
+		),
+	}
+	if diff := cmp.Diff(wantTrans, gott, optstrans); diff != "" {
+		t.Fatalf("Transaction mismatch (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(wantCodes, statusCodes, cmp.Options{}); diff != "" {
+		t.Fatalf("Transaction status codes mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
This PR adds:

http method/response code to Echo and net/http
http response code to fasthttp and gin

Adds transaction tests for net/http

Once other integrations are covered in #809, #808 and #807 - all of them should have `http.response.status_code` which I would assume would resolve #667 .