### PR TITLE
add SendEventWithContext method

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -285,15 +285,9 @@ func getRequestFromEvent(ctx context.Context, event *Event, dsn *Dsn) (r *http.R
 	if err != nil {
 		return nil, err
 	}
-	if ctx != nil {
-		return http.NewRequestWithContext(
-			ctx,
-			http.MethodPost,
-			dsn.GetAPIURL().String(),
-			envelope,
-		)
-	}
-	return http.NewRequest(
+
+	return http.NewRequestWithContext(
+		ctx,
 		http.MethodPost,
 		dsn.GetAPIURL().String(),
 		envelope,

--- a/transport.go
+++ b/transport.go
@@ -258,7 +258,7 @@ func envelopeFromBody(event *Event, dsn *Dsn, sentAt time.Time, body json.RawMes
 	return &b, nil
 }
 
-func getRequestFromEvent(event *Event, dsn *Dsn, ctx context.Context) (r *http.Request, err error) {
+func getRequestFromEvent(ctx context.Context, event *Event, dsn *Dsn) (r *http.Request, err error) {
 	defer func() {
 		if r != nil {
 			r.Header.Set("User-Agent", fmt.Sprintf("%s/%s", event.Sdk.Name, event.Sdk.Version))
@@ -406,11 +406,11 @@ func (t *HTTPTransport) Configure(options ClientOptions) {
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
 func (t *HTTPTransport) SendEvent(event *Event) {
-	t.SendEventWithContext(event, nil)
+	t.SendEventWithContext(context.TODO(), event)
 }
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
-func (t *HTTPTransport) SendEventWithContext(event *Event, ctx context.Context) {
+func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) {
 	if t.dsn == nil {
 		return
 	}
@@ -421,7 +421,7 @@ func (t *HTTPTransport) SendEventWithContext(event *Event, ctx context.Context) 
 		return
 	}
 
-	request, err := getRequestFromEvent(event, t.dsn, ctx)
+	request, err := getRequestFromEvent(ctx, event, t.dsn)
 	if err != nil {
 		return
 	}
@@ -641,11 +641,11 @@ func (t *HTTPSyncTransport) Configure(options ClientOptions) {
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
 func (t *HTTPSyncTransport) SendEvent(event *Event) {
-	t.SendEventWithContext(event, nil)
+	t.SendEventWithContext(context.TODO(), event)
 }
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
-func (t *HTTPSyncTransport) SendEventWithContext(event *Event, ctx context.Context) {
+func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Event) {
 	if t.dsn == nil {
 		return
 	}
@@ -654,7 +654,7 @@ func (t *HTTPSyncTransport) SendEventWithContext(event *Event, ctx context.Conte
 		return
 	}
 
-	request, err := getRequestFromEvent(event, t.dsn, ctx)
+	request, err := getRequestFromEvent(ctx, event, t.dsn)
 	if err != nil {
 		return
 	}

--- a/transport.go
+++ b/transport.go
@@ -286,6 +286,10 @@ func getRequestFromEvent(ctx context.Context, event *Event, dsn *Dsn) (r *http.R
 		return nil, err
 	}
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	return http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
@@ -400,7 +404,7 @@ func (t *HTTPTransport) Configure(options ClientOptions) {
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
 func (t *HTTPTransport) SendEvent(event *Event) {
-	t.SendEventWithContext(context.TODO(), event)
+	t.SendEventWithContext(context.Background(), event)
 }
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
@@ -635,7 +639,7 @@ func (t *HTTPSyncTransport) Configure(options ClientOptions) {
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.
 func (t *HTTPSyncTransport) SendEvent(event *Event) {
-	t.SendEventWithContext(context.TODO(), event)
+	t.SendEventWithContext(context.Background(), event)
 }
 
 // SendEvent assembles a new packet out of Event and sends it to remote server.

--- a/transport.go
+++ b/transport.go
@@ -402,12 +402,12 @@ func (t *HTTPTransport) Configure(options ClientOptions) {
 	})
 }
 
-// SendEvent assembles a new packet out of Event and sends it to remote server.
+// SendEvent assembles a new packet out of Event and sends it to the remote server.
 func (t *HTTPTransport) SendEvent(event *Event) {
 	t.SendEventWithContext(context.Background(), event)
 }
 
-// SendEvent assembles a new packet out of Event and sends it to remote server.
+// SendEventWithContext assembles a new packet out of Event and sends it to the remote server.
 func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) {
 	if t.dsn == nil {
 		return
@@ -637,12 +637,12 @@ func (t *HTTPSyncTransport) Configure(options ClientOptions) {
 	}
 }
 
-// SendEvent assembles a new packet out of Event and sends it to remote server.
+// SendEvent assembles a new packet out of Event and sends it to the remote server.
 func (t *HTTPSyncTransport) SendEvent(event *Event) {
 	t.SendEventWithContext(context.Background(), event)
 }
 
-// SendEvent assembles a new packet out of Event and sends it to remote server.
+// SendEventWithContext assembles a new packet out of Event and sends it to the remote server.
 func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Event) {
 	if t.dsn == nil {
 		return

--- a/transport_test.go
+++ b/transport_test.go
@@ -339,7 +339,7 @@ func TestGetRequestFromEvent(t *testing.T) {
 		}
 
 		t.Run(test.testName, func(t *testing.T) {
-			req, err := getRequestFromEvent(test.event, dsn)
+			req, err := getRequestFromEvent(test.event, dsn, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/transport_test.go
+++ b/transport_test.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -339,7 +340,7 @@ func TestGetRequestFromEvent(t *testing.T) {
 		}
 
 		t.Run(test.testName, func(t *testing.T) {
-			req, err := getRequestFromEvent(test.event, dsn, nil)
+			req, err := getRequestFromEvent(context.TODO(), test.event, dsn)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This will let us pass a context.Context when creating a new request with getRequestFromEvent.

This will let us have a more granular control over how/when we cancel a request instead of relying only on the client timeout.

For example, if such API is invoked while serving another HTTP request, we might want to take advantage of such request context to bail out earlier than the client timeout if necessary.

As per [documentation](https://pkg.go.dev/net/http#Request.Context):

> For outgoing client requests, the context controls cancellation.
> 
> For incoming server requests, the context is canceled when the client's connection closes, the request is canceled (with HTTP/2), or when the ServeHTTP method returns.

