### PR TITLE
fix: input validation to NewRequest

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -176,7 +176,11 @@ var sensitiveHeaders = map[string]struct{}{
 //
 // NewRequest avoids operations that depend on network access. In particular, it
 // does not read r.Body.
-func NewRequest(r *http.Request) *Request {
+func NewRequest(r *http.Request) (*Request, error) {
+	if r == nil || r.URL == nil || r.Host == "" {
+		return nil, errors.New("http.Request is nil or missing URL.Path or Host")
+	}
+
 	protocol := schemeHTTP
 	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		protocol = schemeHTTPS
@@ -218,7 +222,7 @@ func NewRequest(r *http.Request) *Request {
 		Cookies:     cookies,
 		Headers:     headers,
 		Env:         env,
-	}
+	}, nil
 }
 
 // Mechanism is the mechanism by which an exception was generated and handled.

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -83,7 +84,12 @@ func TestNewRequest(t *testing.T) {
 	r.Header.Add("X-Real-Ip", "127.0.0.1")
 	r.Header.Add("Some-Header", "some-header value")
 
-	got := NewRequest(r)
+	got, err := NewRequest(r)
+
+	if err != nil {
+		t.Error(err)
+	}
+
 	want := &Request{
 		URL:         "http://example.com/test/",
 		Method:      "POST",
@@ -108,6 +114,14 @@ func TestNewRequest(t *testing.T) {
 	}
 }
 
+func TestNewRequestWithInvalidRequest(t *testing.T) {
+	_, err := NewRequest(&http.Request{})
+
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
 func TestNewRequestWithNoPII(t *testing.T) {
 	const payload = `{"test_data": true}`
 	r := httptest.NewRequest("POST", "/test/?q=sentry", strings.NewReader(payload))
@@ -117,7 +131,10 @@ func TestNewRequestWithNoPII(t *testing.T) {
 	r.Header.Add("X-Real-Ip", "127.0.0.1")
 	r.Header.Add("Some-Header", "some-header value")
 
-	got := NewRequest(r)
+	got, err := NewRequest(r)
+	if err != nil {
+		t.Error(err)
+	}
 	want := &Request{
 		URL:         "http://example.com/test/",
 		Method:      "POST",

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -134,6 +134,14 @@ func Test_entryToEvent(t *testing.T) {
 				},
 			},
 		},
+		"invalid http request": {
+			entry: &logrus.Entry{
+				Data: map[string]any{
+					FieldRequest: &http.Request{},
+				},
+			},
+			want: nil,
+		},
 		"error": {
 			entry: &logrus.Entry{
 				Data: map[string]any{
@@ -252,7 +260,18 @@ func Test_entryToEvent(t *testing.T) {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := h.entryToEvent(tt.entry)
+			var got *sentry.Event
+			got, err = h.entryToEvent(tt.entry)
+			if err == nil && tt.want == nil {
+				t.Error("expected error")
+				return
+			}
+
+			if err != nil && tt.want != nil {
+				t.Error(err)
+				return
+			}
+
 			opts := cmp.Options{
 				cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData"),
 			}

--- a/scope.go
+++ b/scope.go
@@ -402,7 +402,14 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
 	}
 
 	if event.Request == nil && scope.request != nil {
-		event.Request = NewRequest(scope.request)
+		var err error
+		event.Request, err = NewRequest(scope.request)
+
+		if err != nil {
+			Logger.Printf("Failed to create http.Request: %s\n", err)
+			return nil
+		}
+
 		// NOTE: The SDK does not attempt to send partial request body data.
 		//
 		// The reason being that Sentry's ingest pipeline and UI are optimized

--- a/scope_test.go
+++ b/scope_test.go
@@ -615,7 +615,12 @@ func TestApplyToEventUsingEmptyEvent(t *testing.T) {
 	assertEqual(t, processedEvent.User, scope.user, "should use scope user")
 	assertEqual(t, processedEvent.Fingerprint, scope.fingerprint, "should use scope fingerprint")
 	assertEqual(t, processedEvent.Level, scope.level, "should use scope level")
-	assertEqual(t, processedEvent.Request, NewRequest(scope.request), "should use scope request")
+
+	newRequest, err := NewRequest(scope.request)
+	if err != nil {
+		t.Error(err)
+	}
+	assertEqual(t, processedEvent.Request, newRequest, "should use scope request")
 }
 
 func TestEventProcessorsModifiesEvent(t *testing.T) {


### PR DESCRIPTION
Fixes `panic: runtime error: invalid memory address or nil pointer dereference` when passing `http.Request` that has not defined `r.Host` or `r.URL.Path` or even just `nil` in general.

```go
req := &http.Request{}
sentry.NewRequest(req)
```

- This adds an error signature onto [`NewRequest`](https://github.com/athyk/sentry-go/blob/fff8a3c49815e31a65c13a0c6ca4e37e0267da0d/interfaces.go#L179) and [`entryToEvent`](https://github.com/athyk/sentry-go/blob/fff8a3c49815e31a65c13a0c6ca4e37e0267da0d/logrus/logrusentry.go#L151)
- Tests have been added to cover error handling