### PR TITLE
ci: add go1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,10 @@ jobs:
         # pull requests, only run this step for a single job in the matrix. For
         # all other workflow triggers (e.g., pushes to a release branch) run
         # this step for the whole matrix.
-        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.22' && matrix.os == 'ubuntu') }}
+        if: ${{ github.event_name != 'pull_request' || (matrix.go == '1.23' && matrix.os == 'ubuntu') }}
     timeout-minutes: 15
     strategy:
       matrix:
-        go: ["1.22", "1.21", "1.20", "1.19", "1.18"]
+        go: ["1.23", "1.22", "1.21", "1.20", "1.19", "1.18"]
         os: [ubuntu, windows, macos]
       fail-fast: false


### PR DESCRIPTION
We advertise support for the latest 3 Go versions in the README, but this puts us at testing the latest 6 - maybe we can consider trimming some of the older versions.