### PR TITLE
Fix scope management in StartSpan and doFinish

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -195,6 +195,10 @@ func StartSpan(ctx context.Context, operation string, options ...SpanOption) *Sp
 	clientOptions := span.clientOptions()
 	if clientOptions.EnableTracing {
 		hub := hubFromContext(ctx)
+		if !span.IsTransaction() {
+			// Push a new scope to stack for non transaction span
+			hub.PushScope()
+		}
 		hub.Scope().SetSpan(&span)
 	}
 
@@ -355,6 +359,12 @@ func (s *Span) doFinish() {
 		s.EndTime = monotonicTimeSince(s.StartTime)
 	}
 
+	hub := hubFromContext(s.ctx)
+	if !s.IsTransaction() {
+		// Referenced to StartSpan function that pushes current non-transaction span to scope stack
+		defer hub.PopScope()
+	}
+
 	if !s.Sampled.Bool() {
 		return
 	}
@@ -370,7 +380,6 @@ func (s *Span) doFinish() {
 	// TODO(tracing): add breadcrumbs
 	// (see https://github.com/getsentry/sentry-python/blob/f6f3525f8812f609/sentry_sdk/tracing.py#L372)
 
-	hub := hubFromContext(s.ctx)
 	hub.CaptureEvent(event)
 }
 


### PR DESCRIPTION
Problem:
Previously, when creating a chain of spans, events triggered with the sentry.CaptureMessage() could be associated with the wrong span due to using the incorrect span in the hub’s scope, which led to inaccurate trace data in Sentry.

Fix:
By introducing proper span scope management, each non-transaction span now pushes a scope when started and pops it when finished. This ensures that events are associated with the correct active span in the trace hierarchy. Transactions remain unchanged as the root elements.

Test Coverage:
The new TestSpanScopeManagement confirms that events captured after finishing a child span are correctly associated with that span, ensuring that the trace and span IDs are accurate.