### PR TITLE
fix(tracing): Correct sentry-trace header parsing for multiple trace IDs

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -383,7 +383,7 @@ func (s *Span) doFinish() {
 //
 //	TRACE_ID - SPAN_ID - SAMPLED
 //	[[:xdigit:]]{32}-[[:xdigit:]]{16}-[01]
-var sentryTracePattern = regexp.MustCompile(`^([[:xdigit:]]{32})-([[:xdigit:]]{16})(?:-([01]))?$`)
+var sentryTracePattern = regexp.MustCompile(`([[:xdigit:]]{32})-([[:xdigit:]]{16})(?:-([01]))?`)
 
 // updateFromSentryTrace parses a sentry-trace HTTP header (as returned by
 // ToSentryTrace) and updates fields of the span. If the header cannot be

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -799,6 +799,26 @@ func TestParseTraceParentContext(t *testing.T) {
 			},
 			wantValid: true,
 		},
+		{
+			name:        "Valid multiple header, sampled",
+			sentryTrace: "d49d9bf66f13450b81f65bc51cf49c03-1cc4b26ab9094ef0-1,faca5d26f53d660657d9e4b073fb8da2-74dbb120f6aca02a-1",
+			wantContext: TraceParentContext{
+				TraceID:      TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03"),
+				ParentSpanID: SpanIDFromHex("1cc4b26ab9094ef0"),
+				Sampled:      SampledTrue,
+			},
+			wantValid: true,
+		},
+		{
+			name:        "Valid multiple header, unsampled",
+			sentryTrace: "d49d9bf66f13450b81f65bc51cf49c03-1cc4b26ab9094ef0-0,faca5d26f53d660657d9e4b073fb8da2-74dbb120f6aca02a-0",
+			wantContext: TraceParentContext{
+				TraceID:      TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03"),
+				ParentSpanID: SpanIDFromHex("1cc4b26ab9094ef0"),
+				Sampled:      SampledFalse,
+			},
+			wantValid: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Problem

The `sentry-trace` header parsing fails when multiple trace IDs are present due to strict matching with `^` and `$` in the regex.

### Solution

This PR fixes the regex by removing `^` and `$` anchors, allowing to correctly parse headers with multiple trace IDs.

### Tests

Added unit tests for parsing multiple trace IDs in the `sentry-trace` header.