### PR TITLE
Fix applying the `trace` context on events

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -383,6 +383,15 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		}
 
 		for key, value := range scope.contexts {
+			if key == "trace" && event.Type == transactionType {
+				// Do not override trace context of
+				// transactions, otherwise it breaks the
+				// transaction event representation.
+				// For error events, the trace context is used
+				// to link errors and traces/spans in Sentry.
+				continue
+			}
+
 			// Ensure we are not overwriting event fields
 			if _, ok := event.Contexts[key]; !ok {
 				event.Contexts[key] = cloneContext(value)
@@ -395,7 +404,9 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 	}
 
 	if scope.span != nil {
-		event.Contexts["trace"] = scope.span.traceContext().Map()
+		if _, ok := event.Contexts["trace"]; !ok {
+			event.Contexts["trace"] = scope.span.traceContext().Map()
+		}
 
 		transaction := scope.span.GetTransaction()
 		if transaction != nil {

--- a/tracing.go
+++ b/tracing.go
@@ -554,10 +554,11 @@ func (s *Span) toEvent() *Event {
 		s.dynamicSamplingContext = DynamicSamplingContextFromTransaction(s)
 	}
 
-	contexts := make(map[string]Context, len(s.contexts))
+	contexts := map[string]Context{}
 	for k, v := range s.contexts {
 		contexts[k] = cloneContext(v)
 	}
+	contexts["trace"] = s.traceContext().Map()
 
 	// Make sure that the transaction source is valid
 	transactionSource := s.Source

--- a/tracing.go
+++ b/tracing.go
@@ -554,7 +554,7 @@ func (s *Span) toEvent() *Event {
 		s.dynamicSamplingContext = DynamicSamplingContextFromTransaction(s)
 	}
 
-	contexts := map[string]Context{}
+	contexts := make(map[string]Context, len(s.contexts)+1)
 	for k, v := range s.contexts {
 		contexts[k] = cloneContext(v)
 	}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-go/issues/884

We mistakenly used the scope's span `trace` context as the `trace` context for the transaction. Instead, we now set the `trace` context on the event when the transaction finishes and only use the scope's span `trace` context in case there is no `trace` context on the event already.