### PR TITLE
Prevent panic in case url.Parsing fails in fasthttp and fiber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Add `sentryslog` integration ([#865](https://github.com/getsentry/sentry-go/pull/865))
 - Always set Mechanism Type to generic ([#896](https://github.com/getsentry/sentry-go/pull/897))
 
+### Bug Fixes
+
+- Prevent panic in `fasthttp` and `fiber` integration in case a malformed URL has to be parsed ([#912](https://github.com/getsentry/sentry-go/pull/912))
+
 ### Misc
 
 Drop support for Go 1.18, 1.19 and 1.20. The currently supported Go versions are the last 3 stable releases: 1.23, 1.22 and 1.21.

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -147,8 +147,12 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 
 	r.Method = string(ctx.Method())
 	uri := ctx.URI()
-	// Ignore error.
-	r.URL, _ = url.Parse(fmt.Sprintf("%s://%s%s", uri.Scheme(), uri.Host(), uri.Path()))
+	url, err := url.Parse(fmt.Sprintf("%s://%s%s", uri.Scheme(), uri.Host(), uri.Path()))
+	fmt.Println("Error: ", err, "URL: ", url)
+	if err == nil {
+		r.URL = url
+		r.URL.RawQuery = string(uri.QueryString())
+	}
 
 	// Headers
 	r.Header = make(http.Header)
@@ -165,9 +169,6 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 
 	// Env
 	r.RemoteAddr = ctx.RemoteAddr().String()
-
-	// QueryString
-	r.URL.RawQuery = string(ctx.URI().QueryString())
 
 	// Body
 	r.Body = io.NopCloser(bytes.NewReader(ctx.Request.Body()))

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -148,13 +148,15 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 		r.URL.RawQuery = string(uri.QueryString())
 	}
 
+	host := string(ctx.Host())
+	r.Host = host
+
 	// Headers
 	r.Header = make(http.Header)
-	r.Header.Add("Host", string(ctx.Host()))
+	r.Header.Add("Host", host)
 	ctx.Request.Header.VisitAll(func(key, value []byte) {
 		r.Header.Add(string(key), string(value))
 	})
-	r.Host = string(ctx.Host())
 
 	// Cookies
 	ctx.Request.Header.VisitAllCookie(func(key, value []byte) {

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -147,16 +147,16 @@ func convert(ctx *fiber.Ctx) *http.Request {
 		r.URL.RawQuery = string(uri.QueryString())
 	}
 
+	host := utils.CopyString(ctx.Hostname())
+	r.Host = host
+
 	// Headers
 	r.Header = make(http.Header)
-
-	host := utils.CopyString(ctx.Hostname())
 	r.Header.Add("Host", host)
 
 	ctx.Request().Header.VisitAll(func(key, value []byte) {
 		r.Header.Add(string(key), string(value))
 	})
-	r.Host = utils.CopyString(host)
 
 	// Cookies
 	ctx.Request().Header.VisitAllCookie(func(key, value []byte) {


### PR DESCRIPTION
Resolves #911 

If r.URL is not set due to some error, setting r.URL.RawQuery panics. Panic is recovered, but `request` is never converted thus causing another panic.

