### PR TITLE
Add WithContext variants of methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -435,6 +435,16 @@ func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorCon
 	return nil
 }
 
+// CaptureCheckInWithContext captures a check in.
+func (client *Client) CaptureCheckInWithContext(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig, scope EventModifier) *EventID {
+	event := client.EventFromCheckIn(checkIn, monitorConfig)
+	if event != nil && event.CheckIn != nil {
+		client.CaptureEvent(event, &EventHint{Context: ctx}, scope)
+		return &event.CheckIn.ID
+	}
+	return nil
+}
+
 // CaptureEvent captures an event on the currently active client if any.
 //
 // The event must already be assembled. Typically code would instead use

--- a/hub.go
+++ b/hub.go
@@ -316,6 +316,72 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 	hub.Scope().AddBreadcrumb(breadcrumb, max)
 }
 
+// CaptureEventWithContext calls the method of a same name on currently bound Client instance
+// passing it a top-level Scope.
+// Returns EventID if successfully, or nil if there's no Scope or Client available.
+func (hub *Hub) CaptureEventWithContext(ctx context.Context, event *Event) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	eventID := client.CaptureEvent(event, &EventHint{Context: ctx}, scope)
+
+	if event.Type != transactionType && eventID != nil {
+		hub.mu.Lock()
+		hub.lastEventID = *eventID
+		hub.mu.Unlock()
+	}
+	return eventID
+}
+
+// CaptureMessageWithContext calls the method of a same name on currently bound Client instance
+// passing it a top-level Scope.
+// Returns EventID if successfully, or nil if there's no Scope or Client available.
+func (hub *Hub) CaptureMessageWithContext(ctx context.Context, message string) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	eventID := client.CaptureMessage(message, &EventHint{Context: ctx}, scope)
+
+	if eventID != nil {
+		hub.mu.Lock()
+		hub.lastEventID = *eventID
+		hub.mu.Unlock()
+	}
+	return eventID
+}
+
+// CaptureExceptionWithContext calls the method of a same name on currently bound Client instance
+// passing it a top-level Scope.
+// Returns EventID if successfully, or nil if there's no Scope or Client available.
+func (hub *Hub) CaptureExceptionWithContext(ctx context.Context, exception error) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	eventID := client.CaptureException(exception, &EventHint{OriginalException: exception, Context: ctx}, scope)
+
+	if eventID != nil {
+		hub.mu.Lock()
+		hub.lastEventID = *eventID
+		hub.mu.Unlock()
+	}
+	return eventID
+}
+
+// CaptureCheckInWithContext calls the method of the same name on currently bound Client instance
+// passing it a top-level Scope.
+// Returns CheckInID if the check-in was captured successfully, or nil otherwise.
+func (hub *Hub) CaptureCheckInWithContext(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil {
+		return nil
+	}
+
+	return client.CaptureCheckInWithContext(ctx, checkIn, monitorConfig, scope)
+}
+
 // Recover calls the method of a same name on currently bound Client instance
 // passing it a top-level Scope.
 // Returns EventID if successfully, or nil if there's no Scope or Client available.

--- a/sentry.go
+++ b/sentry.go
@@ -61,6 +61,34 @@ func CaptureEvent(event *Event) *EventID {
 	return hub.CaptureEvent(event)
 }
 
+// CaptureMessageWithContext captures an arbitrary message and adds the context to the EventHint.
+func CaptureMessageWithContext(ctx context.Context, message string) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureMessageWithContext(ctx, message)
+}
+
+// CaptureExceptionWithContext captures an error and adds the context to the EventHint.
+func CaptureExceptionWithContext(ctx context.Context, exception error) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureExceptionWithContext(ctx, exception)
+}
+
+// CaptureCheckInWithContext captures a (cron) monitor check-in and adds the context to the EventHint.
+func CaptureCheckInWithContext(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureCheckInWithContext(ctx, checkIn, monitorConfig)
+}
+
+// CaptureEventWithContext captures an event on the currently active client if any and adds the context to the EventHint.
+//
+// The event must already be assembled. Typically code would instead use
+// the utility methods like CaptureException. The return value is the
+// event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
+func CaptureEventWithContext(ctx context.Context, event *Event) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureEventWithContext(ctx, event)
+}
+
 // Recover captures a panic.
 func Recover() *EventID {
 	if err := recover(); err != nil {


### PR DESCRIPTION
Added WithContext variants of captureException, captureMessage, captureCheckIn and captureEvent, that pass the context down into the EventHint

Closes #555 
