### PR TITLE
Rename sentry-go/logrus module

### DIFF
--- a/logrus/go.mod
+++ b/logrus/go.mod
@@ -1,4 +1,4 @@
-module github.com/getsentry/sentry-go/sentrylogrus
+module github.com/getsentry/sentry-go/logrus
 
 go 1.21
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-go/issues/949.