### PR TITLE
Add date range to licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Functional Software, Inc. dba Sentry
+Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
To align with all other Sentry SDKs.

#skip-changelog