### PR TITLE
Add `errorTree` type for joined, wrapped error traversal

### DIFF
--- a/error_tree.go
+++ b/error_tree.go
@@ -1,0 +1,82 @@
+package sentry
+
+import (
+	"errors"
+	"reflect"
+)
+
+type errorTree struct {
+	Err error
+}
+
+func (et errorTree) children() []errorTree {
+	if et.Err == nil {
+		return nil
+	}
+
+	// Attempt to unwrap the error using the standard library's Unwrap method.
+	if unwrappedErr := errors.Unwrap(et.Err); unwrappedErr != nil {
+		return []errorTree{{unwrappedErr}}
+	}
+	// The error implements the Cause method, indicating it may have been wrapped
+	// using the github.com/pkg/errors package.
+	if caused, ok := et.Err.(interface{ Cause() error }); ok && caused.Cause() != nil {
+		return []errorTree{{caused.Cause()}}
+	}
+	// A non-nil error returned by `errors.Join` implements `Unwrap() []error`.
+	if joined, ok := et.Err.(interface{ Unwrap() []error }); ok {
+		members := joined.Unwrap()
+		children := make([]errorTree, len(members))
+		for i := range members {
+			children[i] = errorTree{members[i]}
+		}
+		return children
+	}
+	return []errorTree{}
+}
+
+// Exceptions in et, ordered from earliest to latest. All exception Mechanisms
+// returned here are as if the exceptions belong to a group.
+func (et errorTree) Exceptions() []Exception {
+	if et.Err == nil {
+		return nil
+	}
+
+	// Child exceptions are chronologically earlier.
+	children := et.children()
+	exceptions := make([]Exception, 0, len(children))
+	for _, child := range children {
+		exceptions = join(exceptions, child.Exceptions()...)
+	}
+
+	// Append this error.
+	mechanism := &Mechanism{
+		IsExceptionGroup: true,
+		ExceptionID:      len(exceptions),
+		Type:             "generic",
+	}
+	if len(children) == 1 {
+		// Part of a causal chain; record parent-child relationship.
+		lastChild := exceptions[len(exceptions)-1]
+		mechanism.ParentID = Pointer(lastChild.Mechanism.ExceptionID)
+	}
+	exceptions = append(exceptions, Exception{
+		Value:      et.Err.Error(),
+		Type:       reflect.TypeOf(et.Err).String(),
+		Stacktrace: ExtractStacktrace(et.Err),
+		Mechanism:  mechanism,
+	})
+	return exceptions
+}
+
+// join Exception sequences, adjusting indexed IDs (ExceptionID, ParentID).
+func join(prior []Exception, latter ...Exception) []Exception {
+	for i := range latter {
+		latter[i].Mechanism.ExceptionID += len(prior)
+		if latter[i].Mechanism.ParentID != nil {
+			parentID := latter[i].Mechanism.ParentID
+			latter[i].Mechanism.ParentID = Pointer(len(prior) + *parentID)
+		}
+	}
+	return append(prior, latter...)
+}

--- a/error_tree_test.go
+++ b/error_tree_test.go
@@ -1,0 +1,202 @@
+package sentry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestErrorTree(t *testing.T) {
+	testCases := map[string]struct {
+		root     error
+		expected []Exception
+	}{
+		"Single error without unwrap": {
+			root: errors.New("simple error"),
+			expected: []Exception{
+				{
+					Value:     "simple error",
+					Type:      "*errors.errorString",
+					Mechanism: &Mechanism{Type: "generic", IsExceptionGroup: true},
+				},
+			},
+		},
+		"Nested errors with Unwrap": {
+			root: fmt.Errorf("level 2: %w", fmt.Errorf("level 1: %w", errors.New("base error"))),
+			expected: []Exception{
+				{
+					Value: "base error",
+					Type:  "*errors.errorString",
+					Mechanism: &Mechanism{
+						Type:             "generic",
+						ExceptionID:      0,
+						IsExceptionGroup: true,
+					},
+				},
+				{
+					Value: "level 1: base error",
+					Type:  "*fmt.wrapError",
+					Mechanism: &Mechanism{
+						Type:             "generic",
+						ExceptionID:      1,
+						ParentID:         Pointer(0),
+						IsExceptionGroup: true,
+					},
+				},
+				{
+					Value: "level 2: level 1: base error",
+					Type:  "*fmt.wrapError",
+					Mechanism: &Mechanism{
+						Type:             "generic",
+						ExceptionID:      2,
+						ParentID:         Pointer(1),
+						IsExceptionGroup: true,
+					},
+				},
+			},
+		},
+		// TODO: more cases from TestSetException.
+		"Simple two-error join": {
+			root: errors.Join(
+				errors.New("0"),
+				errors.New("1"),
+			),
+			expected: []Exception{
+				{
+					Value:      "0",
+					Type:       "*errors.errorString",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true},
+				},
+				{
+					Value:      "1",
+					Type:       "*errors.errorString",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 1},
+				},
+				{
+					Value:      "0\n1",
+					Type:       "*errors.joinError",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 2},
+				},
+			},
+		},
+		"Complex join": {
+			root: errors.Join(
+				errors.Join(
+					errors.New("0"),
+					errors.New("1"),
+				),
+				errors.New("2"),
+			),
+			expected: []Exception{
+				{
+					Value:      "0",
+					Type:       "*errors.errorString",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true},
+				},
+				{
+					Value:      "1",
+					Type:       "*errors.errorString",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 1},
+				},
+				{
+					Value:      "0\n1",
+					Type:       "*errors.joinError",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 2},
+				},
+				{
+					Value:      "2",
+					Type:       "*errors.errorString",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 3},
+				},
+				{
+					Value:      "0\n1\n2",
+					Type:       "*errors.joinError",
+					Stacktrace: nil,
+					Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 4},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tree := errorTree{tc.root}
+			result := tree.Exceptions()
+
+			if len(result) != len(tc.expected) {
+				t.Fatalf("Expected %d exceptions, got %d", len(tc.expected), len(result))
+			}
+
+			for i, exp := range tc.expected {
+				if diff := cmp.Diff(exp, result[i]); diff != "" {
+					t.Errorf("Event mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorTree_JoinComplex(t *testing.T) {
+	err := errors.Join(
+		errors.Join(
+			errors.New("0"),
+			errors.New("1"),
+		),
+		errors.New("2"),
+	)
+	tree := errorTree{err}
+
+	exceptions := tree.Exceptions()
+
+	expected := []Exception{
+		{
+			Value:      "0",
+			Type:       "*errors.errorString",
+			Stacktrace: nil,
+			Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true},
+		},
+		{
+			Value:      "1",
+			Type:       "*errors.errorString",
+			Stacktrace: nil,
+			Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 1},
+		},
+		{
+			Value:      "0\n1",
+			Type:       "*errors.joinError",
+			Stacktrace: nil,
+			Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 2},
+		},
+		{
+			Value:      "2",
+			Type:       "*errors.errorString",
+			Stacktrace: nil,
+			Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 3},
+		},
+		{
+			Value:      "0\n1\n2",
+			Type:       "*errors.joinError",
+			Stacktrace: nil,
+			Mechanism:  &Mechanism{Type: "generic", IsExceptionGroup: true, ExceptionID: 4},
+		},
+	}
+
+	if len(exceptions) != len(expected) {
+		t.Fatalf("Expected %d exceptions, got %d", len(expected), len(exceptions))
+	}
+
+	for i, exp := range expected {
+		if diff := cmp.Diff(exp, exceptions[i]); diff != "" {
+			t.Errorf("Event mismatch (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -3,12 +3,9 @@ package sentry
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"reflect"
-	"slices"
 	"strings"
 	"time"
 )
@@ -335,68 +332,28 @@ type Event struct {
 // maxErrorDepth is the maximum depth of the error chain we will look
 // into while unwrapping the errors. If maxErrorDepth is -1, we will
 // unwrap all errors in the chain.
-func (e *Event) SetException(exception error, maxErrorDepth int) {
+//
+// FIXME: "depth" and "count" have very different meanings for error trees.
+func (e *Event) SetException(exception error, maxErrorCount int) {
 	if exception == nil {
 		return
 	}
 
-	err := exception
-
-	for i := 0; err != nil && (i < maxErrorDepth || maxErrorDepth == -1); i++ {
-		// Add the current error to the exception slice with its details
-		e.Exception = append(e.Exception, Exception{
-			Value:      err.Error(),
-			Type:       reflect.TypeOf(err).String(),
-			Stacktrace: ExtractStacktrace(err),
-		})
-
-		// Attempt to unwrap the error using the standard library's Unwrap method.
-		// If errors.Unwrap returns nil, it means either there is no error to unwrap,
-		// or the error does not implement the Unwrap method.
-		unwrappedErr := errors.Unwrap(err)
-
-		if unwrappedErr != nil {
-			// The error was successfully unwrapped using the standard library's Unwrap method.
-			err = unwrappedErr
-			continue
-		}
-
-		cause, ok := err.(interface{ Cause() error })
-		if !ok {
-			// We cannot unwrap the error further.
-			break
-		}
-
-		// The error implements the Cause method, indicating it may have been wrapped
-		// using the github.com/pkg/errors package.
-		err = cause.Cause()
-	}
-
-	// Add a trace of the current stack to the most recent error in a chain if
-	// it doesn't have a stack trace yet.
-	// We only add to the most recent error to avoid duplication and because the
-	// current stack is most likely unrelated to errors deeper in the chain.
-	if e.Exception[0].Stacktrace == nil {
-		e.Exception[0].Stacktrace = NewStacktrace()
-	}
-
-	if len(e.Exception) <= 1 {
+	e.Exception = errorTree{exception}.Exceptions()
+	if len(e.Exception) == 0 {
 		return
 	}
 
-	// event.Exception should be sorted such that the most recent error is last.
-	slices.Reverse(e.Exception)
+	if len(e.Exception) <= 1 {
+		// Strip indication the Exception belongs to a group.
+		for i := range e.Exception {
+			e.Exception[i].Mechanism = nil
+		}
+	}
 
-	for i := range e.Exception {
-		e.Exception[i].Mechanism = &Mechanism{
-			IsExceptionGroup: true,
-			ExceptionID:      i,
-			Type:             "generic",
-		}
-		if i == 0 {
-			continue
-		}
-		e.Exception[i].Mechanism.ParentID = Pointer(i - 1)
+	latest := len(e.Exception) - 1
+	if e.Exception[latest].Stacktrace == nil {
+		e.Exception[latest].Stacktrace = NewStacktrace()
 	}
 }
 

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -380,6 +380,36 @@ func TestSetException(t *testing.T) {
 				},
 			},
 		},
+		"Joined and wrapped errors": {
+			exception: errors.Join(
+				fmt.Errorf("wrapper: %w", errors.New("base error")),
+				errors.New("joined"),
+			),
+			maxErrorCount: -1,
+			expected: []Exception{
+				{
+					Value:     "base error",
+					Type:      "*errors.errorString",
+					Mechanism: &Mechanism{Type: "generic", ExceptionID: 0, IsExceptionGroup: true},
+				},
+				{
+					Value:     "wrapper: base error",
+					Type:      "*fmt.wrapError",
+					Mechanism: &Mechanism{Type: "generic", ExceptionID: 1, ParentID: Pointer(0), IsExceptionGroup: true},
+				},
+				{
+					Value:     "joined",
+					Type:      "*errors.errorString",
+					Mechanism: &Mechanism{Type: "generic", ExceptionID: 2, IsExceptionGroup: true},
+				},
+				{
+					Value:      "wrapper: base error\njoined",
+					Type:       "*errors.joinError",
+					Stacktrace: &Stacktrace{Frames: []Frame{}},
+					Mechanism:  &Mechanism{Type: "generic", ExceptionID: 3, IsExceptionGroup: true},
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
# Changes

+ Adds an `errorTree` for traversing composed errors: `errors.Wrap`, `(github.com/pkg/errors).Wrap`, and now `errors.Join`.
+ Refactors `SetException` to use `errorTree`.

# Motivation 

Fix https://github.com/getsentry/sentry-go/issues/977

See discussion and open questions there.