### PR TITLE
Fix lint issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,17 +22,9 @@ jobs:
         with:
           go-version: "1.24"
       - uses: actions/checkout@v4
-      - name: Get auth token
-        id: token
-        uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2 # v1.11.5
-        with:
-          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # pin@v6.5.0
         with:
-          github-token: ${{ steps.token.outputs.token }}
           version: v1.62
-          only-new-issues: true
           args: --timeout=10m
     timeout-minutes: 10

--- a/client_test.go
+++ b/client_test.go
@@ -47,7 +47,7 @@ func setupClientTest() (*Client, *ScopeMock, *TransportMock) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:       "http://whatever@example.com/1337",
 		Transport: transport,
-		Integrations: func(i []Integration) []Integration {
+		Integrations: func(_ []Integration) []Integration {
 			return []Integration{}
 		},
 	})
@@ -490,7 +490,7 @@ func TestApplyToScopeCanDropEvent(t *testing.T) {
 	client, scope, transport := setupClientTest()
 	scope.shouldDropEvent = true
 
-	client.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+	client.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
 		if event == nil {
 			t.Errorf("EventProcessor received nil Event")
 		}
@@ -506,7 +506,7 @@ func TestApplyToScopeCanDropEvent(t *testing.T) {
 
 func TestBeforeSendCanDropEvent(t *testing.T) {
 	client, scope, transport := setupClientTest()
-	client.options.BeforeSend = func(event *Event, hint *EventHint) *Event {
+	client.options.BeforeSend = func(_ *Event, _ *EventHint) *Event {
 		return nil
 	}
 
@@ -538,11 +538,11 @@ func TestBeforeSendTransactionCanDropTransaction(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 		Transport:        transport,
-		BeforeSend: func(event *Event, hint *EventHint) *Event {
+		BeforeSend: func(event *Event, _ *EventHint) *Event {
 			t.Error("beforeSend should not be called")
 			return event
 		},
-		BeforeSendTransaction: func(event *Event, hint *EventHint) *Event {
+		BeforeSendTransaction: func(event *Event, _ *EventHint) *Event {
 			assertEqual(t, event.Transaction, "Foo")
 			return nil
 		},
@@ -564,11 +564,11 @@ func TestBeforeSendTransactionIsCalled(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 		Transport:        transport,
-		BeforeSend: func(event *Event, hint *EventHint) *Event {
+		BeforeSend: func(event *Event, _ *EventHint) *Event {
 			t.Error("beforeSend should not be called")
 			return event
 		},
-		BeforeSendTransaction: func(event *Event, hint *EventHint) *Event {
+		BeforeSendTransaction: func(event *Event, _ *EventHint) *Event {
 			assertEqual(t, event.Transaction, "Foo")
 			event.Transaction = "Bar"
 			return event

--- a/example_transportwithhooks_test.go
+++ b/example_transportwithhooks_test.go
@@ -43,7 +43,7 @@ func Example_transportWithHooks() {
 				}
 				return nil
 			},
-			After: func(req *http.Request, resp *http.Response, err error) (*http.Response, error) {
+			After: func(_ *http.Request, resp *http.Response, err error) (*http.Response, error) {
 				if b, err := httputil.DumpResponse(resp, true); err != nil {
 					fmt.Println(err)
 				} else {

--- a/http/example_test.go
+++ b/http/example_test.go
@@ -1,3 +1,4 @@
+// nolint // Don't lint example code.
 package sentryhttp_test
 
 import (

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -68,7 +68,7 @@ func TestIntegration(t *testing.T) {
 			Path:   "/post",
 			Method: "POST",
 			Body:   "payload",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				body, err := io.ReadAll(r.Body)
 				if err != nil {
@@ -112,7 +112,7 @@ func TestIntegration(t *testing.T) {
 		},
 		{
 			Path: "/get",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				hub.CaptureMessage("get")
 			}),
@@ -150,7 +150,7 @@ func TestIntegration(t *testing.T) {
 			Path:   "/post/large",
 			Method: "POST",
 			Body:   largePayload,
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				body, err := io.ReadAll(r.Body)
 				if err != nil {
@@ -198,7 +198,7 @@ func TestIntegration(t *testing.T) {
 			Path:   "/post/body-ignored",
 			Method: "POST",
 			Body:   "client sends, server ignores, SDK doesn't read",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				hub.CaptureMessage("body ignored")
 			}),
@@ -245,11 +245,11 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			transactionsCh <- tx
 			return tx
 		},

--- a/hub.go
+++ b/hub.go
@@ -293,14 +293,14 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 		return
 	}
 
-	max := client.options.MaxBreadcrumbs
+	limit := client.options.MaxBreadcrumbs
 	switch {
-	case max < 0:
+	case limit < 0:
 		return
-	case max == 0:
-		max = defaultMaxBreadcrumbs
-	case max > maxBreadcrumbs:
-		max = maxBreadcrumbs
+	case limit == 0:
+		limit = defaultMaxBreadcrumbs
+	case limit > maxBreadcrumbs:
+		limit = maxBreadcrumbs
 	}
 
 	if client.options.BeforeBreadcrumb != nil {
@@ -313,7 +313,7 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 		}
 	}
 
-	hub.Scope().AddBreadcrumb(breadcrumb, max)
+	hub.Scope().AddBreadcrumb(breadcrumb, limit)
 }
 
 // Recover calls the method of a same name on currently bound Client instance

--- a/hub_test.go
+++ b/hub_test.go
@@ -114,7 +114,7 @@ func TestBindClient(t *testing.T) {
 func TestWithScopeCreatesIsolatedScope(t *testing.T) {
 	hub, _, _ := setupHubTest()
 
-	hub.WithScope(func(scope *Scope) {
+	hub.WithScope(func(_ *Scope) {
 		assertEqual(t, len(*hub.stack), 2)
 	})
 
@@ -124,7 +124,7 @@ func TestWithScopeCreatesIsolatedScope(t *testing.T) {
 func TestWithScopeBindClient(t *testing.T) {
 	hub, client, _ := setupHubTest()
 
-	hub.WithScope(func(scope *Scope) {
+	hub.WithScope(func(_ *Scope) {
 		newClient, _ := NewClient(ClientOptions{Dsn: testDsn, Transport: &TransportMock{}})
 		hub.BindClient(newClient)
 		if hub.stackTop().client != newClient {
@@ -153,7 +153,7 @@ func TestWithScopeChangesThroughConfigureScope(t *testing.T) {
 	hub, _, _ := setupHubTest()
 	hub.Scope().SetExtra("extra", "foo")
 
-	hub.WithScope(func(scope *Scope) {
+	hub.WithScope(func(_ *Scope) {
 		hub.ConfigureScope(func(scope *Scope) {
 			scope.SetExtra("extra", "bar")
 		})
@@ -210,7 +210,7 @@ func TestLastEventIDDoesNotReset(t *testing.T) {
 	id1 := hub.CaptureException(fmt.Errorf("error 1"))
 	assertEqual(t, hub.LastEventID(), *id1)
 
-	client.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+	client.AddEventProcessor(func(_ *Event, _ *EventHint) *Event {
 		// drop all events
 		return nil
 	})
@@ -273,7 +273,7 @@ func TestAddBreadcrumbShouldWorkWithoutClient(t *testing.T) {
 
 func TestAddBreadcrumbCallsBeforeBreadcrumbCallback(t *testing.T) {
 	hub, client, scope := setupHubTest()
-	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb {
+	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, _ *BreadcrumbHint) *Breadcrumb {
 		breadcrumb.Message += "_wat"
 		return breadcrumb
 	}
@@ -286,7 +286,7 @@ func TestAddBreadcrumbCallsBeforeBreadcrumbCallback(t *testing.T) {
 
 func TestBeforeBreadcrumbCallbackCanDropABreadcrumb(t *testing.T) {
 	hub, client, scope := setupHubTest()
-	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb {
+	client.options.BeforeBreadcrumb = func(_ *Breadcrumb, _ *BreadcrumbHint) *Breadcrumb {
 		return nil
 	}
 

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -43,4 +43,3 @@ func (t *TransportMock) Events() []*Event {
 	return t.events
 }
 func (t *TransportMock) Close() {}
-

--- a/scope_test.go
+++ b/scope_test.go
@@ -393,7 +393,7 @@ func TestScopeBasicInheritance(t *testing.T) {
 	scope := NewScope()
 	scope.SetExtra("a", 1)
 	scope.SetRequestBody([]byte("requestbody"))
-	scope.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+	scope.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
 		return event
 	})
 	clone := scope.Clone()
@@ -474,7 +474,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	scope.SetUser(User{ID: "bar"})
 	r1 := httptest.NewRequest("GET", "/bar", nil)
 	scope.SetRequest(r1)
-	scope.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+	scope.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
 		return event
 	})
 	p1 := NewPropagationContext()
@@ -493,7 +493,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	clone.SetUser(User{ID: "foo"})
 	r2 := httptest.NewRequest("GET", "/foo", nil)
 	clone.SetRequest(r2)
-	clone.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+	clone.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
 		return event
 	})
 	p2 := NewPropagationContext()
@@ -654,11 +654,11 @@ func TestEventProcessorsModifiesEvent(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()
 	scope.eventProcessors = []EventProcessor{
-		func(event *Event, hint *EventHint) *Event {
+		func(event *Event, _ *EventHint) *Event {
 			event.Level = LevelFatal
 			return event
 		},
-		func(event *Event, hint *EventHint) *Event {
+		func(event *Event, _ *EventHint) *Event {
 			event.Fingerprint = []string{"wat"}
 			return event
 		},
@@ -676,7 +676,7 @@ func TestEventProcessorsCanDropEvent(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()
 	scope.eventProcessors = []EventProcessor{
-		func(event *Event, hint *EventHint) *Event {
+		func(_ *Event, _ *EventHint) *Event {
 			return nil
 		},
 	}
@@ -696,7 +696,7 @@ func TestEventProcessorsAddEventProcessor(t *testing.T) {
 		t.Error("event should not be dropped")
 	}
 
-	scope.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+	scope.AddEventProcessor(func(_ *Event, _ *EventHint) *Event {
 		return nil
 	})
 	processedEvent = scope.ApplyToEvent(event, nil, nil)

--- a/traces_sampler_test.go
+++ b/traces_sampler_test.go
@@ -26,7 +26,7 @@ func TestFixedRateSampler(t *testing.T) {
 		for _, tt := range tests {
 			tt := tt
 			t.Run(fmt.Sprint(tt.Rate), func(t *testing.T) {
-				got := repeatedSample(func(ctx SamplingContext) float64 { return tt.Rate }, SamplingContext{Span: rootSpan}, 10000)
+				got := repeatedSample(func(_ SamplingContext) float64 { return tt.Rate }, SamplingContext{Span: rootSpan}, 10000)
 				if got < tt.Rate*(1-tt.Tolerance) || got > tt.Rate*(1+tt.Tolerance) {
 					t.Errorf("got rootSpan sample rate %.2f, want %.2f±%.0f%%", got, tt.Rate, 100*tt.Tolerance)
 				}
@@ -34,14 +34,14 @@ func TestFixedRateSampler(t *testing.T) {
 		}
 	})
 
-	t.Run("Concurrency", func(t *testing.T) {
+	t.Run("Concurrency", func(_ *testing.T) {
 		// This test is for use with -race to catch data races.
 		var wg sync.WaitGroup
 		for i := 0; i < 32; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				repeatedSample(func(ctx SamplingContext) float64 { return 0.5 }, SamplingContext{Span: rootSpan}, 10000)
+				repeatedSample(func(_ SamplingContext) float64 { return 0.5 }, SamplingContext{Span: rootSpan}, 10000)
 			}()
 		}
 		wg.Wait()

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -224,7 +224,7 @@ func TestStartChild(t *testing.T) {
 			"Release", "Sdk", "ServerName", "Timestamp", "StartTime",
 			"sdkMetaData",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ interface{}) bool {
 			return k != "trace"
 		}),
 		cmpopts.IgnoreFields(Span{},
@@ -691,7 +691,7 @@ func TestSample(t *testing.T) {
 	// traces sampler
 	ctx = NewTestContext(ClientOptions{
 		EnableTracing: true,
-		TracesSampler: func(ctx SamplingContext) float64 {
+		TracesSampler: func(_ SamplingContext) float64 {
 			return 1.0
 		},
 	})

--- a/transport_test.go
+++ b/transport_test.go
@@ -333,7 +333,7 @@ type testHTTPServer struct {
 func newTestHTTPServer(t *testing.T) *testHTTPServer {
 	ch := make(chan bool)
 	eventCounter := new(uint64)
-	handler := func(w http.ResponseWriter, r *http.Request) {
+	handler := func(_ http.ResponseWriter, r *http.Request) {
 		var event struct {
 			EventID string `json:"event_id"`
 		}
@@ -481,7 +481,7 @@ func testKeepAlive(t *testing.T, tr Transport) {
 	// unexpectedly large response from Relay -- the SDK should not try to
 	// consume arbitrarily large responses.
 	largeResponse := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Simulates a response from Relay. The event_id is arbitrary,
 		// it doesn't matter for this test.
 		fmt.Fprintln(w, `{"id":"ec71d87189164e79ab1e61030c183af0"}`)
@@ -660,7 +660,7 @@ func TestHTTPTransportClose(t *testing.T) {
 	}
 }
 
-func TestHTTPSyncTransportClose(t *testing.T) {
+func TestHTTPSyncTransportClose(_ *testing.T) {
 	// Close does not do anything for HTTPSyncTransport, added for coverage.
 	transport := HTTPSyncTransport{}
 	transport.Close()


### PR DESCRIPTION
# Changes

+ Fix all lint issues. Makes minimal changes — mostly renaming unused parameters to `_` for `revive` — to bring all files into compliance with the current golangci-lint config.
    + Exempts http/example_test.go from linting — the lint errors _are valid,_ but this is example code and I want to avoid changing public-facing documentation in this PR. Consider removing the `//nolint` directive in a follow-up.
+ Update lint.yml; allow secretless linting of PRs from public forks.
    + See e.g. https://github.com/getsentry/sentry-go/pull/972#issuecomment-2722970359)
    + Remove the `only-new-issues: true` and `github-token` options from  the `golangci-lint-action` step. [`github-token` is only necessary when `only-new-issues: true`.](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#github-token)
    + Remove the "Get auth token" step: only necessary to provide `github-token` to the `golangci-lint-action` step.

# Testing

I _believe_ CI should run the version of the lint.yml action on this branch.

`make test` and `make lint` succeed locally:

```console
$ make test lint 
>>> Running tests for module: .
(cd . && go test -count=1 -timeout 300s  ./...)
?       github.com/getsentry/sentry-go/internal/debug   [no test files]
?       github.com/getsentry/sentry-go/internal/otel/baggage/internal/baggage   [no test files]
?       github.com/getsentry/sentry-go/internal/testutils       [no test files]
ok      github.com/getsentry/sentry-go  2.297s
ok      github.com/getsentry/sentry-go/http     0.427s
ok      github.com/getsentry/sentry-go/internal/httputils       0.712s
ok      github.com/getsentry/sentry-go/internal/otel/baggage    0.872s
ok      github.com/getsentry/sentry-go/internal/ratelimit       1.080s
ok      github.com/getsentry/sentry-go/internal/traceutils      1.233s
>>> Running tests for module: ./echo
(cd ./echo && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/echo     0.592s
>>> Running tests for module: ./fasthttp
(cd ./fasthttp && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/fasthttp 0.513s
>>> Running tests for module: ./fiber
(cd ./fiber && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/fiber    0.532s
>>> Running tests for module: ./gin
(cd ./gin && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/gin      0.505s
>>> Running tests for module: ./iris
(cd ./iris && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/iris     0.429s
>>> Running tests for module: ./logrus
(cd ./logrus && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/logrus   0.495s
>>> Running tests for module: ./negroni
(cd ./negroni && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/negroni  0.487s
>>> Running tests for module: ./otel
(cd ./otel && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/otel     0.437s
ok      github.com/getsentry/sentry-go/otel/internal/utils      0.474s
>>> Running tests for module: ./slog
(cd ./slog && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/slog     0.356s
>>> Running tests for module: ./zerolog
(cd ./zerolog && go test -count=1 -timeout 300s  ./...)
ok      github.com/getsentry/sentry-go/zerolog  0.565s
golangci-lint run
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```