### PR TITLE
Add attributes API

### DIFF
--- a/attribute/builder_test.go
+++ b/attribute/builder_test.go
@@ -1,0 +1,88 @@
+package attribute
+
+import (
+	"testing"
+)
+
+func TestBuilder(t *testing.T) {
+	k := "key"
+	for _, testcase := range []struct {
+		name      string
+		value     Builder
+		wantType  Type
+		wantValue interface{}
+	}{
+		{
+			name:      "Bool correctly returns a boolean builder",
+			value:     Bool(k, true),
+			wantType:  BOOL,
+			wantValue: true,
+		},
+		{
+			name:      "Int64() correctly returns an builder",
+			value:     Int64(k, 42),
+			wantType:  INT64,
+			wantValue: int64(42),
+		},
+		{
+			name:      "Int() correctly returns an builder",
+			value:     Int(k, 42),
+			wantType:  INT64,
+			wantValue: int64(42),
+		},
+		{
+			name:      "Float64() correctly returns a float64 builder",
+			value:     Float64(k, 42.1),
+			wantType:  FLOAT64,
+			wantValue: 42.1,
+		},
+		{
+			name:      "String() correctly returns a string builder",
+			value:     String(k, "foo"),
+			wantType:  STRING,
+			wantValue: "foo",
+		},
+	} {
+		if testcase.value.Value.Type() != testcase.wantType {
+			t.Errorf("wrong value type, got %#v, expected %#v", testcase.value.Value.Type(), testcase.wantType)
+		}
+	}
+}
+
+func TestBuilder_Valid(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		builder   Builder
+		wantValid bool
+	}{
+		{
+			name: "valid key and value are valid",
+			builder: Builder{
+				Key:   "key",
+				Value: BoolValue(true),
+			},
+			wantValid: true,
+		},
+		{
+			name: "empty key should be invalid",
+			builder: Builder{
+				Key:   "",
+				Value: IntValue(42),
+			},
+			wantValid: false,
+		},
+		{
+			name: "invalid value should be invalid",
+			builder: Builder{
+				Key:   "key",
+				Value: Value{},
+			},
+			wantValid: false,
+		},
+	} {
+		valid := tt.builder.Valid()
+		if tt.wantValid != valid {
+			t.Errorf("expected builder valid to be %v, got %v", tt.wantValid, valid)
+		}
+	}
+}

--- a/attribute/bulider.go
+++ b/attribute/bulider.go
@@ -1,0 +1,36 @@
+package attribute
+
+type Builder struct {
+	Key   string
+	Value Value
+}
+
+// String returns a Builder for a string value.
+func String(key, value string) Builder {
+	return Builder{key, StringValue(value)}
+}
+
+// Int64 returns a Builder for an int64.
+func Int64(key string, value int64) Builder {
+	return Builder{key, Int64Value(value)}
+}
+
+// Int returns a Builder for an int64.
+func Int(key string, value int) Builder {
+	return Builder{key, IntValue(value)}
+}
+
+// Float64 returns a Builder for a float64.
+func Float64(key string, v float64) Builder {
+	return Builder{key, Float64Value(v)}
+}
+
+// Bool returns a Builder for a boolean.
+func Bool(key string, v bool) Builder {
+	return Builder{key, BoolValue(v)}
+}
+
+// Valid checks for valid key and type.
+func (b *Builder) Valid() bool {
+	return len(b.Key) > 0 && b.Value.Type() != INVALID
+}

--- a/attribute/rawhelpers.go
+++ b/attribute/rawhelpers.go
@@ -19,7 +19,7 @@ import (
 	"math"
 )
 
-func boolToRaw(b bool) uint64 { // nolint:revive  // b is not a control flag.
+func boolToRaw(b bool) uint64 { // b is not a control flag.
 	if b {
 		return 1
 	}

--- a/attribute/rawhelpers.go
+++ b/attribute/rawhelpers.go
@@ -1,0 +1,49 @@
+// Copied from https://github.com/open-telemetry/opentelemetry-go/blob/cc43e01c27892252aac9a8f20da28cdde957a289/attribute/rawhelpers.go
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"math"
+)
+
+func boolToRaw(b bool) uint64 { // nolint:revive  // b is not a control flag.
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func rawToBool(r uint64) bool {
+	return r != 0
+}
+
+func int64ToRaw(i int64) uint64 {
+	// Assumes original was a valid int64 (overflow not checked).
+	return uint64(i) // nolint: gosec
+}
+
+func rawToInt64(r uint64) int64 {
+	// Assumes original was a valid int64 (overflow not checked).
+	return int64(r) // nolint: gosec
+}
+
+func float64ToRaw(f float64) uint64 {
+	return math.Float64bits(f)
+}
+
+func rawToFloat64(r uint64) float64 {
+	return math.Float64frombits(r)
+}

--- a/attribute/value.go
+++ b/attribute/value.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Type describes the type of the data Value holds.
-type Type int // nolint: revive  // redefines builtin Type.
+type Type int // redefines builtin Type.
 
 // Value represents the value part in key-value pairs.
 type Value struct {

--- a/attribute/value.go
+++ b/attribute/value.go
@@ -128,8 +128,8 @@ func (v Value) AsInterface() interface{} {
 	return unknownValueType{}
 }
 
-// Emit returns a string representation of Value's data.
-func (v Value) Emit() string {
+// String returns a string representation of Value's data.
+func (v Value) String() string {
 	switch v.Type() {
 	case BOOL:
 		return strconv.FormatBool(v.AsBool())

--- a/attribute/value.go
+++ b/attribute/value.go
@@ -1,0 +1,170 @@
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/cc43e01c27892252aac9a8f20da28cdde957a289/attribute/value.go
+//
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Type describes the type of the data Value holds.
+type Type int // nolint: revive  // redefines builtin Type.
+
+// Value represents the value part in key-value pairs.
+type Value struct {
+	vtype    Type
+	numeric  uint64
+	stringly string
+}
+
+const (
+	// INVALID is used for a Value with no value set.
+	INVALID Type = iota
+	// BOOL is a boolean Type Value.
+	BOOL
+	// INT64 is a 64-bit signed integral Type Value.
+	INT64
+	// FLOAT64 is a 64-bit floating point Type Value.
+	FLOAT64
+	// STRING is a string Type Value.
+	STRING
+)
+
+// BoolValue creates a BOOL Value.
+func BoolValue(v bool) Value {
+	return Value{
+		vtype:   BOOL,
+		numeric: boolToRaw(v),
+	}
+}
+
+// IntValue creates an INT64 Value.
+func IntValue(v int) Value {
+	return Int64Value(int64(v))
+}
+
+// Int64Value creates an INT64 Value.
+func Int64Value(v int64) Value {
+	return Value{
+		vtype:   INT64,
+		numeric: int64ToRaw(v),
+	}
+}
+
+// Float64Value creates a FLOAT64 Value.
+func Float64Value(v float64) Value {
+	return Value{
+		vtype:   FLOAT64,
+		numeric: float64ToRaw(v),
+	}
+}
+
+// StringValue creates a STRING Value.
+func StringValue(v string) Value {
+	return Value{
+		vtype:    STRING,
+		stringly: v,
+	}
+}
+
+// Type returns a type of the Value.
+func (v Value) Type() Type {
+	return v.vtype
+}
+
+// AsBool returns the bool value. Make sure that the Value's type is
+// BOOL.
+func (v Value) AsBool() bool {
+	return rawToBool(v.numeric)
+}
+
+// AsInt64 returns the int64 value. Make sure that the Value's type is
+// INT64.
+func (v Value) AsInt64() int64 {
+	return rawToInt64(v.numeric)
+}
+
+// AsFloat64 returns the float64 value. Make sure that the Value's
+// type is FLOAT64.
+func (v Value) AsFloat64() float64 {
+	return rawToFloat64(v.numeric)
+}
+
+// AsString returns the string value. Make sure that the Value's type
+// is STRING.
+func (v Value) AsString() string {
+	return v.stringly
+}
+
+type unknownValueType struct{}
+
+// AsInterface returns Value's data as interface{}.
+func (v Value) AsInterface() interface{} {
+	switch v.Type() {
+	case BOOL:
+		return v.AsBool()
+	case INT64:
+		return v.AsInt64()
+	case FLOAT64:
+		return v.AsFloat64()
+	case STRING:
+		return v.stringly
+	}
+	return unknownValueType{}
+}
+
+// Emit returns a string representation of Value's data.
+func (v Value) Emit() string {
+	switch v.Type() {
+	case BOOL:
+		return strconv.FormatBool(v.AsBool())
+	case INT64:
+		return strconv.FormatInt(v.AsInt64(), 10)
+	case FLOAT64:
+		return fmt.Sprint(v.AsFloat64())
+	case STRING:
+		return v.stringly
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON returns the JSON encoding of the Value.
+func (v Value) MarshalJSON() ([]byte, error) {
+	var jsonVal struct {
+		Type  string
+		Value interface{}
+	}
+	jsonVal.Type = v.Type().String()
+	jsonVal.Value = v.AsInterface()
+	return json.Marshal(jsonVal)
+}
+
+func (t Type) String() string {
+	switch t {
+	case BOOL:
+		return "bool"
+	case INT64:
+		return "int64"
+	case FLOAT64:
+		return "float64"
+	case STRING:
+		return "string"
+	}
+	return "invalid"
+}

--- a/attribute/value_test.go
+++ b/attribute/value_test.go
@@ -1,0 +1,164 @@
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/cc43e01c27892252aac9a8f20da28cdde957a289/attribute/value.go
+//
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestValue(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		value     Value
+		wantType  Type
+		wantValue interface{}
+	}{
+		{
+			name:      "BoolValue correctly returns a boolean",
+			value:     BoolValue(true),
+			wantType:  BOOL,
+			wantValue: true,
+		},
+		{
+			name:      "Int64Value() correctly returns an int64",
+			value:     Int64Value(42),
+			wantType:  INT64,
+			wantValue: int64(42),
+		},
+		{
+			name:      "IntValue() correctly returns an int64",
+			value:     IntValue(42),
+			wantType:  INT64,
+			wantValue: int64(42),
+		},
+		{
+			name:      "Float64Value() correctly returns a float64 value",
+			value:     Float64Value(42.1),
+			wantType:  FLOAT64,
+			wantValue: 42.1,
+		},
+		{
+			name:      "StringValue() correctly returns a string value",
+			value:     StringValue("foo"),
+			wantType:  STRING,
+			wantValue: "foo",
+		},
+		{
+			name:      "Invalid value type",
+			value:     Value{},
+			wantType:  INVALID,
+			wantValue: unknownValueType{},
+		},
+	} {
+		if testcase.value.Type() != testcase.wantType {
+			t.Errorf("wrong value type, got %#v, expected %#v", testcase.value.Type(), testcase.wantType)
+		}
+		got := testcase.value.AsInterface()
+		if diff := cmp.Diff(testcase.wantValue, got); diff != "" {
+			t.Errorf("+got, -want: %s", diff)
+		}
+	}
+}
+
+func TestValue_Emit(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value Value
+		want  string
+	}{
+		{
+			name:  "StringValue",
+			value: StringValue("foo"),
+			want:  "foo",
+		},
+		{
+			name:  "Int64Value",
+			value: Int64Value(42),
+			want:  "42",
+		},
+		{
+			name:  "IntValue",
+			value: IntValue(42),
+			want:  "42",
+		},
+		{
+			name:  "Float64Value",
+			value: Float64Value(42.1),
+			want:  "42.1",
+		},
+		{
+			name:  "BoolValue",
+			value: BoolValue(true),
+			want:  "true",
+		},
+		{
+			name:  "Invalid Value",
+			value: Value{},
+			want:  "unknown",
+		},
+	} {
+		str := tt.value.Emit()
+		if str != tt.want {
+			t.Errorf("expected %v, got: %v", tt.want, str)
+		}
+	}
+}
+
+func TestType_String(t *testing.T) {
+	for _, testcase := range []struct {
+		name  string
+		value Value
+		want  string
+	}{
+		{
+			name:  "BoolValue correctly returns a boolean",
+			value: BoolValue(true),
+			want:  "bool",
+		},
+		{
+			name:  "Int64Value() correctly returns an int64",
+			value: Int64Value(42),
+			want:  "int64",
+		},
+		{
+			name:  "IntValue() correctly returns an int64",
+			value: IntValue(42),
+			want:  "int64",
+		},
+		{
+			name:  "Float64Value() correctly returns a float64 value",
+			value: Float64Value(42.1),
+			want:  "float64",
+		},
+		{
+			name:  "StringValue() correctly returns a string value",
+			value: StringValue("foo"),
+			want:  "string",
+		},
+		{
+			name:  "Invalid value returns INVALID",
+			value: Value{},
+			want:  "invalid",
+		},
+	} {
+		if testcase.value.Type().String() != testcase.want {
+			t.Errorf("wrong value type, got %#v, expected %#v", testcase.value.Type().String(), testcase.want)
+		}
+	}
+}

--- a/attribute/value_test.go
+++ b/attribute/value_test.go
@@ -76,7 +76,7 @@ func TestValue(t *testing.T) {
 	}
 }
 
-func TestValue_Emit(t *testing.T) {
+func TestValue_toString(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		value Value
@@ -113,7 +113,7 @@ func TestValue_Emit(t *testing.T) {
 			want:  "unknown",
 		},
 	} {
-		str := tt.value.Emit()
+		str := tt.value.String()
 		if str != tt.want {
 			t.Errorf("expected %v, got: %v", tt.want, str)
 		}


### PR DESCRIPTION
## Description 

Implement the attributes API for typesafe values to set on spans.

## Usage example
```go
// creating [attribute.Values]
strValue := attribute.StringValue("value")
intValue := attribute.IntValue(42)
int64Value := attribute.Int64Value(42)
float64Value := attribute.Float64Value(42.1)

// accessing them
strValue.AsString()
intValue.AsInt64()

// creating [attribute.Builder]
attribute.String("key", "value")
attribute.Int("key.int", 42)

// usage example with SetData 
span.SetData("key",  attribute.StringValue("value"))
```

## Improvements
allow `SetData` to handle a `map[string]Value` for providing easier access to the span values and also ensure that we support all values provided on `SetData`. An example of how that would look like is something like:
```go
span.SetData(
  attribute.String("key", "value"),
  attribute.Bool("key.bool", true),
  attribute.Int("key.int", 42),
  attribute.Int64("key.int64", 17),
  attribute.Float64("key.float", 42.1),
)
```