### PR TITLE
Rename Logger to DebugLogger

### DIFF
--- a/_examples/http/main.go
+++ b/_examples/http/main.go
@@ -264,8 +264,8 @@ func NewImage(ctx context.Context, width, height int, seed []byte) image.Image {
 // The only reason to change logger configuration in this example is aesthetics.
 func configureLoggers() {
 	logFlags := log.Ldate | log.Ltime
-	sentry.Logger.SetPrefix("[sentry sdk]   ")
-	sentry.Logger.SetFlags(logFlags)
+	sentry.DebugLogger.SetPrefix("[sentry sdk]   ")
+	sentry.DebugLogger.SetFlags(logFlags)
 	log.SetPrefix("[http example] ")
 	log.SetFlags(logFlags)
 }

--- a/client.go
+++ b/client.go
@@ -77,9 +77,9 @@ type usageError struct {
 	error
 }
 
-// Logger is an instance of log.Logger that is use to provide debug information about running Sentry Client
-// can be enabled by either using Logger.SetOutput directly or with Debug client option.
-var Logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
+// DebugLogger is an instance of log.Logger that is used to provide debug information about running Sentry Client
+// can be enabled by either using DebugLogger.SetOutput directly or with Debug client option.
+var DebugLogger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
 
 // EventProcessor is a function that processes an event.
 // Event processors are used to change an event before it is sent to Sentry.
@@ -275,7 +275,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		if debugWriter == nil {
 			debugWriter = os.Stderr
 		}
-		Logger.SetOutput(debugWriter)
+		DebugLogger.SetOutput(debugWriter)
 	}
 
 	if options.Dsn == "" {
@@ -383,12 +383,12 @@ func (client *Client) setupIntegrations() {
 
 	for _, integration := range integrations {
 		if client.integrationAlreadyInstalled(integration.Name()) {
-			Logger.Printf("Integration %s is already installed\n", integration.Name())
+			DebugLogger.Printf("Integration %s is already installed\n", integration.Name())
 			continue
 		}
 		client.integrations = append(client.integrations, integration)
 		integration.SetupOnce(client)
-		Logger.Printf("Integration installed: %s\n", integration.Name())
+		DebugLogger.Printf("Integration installed: %s\n", integration.Name())
 	}
 
 	sort.Slice(client.integrations, func(i, j int) bool {
@@ -605,7 +605,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	// options.TracesSampler when they are started. Other events
 	// (errors, messages) are sampled here. Does not apply to check-ins.
 	if event.Type != transactionType && event.Type != checkInType && !sample(client.options.SampleRate) {
-		Logger.Println("Event dropped due to SampleRate hit.")
+		DebugLogger.Println("Event dropped due to SampleRate hit.")
 		return nil
 	}
 
@@ -620,13 +620,13 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	if event.Type == transactionType && client.options.BeforeSendTransaction != nil {
 		// Transaction events
 		if event = client.options.BeforeSendTransaction(event, hint); event == nil {
-			Logger.Println("Transaction dropped due to BeforeSendTransaction callback.")
+			DebugLogger.Println("Transaction dropped due to BeforeSendTransaction callback.")
 			return nil
 		}
 	} else if event.Type != transactionType && event.Type != checkInType && client.options.BeforeSend != nil {
 		// All other events
 		if event = client.options.BeforeSend(event, hint); event == nil {
-			Logger.Println("Event dropped due to BeforeSend callback.")
+			DebugLogger.Println("Event dropped due to BeforeSend callback.")
 			return nil
 		}
 	}
@@ -692,7 +692,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			Logger.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
+			DebugLogger.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
 			return nil
 		}
 	}
@@ -701,7 +701,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			Logger.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
+			DebugLogger.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
 			return nil
 		}
 	}

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -143,7 +143,7 @@ func GetSpanFromContext(ctx *fasthttp.RequestCtx) *sentry.Span {
 func convert(ctx *fasthttp.RequestCtx) *http.Request {
 	defer func() {
 		if err := recover(); err != nil {
-			sentry.Logger.Printf("%v", err)
+			sentry.DebugLogger.Printf("%v", err)
 		}
 	}()
 

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -143,7 +143,7 @@ func GetSpanFromContext(ctx *fiber.Ctx) *sentry.Span {
 func convert(ctx *fiber.Ctx) *http.Request {
 	defer func() {
 		if err := recover(); err != nil {
-			sentry.Logger.Printf("%v", err)
+			sentry.DebugLogger.Printf("%v", err)
 		}
 	}()
 

--- a/hub.go
+++ b/hub.go
@@ -308,7 +308,7 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 			hint = &BreadcrumbHint{}
 		}
 		if breadcrumb = client.options.BeforeBreadcrumb(breadcrumb, hint); breadcrumb == nil {
-			Logger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
+			DebugLogger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
 			return
 		}
 	}

--- a/integrations.go
+++ b/integrations.go
@@ -32,7 +32,7 @@ func (mi *modulesIntegration) processor(event *Event, _ *EventHint) *Event {
 		mi.once.Do(func() {
 			info, ok := debug.ReadBuildInfo()
 			if !ok {
-				Logger.Print("The Modules integration is not available in binaries built without module support.")
+				DebugLogger.Print("The Modules integration is not available in binaries built without module support.")
 				return
 			}
 			mi.modules = extractModules(info)
@@ -141,7 +141,7 @@ func (iei *ignoreErrorsIntegration) processor(event *Event, _ *EventHint) *Event
 	for _, suspect := range suspects {
 		for _, pattern := range iei.ignoreErrors {
 			if pattern.Match([]byte(suspect)) || strings.Contains(suspect, pattern.String()) {
-				Logger.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
+				DebugLogger.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
 					"| Value matched: %s | Filter used: %s", suspect, pattern)
 				return nil
 			}
@@ -203,7 +203,7 @@ func (iei *ignoreTransactionsIntegration) processor(event *Event, _ *EventHint) 
 
 	for _, pattern := range iei.ignoreTransactions {
 		if pattern.Match([]byte(suspect)) || strings.Contains(suspect, pattern.String()) {
-			Logger.Printf("Transaction dropped due to being matched by `IgnoreTransactions` option."+
+			DebugLogger.Printf("Transaction dropped due to being matched by `IgnoreTransactions` option."+
 				"| Value matched: %s | Filter used: %s", suspect, pattern)
 			return nil
 		}

--- a/scope.go
+++ b/scope.go
@@ -464,7 +464,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			Logger.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
+			DebugLogger.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
 			return nil
 		}
 	}

--- a/span_recorder.go
+++ b/span_recorder.go
@@ -24,7 +24,7 @@ func (r *spanRecorder) record(s *Span) {
 	if len(r.spans) >= maxSpans {
 		r.overflowOnce.Do(func() {
 			root := r.spans[0]
-			Logger.Printf("Too many spans: dropping spans from transaction with TraceID=%s SpanID=%s limit=%d",
+			DebugLogger.Printf("Too many spans: dropping spans from transaction with TraceID=%s SpanID=%s limit=%d",
 				root.TraceID, root.SpanID, maxSpans)
 		})
 		// TODO(tracing): mark the transaction event in some way to

--- a/span_recorder_test.go
+++ b/span_recorder_test.go
@@ -32,8 +32,8 @@ func Test_spanRecorder_record(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			logBuffer := bytes.Buffer{}
-			Logger.SetOutput(&logBuffer)
-			defer Logger.SetOutput(io.Discard)
+			DebugLogger.SetOutput(&logBuffer)
+			defer DebugLogger.SetOutput(io.Discard)
 			spanRecorder := spanRecorder{}
 
 			currentHub.BindClient(&Client{
@@ -54,7 +54,7 @@ func Test_spanRecorder_record(t *testing.T) {
 			} else {
 				assertEqual(t, len(spanRecorder.spans), tt.toRecordSpans, "expected no overflow")
 			}
-			// check if Logger was called for overflow messages
+			// check if DebugLogger was called for overflow messages
 			if bytes.Contains(logBuffer.Bytes(), []byte("Too many spans")) && !tt.expectOverflow {
 				t.Error("unexpected overflow log")
 			}

--- a/tracing.go
+++ b/tracing.go
@@ -452,14 +452,14 @@ func (s *Span) sample() Sampled {
 	// https://develop.sentry.dev/sdk/performance/#sampling
 	// #1 tracing is not enabled.
 	if !clientOptions.EnableTracing {
-		Logger.Printf("Dropping transaction: EnableTracing is set to %t", clientOptions.EnableTracing)
+		DebugLogger.Printf("Dropping transaction: EnableTracing is set to %t", clientOptions.EnableTracing)
 		s.sampleRate = 0.0
 		return SampledFalse
 	}
 
 	// #2 explicit sampling decision via StartSpan/StartTransaction options.
 	if s.explicitSampled != SampledUndefined {
-		Logger.Printf("Using explicit sampling decision from StartSpan/StartTransaction: %v", s.explicitSampled)
+		DebugLogger.Printf("Using explicit sampling decision from StartSpan/StartTransaction: %v", s.explicitSampled)
 		switch s.explicitSampled {
 		case SampledTrue:
 			s.sampleRate = 1.0
@@ -492,25 +492,25 @@ func (s *Span) sample() Sampled {
 			s.dynamicSamplingContext.Entries["sample_rate"] = strconv.FormatFloat(tracesSamplerSampleRate, 'f', -1, 64)
 		}
 		if tracesSamplerSampleRate < 0.0 || tracesSamplerSampleRate > 1.0 {
-			Logger.Printf("Dropping transaction: Returned TracesSampler rate is out of range [0.0, 1.0]: %f", tracesSamplerSampleRate)
+			DebugLogger.Printf("Dropping transaction: Returned TracesSampler rate is out of range [0.0, 1.0]: %f", tracesSamplerSampleRate)
 			return SampledFalse
 		}
 		if tracesSamplerSampleRate == 0.0 {
-			Logger.Printf("Dropping transaction: Returned TracesSampler rate is: %f", tracesSamplerSampleRate)
+			DebugLogger.Printf("Dropping transaction: Returned TracesSampler rate is: %f", tracesSamplerSampleRate)
 			return SampledFalse
 		}
 
 		if rng.Float64() < tracesSamplerSampleRate {
 			return SampledTrue
 		}
-		Logger.Printf("Dropping transaction: TracesSampler returned rate: %f", tracesSamplerSampleRate)
+		DebugLogger.Printf("Dropping transaction: TracesSampler returned rate: %f", tracesSamplerSampleRate)
 
 		return SampledFalse
 	}
 
 	// #4 inherit parent decision.
 	if s.Sampled != SampledUndefined {
-		Logger.Printf("Using sampling decision from parent: %v", s.Sampled)
+		DebugLogger.Printf("Using sampling decision from parent: %v", s.Sampled)
 		switch s.Sampled {
 		case SampledTrue:
 			s.sampleRate = 1.0
@@ -528,11 +528,11 @@ func (s *Span) sample() Sampled {
 		s.dynamicSamplingContext.Entries["sample_rate"] = strconv.FormatFloat(sampleRate, 'f', -1, 64)
 	}
 	if sampleRate < 0.0 || sampleRate > 1.0 {
-		Logger.Printf("Dropping transaction: TracesSampleRate out of range [0.0, 1.0]: %f", sampleRate)
+		DebugLogger.Printf("Dropping transaction: TracesSampleRate out of range [0.0, 1.0]: %f", sampleRate)
 		return SampledFalse
 	}
 	if sampleRate == 0.0 {
-		Logger.Printf("Dropping transaction: TracesSampleRate rate is: %f", sampleRate)
+		DebugLogger.Printf("Dropping transaction: TracesSampleRate rate is: %f", sampleRate)
 		return SampledFalse
 	}
 
@@ -555,7 +555,7 @@ func (s *Span) toEvent() *Event {
 	finished := make([]*Span, 0, len(children))
 	for _, child := range children {
 		if child.EndTime.IsZero() {
-			Logger.Printf("Dropped unfinished span: Op=%q TraceID=%s SpanID=%s", child.Op, child.TraceID, child.SpanID)
+			DebugLogger.Printf("Dropped unfinished span: Op=%q TraceID=%s SpanID=%s", child.Op, child.TraceID, child.SpanID)
 			continue
 		}
 		finished = append(finished, child)

--- a/util.go
+++ b/util.go
@@ -62,7 +62,7 @@ func defaultRelease() (release string) {
 	}
 	for _, e := range envs {
 		if release = os.Getenv(e); release != "" {
-			Logger.Printf("Using release from environment variable %s: %s", e, release)
+			DebugLogger.Printf("Using release from environment variable %s: %s", e, release)
 			return release
 		}
 	}
@@ -89,23 +89,23 @@ func defaultRelease() (release string) {
 			if err, ok := err.(*exec.ExitError); ok && len(err.Stderr) > 0 {
 				fmt.Fprintf(&s, ": %s", err.Stderr)
 			}
-			Logger.Print(s.String())
+			DebugLogger.Print(s.String())
 		} else {
 			release = strings.TrimSpace(string(b))
-			Logger.Printf("Using release from Git: %s", release)
+			DebugLogger.Printf("Using release from Git: %s", release)
 			return release
 		}
 	}
 
-	Logger.Print("Some Sentry features will not be available. See https://docs.sentry.io/product/releases/.")
-	Logger.Print("To stop seeing this message, pass a Release to sentry.Init or set the SENTRY_RELEASE environment variable.")
+	DebugLogger.Print("Some Sentry features will not be available. See https://docs.sentry.io/product/releases/.")
+	DebugLogger.Print("To stop seeing this message, pass a Release to sentry.Init or set the SENTRY_RELEASE environment variable.")
 	return ""
 }
 
 func revisionFromBuildInfo(info *debug.BuildInfo) string {
 	for _, setting := range info.Settings {
 		if setting.Key == "vcs.revision" && setting.Value != "" {
-			Logger.Printf("Using release from debug info: %s", setting.Value)
+			DebugLogger.Printf("Using release from debug info: %s", setting.Value)
 			return setting.Value
 		}
 	}


### PR DESCRIPTION
renaming the debug logger to DebugLogger so that we can define the Logger interface for implementing logs in our SDK.