### PR TITLE
Add user details when DefaultPII is enabled

### DIFF
--- a/log.go
+++ b/log.go
@@ -122,9 +122,11 @@ func (l *sentryLogger) log(ctx context.Context, level Level, severity int, messa
 	}
 	if l.client.options.SendDefaultPII {
 		user := GetHubFromContext(ctx).Scope().user
-		attrs["user.id"] = Attribute{Value: user.ID, Type: "string"}
-		attrs["user.name"] = Attribute{Value: user.Name, Type: "string"}
-		attrs["user.email"] = Attribute{Value: user.Email, Type: "string"}
+		if !user.IsEmpty() {
+			attrs["user.id"] = Attribute{Value: user.ID, Type: "string"}
+			attrs["user.name"] = Attribute{Value: user.Name, Type: "string"}
+			attrs["user.email"] = Attribute{Value: user.Email, Type: "string"}
+		}
 	}
 	if spanID.String() != "0000000000000000" {
 		attrs["sentry.trace.parent_span_id"] = Attribute{Value: spanID.String(), Type: "string"}

--- a/log.go
+++ b/log.go
@@ -120,6 +120,12 @@ func (l *sentryLogger) log(ctx context.Context, level Level, severity int, messa
 	} else if serverAddr, err := os.Hostname(); err == nil {
 		attrs["sentry.server.address"] = Attribute{Value: serverAddr, Type: "string"}
 	}
+	if l.client.options.SendDefaultPII {
+		user := GetHubFromContext(ctx).Scope().user
+		attrs["user.id"] = Attribute{Value: user.ID, Type: "string"}
+		attrs["user.name"] = Attribute{Value: user.Name, Type: "string"}
+		attrs["user.email"] = Attribute{Value: user.Email, Type: "string"}
+	}
 	if spanID.String() != "0000000000000000" {
 		attrs["sentry.trace.parent_span_id"] = Attribute{Value: spanID.String(), Type: "string"}
 	}

--- a/log.go
+++ b/log.go
@@ -121,11 +121,20 @@ func (l *sentryLogger) log(ctx context.Context, level Level, severity int, messa
 		attrs["sentry.server.address"] = Attribute{Value: serverAddr, Type: "string"}
 	}
 	if l.client.options.SendDefaultPII {
-		user := GetHubFromContext(ctx).Scope().user
-		if !user.IsEmpty() {
-			attrs["user.id"] = Attribute{Value: user.ID, Type: "string"}
-			attrs["user.name"] = Attribute{Value: user.Name, Type: "string"}
-			attrs["user.email"] = Attribute{Value: user.Email, Type: "string"}
+		scope := hub.Scope()
+		if scope != nil {
+			user := scope.user
+			if !user.IsEmpty() {
+				if user.ID != "" {
+					attrs["user.id"] = Attribute{Value: user.ID, Type: "string"}
+				}
+				if user.Name != "" {
+					attrs["user.name"] = Attribute{Value: user.Name, Type: "string"}
+				}
+				if user.Email != "" {
+					attrs["user.email"] = Attribute{Value: user.Email, Type: "string"}
+				}
+			}
 		}
 	}
 	if spanID.String() != "0000000000000000" {

--- a/log_test.go
+++ b/log_test.go
@@ -655,3 +655,59 @@ func Test_sentryLogger_SendDefaultPII(t *testing.T) {
 		t.Errorf("unexpected user.email: got %v, want %v", val.Value, "test@example.com")
 	}
 }
+
+func Test_sentryLogger_NoUserInfoWithSendDefaultPII_False(t *testing.T) {
+	ctx := context.Background()
+	mockTransport := &MockTransport{}
+	mockClient, _ := NewClient(ClientOptions{
+		Dsn:           testDsn,
+		Transport:     mockTransport,
+		Release:       "v1.2.3",
+		Environment:   "testing",
+		ServerName:    "test-server",
+		EnableLogs:    true,
+		EnableTracing: true,
+	})
+	mockClient.sdkIdentifier = "sentry.go"
+	mockClient.sdkVersion = "0.10.0"
+	hub := CurrentHub()
+	hub.BindClient(mockClient)
+	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
+
+	hub.Scope().SetUser(User{
+		ID:    "user123",
+		Name:  "Test User",
+		Email: "test@example.com",
+	})
+
+	ctx = SetHubOnContext(ctx, hub)
+
+	l := NewLogger(ctx)
+	l.Info(ctx, "test message with PII")
+	Flush(20 * time.Millisecond)
+
+	events := mockTransport.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	logs := events[0].Logs
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+
+	log := logs[0]
+	attrs := log.Attributes
+
+	if _, ok := attrs["user.id"]; ok {
+		t.Error("unexpected user.id attribute")
+	}
+
+	if _, ok := attrs["user.name"]; ok {
+		t.Error("unexpected user.name attribute")
+	}
+
+	if _, ok := attrs["user.email"]; ok {
+		t.Error("unexpected user.email attribute")
+	}
+}


### PR DESCRIPTION
Closes #1017 .

When `SendDefaultPII` is enabled, we should be adding user details on the logs payload.