### PR TITLE
fix: use correct Level signature for logs

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -638,7 +638,7 @@ type EventHint struct {
 type Log struct {
 	Timestamp  time.Time            `json:"timestamp,omitempty"`
 	TraceID    TraceID              `json:"trace_id,omitempty"`
-	Level      Level                `json:"level"`
+	Level      LogLevel             `json:"level"`
 	Severity   int                  `json:"severity_number,omitempty"`
 	Body       string               `json:"body,omitempty"`
 	Attributes map[string]Attribute `json:"attributes,omitempty"`

--- a/log.go
+++ b/log.go
@@ -13,12 +13,12 @@ import (
 type LogLevel string
 
 const (
-	LogLevelTrace Level = "trace"
-	LogLevelDebug Level = "debug"
-	LogLevelInfo  Level = "info"
-	LogLevelWarn  Level = "warn"
-	LogLevelError Level = "error"
-	LogLevelFatal Level = "fatal"
+	LogLevelTrace LogLevel = "trace"
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+	LogLevelFatal LogLevel = "fatal"
 )
 
 const (
@@ -63,11 +63,11 @@ func NewLogger(ctx context.Context) Logger {
 func (l *sentryLogger) Write(p []byte) (int, error) {
 	// Avoid sending double newlines to Sentry
 	msg := strings.TrimRight(string(p), "\n")
-	l.log(context.Background(), LevelInfo, LogSeverityInfo, msg)
+	l.log(context.Background(), LogLevelInfo, LogSeverityInfo, msg)
 	return len(p), nil
 }
 
-func (l *sentryLogger) log(ctx context.Context, level Level, severity int, message string, args ...interface{}) {
+func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, message string, args ...interface{}) {
 	if message == "" {
 		return
 	}


### PR DESCRIPTION
Quick fix for changing the LogLevel signature to properly use `LogLevel` instead of the event `Level`.