### PR TITLE
Fix remove sentry.origin for sentry logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -144,7 +144,6 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 	if sdkVersion := l.client.sdkVersion; sdkVersion != "" {
 		attrs["sentry.sdk.version"] = Attribute{Value: sdkVersion, Type: "string"}
 	}
-	attrs["sentry.origin"] = Attribute{Value: "auto.logger.log", Type: "string"}
 
 	log := &Log{
 		Timestamp:  time.Now(),

--- a/log_test.go
+++ b/log_test.go
@@ -46,7 +46,6 @@ func Test_sentryLogger_MethodsWithFormat(t *testing.T) {
 		"sentry.server.address":       {Value: "test-server", Type: "string"},
 		"sentry.sdk.name":             {Value: "sentry.go", Type: "string"},
 		"sentry.sdk.version":          {Value: "0.10.0", Type: "string"},
-		"sentry.origin":               {Value: "auto.logger.log", Type: "string"},
 		"sentry.message.template":     {Value: "param matching: %v and %v", Type: "string"},
 		"sentry.message.parameters.0": {Value: "param1", Type: "string"},
 		"sentry.message.parameters.1": {Value: "param2", Type: "string"},
@@ -207,7 +206,6 @@ func Test_sentryLogger_MethodsWithoutFormat(t *testing.T) {
 		"sentry.server.address": {Value: "test-server", Type: "string"},
 		"sentry.sdk.name":       {Value: "sentry.go", Type: "string"},
 		"sentry.sdk.version":    {Value: "0.10.0", Type: "string"},
-		"sentry.origin":         {Value: "auto.logger.log", Type: "string"},
 	}
 
 	tests := []struct {
@@ -381,7 +379,6 @@ func Test_sentryLogger_Write(t *testing.T) {
 		"sentry.server.address": {Value: "test-server", Type: "string"},
 		"sentry.sdk.name":       {Value: "sentry.go", Type: "string"},
 		"sentry.sdk.version":    {Value: "0.10.0", Type: "string"},
-		"sentry.origin":         {Value: "auto.logger.log", Type: "string"},
 	}
 	wantLogs := []Log{
 		{


### PR DESCRIPTION
### Description
According to the docs here https://develop.sentry.dev/sdk/telemetry/logs/#sdk-integration-attributes, `sentry.origin` should only be set for integrations.
