### PR TITLE
Add slog fingerprint handler

### DIFF
--- a/slog/converter.go
+++ b/slog/converter.go
@@ -73,6 +73,8 @@ func attrToSentryEvent(attr slog.Attr, event *sentry.Event) {
 		handleUserAttributes(v, event)
 	case k == "request" && kind == slog.KindAny:
 		handleRequestAttributes(v, event)
+	case k == "fingerprint" && kind == slog.KindAny:
+		handleFingerprint(v, event)
 	case kind == slog.KindGroup:
 		event.Extra[k] = attrsToMap(v.Group()...)
 	default:
@@ -119,5 +121,11 @@ func handleRequestAttributes(v slog.Value, event *sentry.Event) {
 				event.User.Data["request"] = fmt.Sprintf("%v", v.Any())
 			}
 		}
+	}
+}
+
+func handleFingerprint(v slog.Value, event *sentry.Event) {
+	if fingerprint, ok := v.Any().([]string); ok {
+		event.Fingerprint = fingerprint
 	}
 }

--- a/slog/converter_test.go
+++ b/slog/converter_test.go
@@ -156,6 +156,10 @@ func TestAttrToSentryEvent(t *testing.T) {
 				}},
 			},
 		},
+		"fingerprint": {
+			attr:     slog.Attr{Key: "fingerprint", Value: slog.AnyValue([]string{"value1", "value2"})},
+			expected: &sentry.Event{Fingerprint: []string{"value1", "value2"}},
+		},
 	}
 
 	for name, tc := range tests {
@@ -171,6 +175,7 @@ func TestAttrToSentryEvent(t *testing.T) {
 			assert.Equal(t, tc.expected.Transaction, event.Transaction)
 			assert.Equal(t, tc.expected.User, event.User)
 			assert.Equal(t, tc.expected.Request, event.Request)
+			assert.Equal(t, tc.expected.Fingerprint, event.Fingerprint)
 			if len(tc.expected.Tags) == 0 {
 				assert.Empty(t, event.Tags)
 			} else {


### PR DESCRIPTION
<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
This pull request introduces support for handling the fingerprint attribute in the slog-to-Sentry event conversion process.

- Added logic in attrToSentryEvent to recognize the "fingerprint" key and assign its value to the Sentry event's Fingerprint field.
- Implemented the handleFingerprint function to process the attribute when it is a []string.
- Added corresponding test cases to ensure correct behavior.

This enhancement allows users to specify custom fingerprints via slog attributes, enabling more flexible event grouping in Sentry.