### PR TITLE
Remove handling for specific logrus keys

### DIFF
--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -335,32 +335,7 @@ func (h *logHook) Fire(entry *logrus.Entry) error {
 			h.logger.SetAttributes(attribute.String(k, fmt.Sprint(v)))
 		}
 	}
-	// Handle request field
-	key := h.key(FieldRequest)
-	if req, ok := entry.Data[key].(*http.Request); ok {
-		h.logger.SetAttributes(attribute.String("http.request.method", req.Method))
-		h.logger.SetAttributes(attribute.String("url.full", req.URL.String()))
-	}
 
-	// Handle error field
-	if err, ok := entry.Data[logrus.ErrorKey].(error); ok {
-		h.logger.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
-		h.logger.SetAttributes(attribute.String("error.message", err.Error()))
-	}
-
-	// Handle user field
-	key = h.key(FieldUser)
-	if user, ok := entry.Data[key].(sentry.User); ok {
-		if user.ID != "" {
-			h.logger.SetAttributes(attribute.String("user.id", user.ID))
-		}
-		if user.Email != "" {
-			h.logger.SetAttributes(attribute.String("user.email", user.Email))
-		}
-		if user.Name != "" {
-			h.logger.SetAttributes(attribute.String("user.name", user.Name))
-		}
-	}
 	h.logger.SetAttributes(attribute.String("sentry.origin", "auto.logger.logrus"))
 
 	switch entry.Level {

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -697,32 +697,25 @@ func TestLogHookFireWithDifferentDataTypes(t *testing.T) {
 		Level: sentry.LogLevelInfo,
 		Body:  "test message",
 		Attributes: map[string]sentry.Attribute{
-			"int8":                {Value: int64(8), Type: "integer"},
-			"int16":               {Value: int64(16), Type: "integer"},
-			"int32":               {Value: int64(32), Type: "integer"},
-			"int64":               {Value: int64(64), Type: "integer"},
-			"int":                 {Value: int64(42), Type: "integer"},
-			"uint8":               {Value: int64(8), Type: "integer"},
-			"uint16":              {Value: int64(16), Type: "integer"},
-			"uint32":              {Value: int64(32), Type: "integer"},
-			"uint64":              {Value: int64(64), Type: "integer"},
-			"uint":                {Value: int64(42), Type: "integer"},
-			"string":              {Value: "test string", Type: "string"},
-			"float32":             {Value: float64(float32(3.14)), Type: "double"},
-			"float64":             {Value: 6.28, Type: "double"},
-			"float64-overflow":    {Value: strconv.FormatUint(math.MaxUint64, 10), Type: "string"},
-			"bool":                {Value: true, Type: "boolean"},
-			"string_slice":        {Value: "[one two three]", Type: "string"},
-			"string_map":          {Value: "map[a:1 b:2 c:3]", Type: "string"},
-			"complex":             {Value: "{test 42}", Type: "string"},
-			"sentry.origin":       {Value: "auto.logger.logrus", Type: "string"},
-			"error.message":       {Value: "test error", Type: "string"},
-			"error.type":          {Value: "*errors.errorString", Type: "string"},
-			"http.request.method": {Value: "GET", Type: "string"},
-			"url.full":            {Value: "https://example.com/test", Type: "string"},
-			"user.email":          {Value: "test@example.com", Type: "string"},
-			"user.id":             {Value: "test-user", Type: "string"},
-			"user.name":           {Value: "tester", Type: "string"},
+			"int8":             {Value: int64(8), Type: "integer"},
+			"int16":            {Value: int64(16), Type: "integer"},
+			"int32":            {Value: int64(32), Type: "integer"},
+			"int64":            {Value: int64(64), Type: "integer"},
+			"int":              {Value: int64(42), Type: "integer"},
+			"uint8":            {Value: int64(8), Type: "integer"},
+			"uint16":           {Value: int64(16), Type: "integer"},
+			"uint32":           {Value: int64(32), Type: "integer"},
+			"uint64":           {Value: int64(64), Type: "integer"},
+			"uint":             {Value: int64(42), Type: "integer"},
+			"string":           {Value: "test string", Type: "string"},
+			"float32":          {Value: float64(float32(3.14)), Type: "double"},
+			"float64":          {Value: 6.28, Type: "double"},
+			"float64-overflow": {Value: strconv.FormatUint(math.MaxUint64, 10), Type: "string"},
+			"bool":             {Value: true, Type: "boolean"},
+			"string_slice":     {Value: "[one two three]", Type: "string"},
+			"string_map":       {Value: "map[a:1 b:2 c:3]", Type: "string"},
+			"complex":          {Value: "{test 42}", Type: "string"},
+			"sentry.origin":    {Value: "auto.logger.logrus", Type: "string"},
 		},
 	}
 
@@ -754,12 +747,6 @@ func TestLogHookFireWithDifferentDataTypes(t *testing.T) {
 	}
 
 	// Add fields for request, user and transaction
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	user := sentry.User{ID: "test-user", Email: "test@example.com", Name: "tester"}
-	entry.Data[logHook.key(FieldRequest)] = req
-	entry.Data[logHook.key(FieldUser)] = user
-	entry.Data[logHook.key(FieldFingerprint)] = []string{"test-fingerprint"}
-
 	err := logHook.Fire(entry)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
We should handle everything a user sets as attributes on logs. 
- The user attributes should be handled by the default log if set on the scope.
- The other keys should be passed as is.
