### PR TITLE
Fix race condition on GetSpan and guard transport Close

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -304,6 +304,9 @@ func (scope *Scope) SetPropagationContext(propagationContext PropagationContext)
 
 // GetSpan returns the span from the current scope.
 func (scope *Scope) GetSpan() *Span {
+	scope.mu.RLock()
+	defer scope.mu.RUnlock()
+
 	return scope.span
 }
 

--- a/transport.go
+++ b/transport.go
@@ -303,7 +303,7 @@ type HTTPTransport struct {
 	// current in-flight items and starts a new batch for subsequent events.
 	buffer chan batch
 
-	start     sync.Once
+	startOnce sync.Once
 	closeOnce sync.Once
 
 	// Size of the transport buffer. Defaults to 30.
@@ -365,7 +365,7 @@ func (t *HTTPTransport) Configure(options ClientOptions) {
 		}
 	}
 
-	t.start.Do(func() {
+	t.startOnce.Do(func() {
 		go t.worker()
 	})
 }

--- a/transport.go
+++ b/transport.go
@@ -303,7 +303,8 @@ type HTTPTransport struct {
 	// current in-flight items and starts a new batch for subsequent events.
 	buffer chan batch
 
-	start sync.Once
+	start     sync.Once
+	closeOnce sync.Once
 
 	// Size of the transport buffer. Defaults to 30.
 	BufferSize int
@@ -506,7 +507,9 @@ fail:
 // Close should be called after Flush and before terminating the program
 // otherwise some events may be lost.
 func (t *HTTPTransport) Close() {
-	close(t.done)
+	t.closeOnce.Do(func() {
+		close(t.done)
+	})
 }
 
 func (t *HTTPTransport) worker() {

--- a/transport_test.go
+++ b/transport_test.go
@@ -503,6 +503,14 @@ func TestHTTPTransport_CloseMultipleTimes(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		transport.Close()
 	}
+
+	// Verify the done channel is closed
+	select {
+	case <-transport.done:
+		// Expected - channel should be closed
+	case <-time.After(time.Second):
+		t.Fatal("tranposrt.done not closed")
+	}
 }
 
 func TestHTTPTransport_FlushWithContext(t *testing.T) {

--- a/transport_test.go
+++ b/transport_test.go
@@ -490,6 +490,20 @@ func TestHTTPTransport(t *testing.T) {
 		wg.Wait()
 	})
 }
+func TestHTTPTransport_CloseMultipleTimes(t *testing.T) {
+	server := newTestHTTPServer(t)
+	defer server.Close()
+	transport := NewHTTPTransport()
+	transport.Configure(ClientOptions{
+		Dsn:        fmt.Sprintf("https://test@%s/1", server.Listener.Addr()),
+		HTTPClient: server.Client(),
+	})
+
+	// Closing multiple times should not panic.
+	for i := 0; i < 10; i++ {
+		transport.Close()
+	}
+}
 
 func TestHTTPTransport_FlushWithContext(t *testing.T) {
 	server := newTestHTTPServer(t)

--- a/transport_test.go
+++ b/transport_test.go
@@ -509,7 +509,7 @@ func TestHTTPTransport_CloseMultipleTimes(t *testing.T) {
 	case <-transport.done:
 		// Expected - channel should be closed
 	case <-time.After(time.Second):
-		t.Fatal("tranposrt.done not closed")
+		t.Fatal("transport.done not closed")
 	}
 }
 


### PR DESCRIPTION
Partial fix for #1047.

## Description

- Fixing a race condition on GetSpan by adding a mutex.
- Guarding transport so that you can only close the `done` channel once, to avoid panics.