### PR TITLE
Modify log API

### DIFF
--- a/_examples/logs/main.go
+++ b/_examples/logs/main.go
@@ -53,7 +53,7 @@ type MyHandler struct {
 
 // ServeHTTP example of a handler
 // To correlate logs with transactions, [context.Context] needs to be passed to the [LogEntry] with the [WithCtx] func.
-// Assuming you are using and sentry tracing integration.
+// Assuming you are using a Sentry tracing integration.
 func (h MyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	// By using [WithCtx] the log entry will be associated with the transaction from the request

--- a/_examples/logs/main.go
+++ b/_examples/logs/main.go
@@ -21,8 +21,7 @@ func main() {
 
 	ctx := context.Background()
 	loggerWithAttrs := sentry.NewLogger(ctx)
-	// Attaching permanent attributes on the logger. The attributes are used for indexing reasons and thus, only
-	// the basic primitive types are supported.
+	// Attaching permanent attributes on the logger.
 	loggerWithAttrs.SetAttributes(
 		attribute.String("version", "1.0.0"),
 	)

--- a/interfaces.go
+++ b/interfaces.go
@@ -140,7 +140,6 @@ type LogEntry interface {
 	Int64(key string, value int64) LogEntry
 	Float64(key string, value float64) LogEntry
 	Bool(key string, value bool) LogEntry
-	Attributes(attrs ...attribute.Builder) LogEntry
 	Emit(args ...interface{})
 	Emitf(format string, args ...interface{})
 }
@@ -634,7 +633,17 @@ type Log struct {
 	Attributes map[string]Attribute `json:"attributes,omitempty"`
 }
 
+type AttrType string
+
+const (
+	AttributeInvalid AttrType = ""
+	AttributeBool             = "boolean"
+	AttributeInt              = "integer"
+	AttributeFloat            = "double"
+	AttributeString           = "string"
+)
+
 type Attribute struct {
-	Value any    `json:"value"`
-	Type  string `json:"type"`
+	Value any      `json:"value"`
+	Type  AttrType `json:"type"`
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -101,6 +101,7 @@ func (b *Breadcrumb) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*breadcrumb)(b))
 }
 
+// Logger provides a chaining API for structured logging to Sentry.
 type Logger interface {
 	// Write implements the io.Writer interface. Currently, the [sentry.Hub] is
 	// context aware, in order to get the correct trace correlation. Using this
@@ -108,51 +109,38 @@ type Logger interface {
 	// Write it is recommended to create a NewLogger so that the associated context
 	// is passed correctly.
 	Write(p []byte) (n int, err error)
-	// Trace emits a [LogLevelTrace] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Print].
-	Trace(ctx context.Context, v ...interface{})
-	// Debug emits a [LogLevelDebug] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Print].
-	Debug(ctx context.Context, v ...interface{})
-	// Info emits a [LogLevelInfo] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Print].
-	Info(ctx context.Context, v ...interface{})
-	// Warn emits a [LogLevelWarn] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Print].
-	Warn(ctx context.Context, v ...interface{})
-	// Error emits a [LogLevelError] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Print].
-	Error(ctx context.Context, v ...interface{})
-	// Fatal emits a [LogLevelFatal] log to Sentry followed by a call to [os.Exit](1).
-	// Arguments are handled in the manner of [fmt.Print].
-	Fatal(ctx context.Context, v ...interface{})
-	// Panic emits a [LogLevelFatal] log to Sentry followed by a call to panic().
-	// Arguments are handled in the manner of [fmt.Print].
-	Panic(ctx context.Context, v ...interface{})
 
-	// Tracef emits a [LogLevelTrace] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Printf].
-	Tracef(ctx context.Context, format string, v ...interface{})
-	// Debugf emits a [LogLevelDebug] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Printf].
-	Debugf(ctx context.Context, format string, v ...interface{})
-	// Infof emits a [LogLevelInfo] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Printf].
-	Infof(ctx context.Context, format string, v ...interface{})
-	// Warnf emits a [LogLevelWarn] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Printf].
-	Warnf(ctx context.Context, format string, v ...interface{})
-	// Errorf emits a [LogLevelError] log to Sentry.
-	// Arguments are handled in the manner of [fmt.Printf].
-	Errorf(ctx context.Context, format string, v ...interface{})
-	// Fatalf emits a [LogLevelFatal] log to Sentry followed by a call to [os.Exit](1).
-	// Arguments are handled in the manner of [fmt.Printf].
-	Fatalf(ctx context.Context, format string, v ...interface{})
-	// Panicf emits a [LogLevelFatal] log to Sentry followed by a call to panic().
-	// Arguments are handled in the manner of [fmt.Printf].
-	Panicf(ctx context.Context, format string, v ...interface{})
-	// SetAttributes allows attaching parameters to the log message using the attribute API.
+	// SetAttributes allows attaching parameters to the logger using the attribute API.
+	// These attributes will be included in all subsequent log entries.
 	SetAttributes(...attribute.Builder)
+
+	// Trace defines the [sentry.LogLevel] for the log entry.
+	Trace() LogEntry
+	// Debug defines the [sentry.LogLevel] for the log entry.
+	Debug() LogEntry
+	// Info defines the [sentry.LogLevel] for the log entry.
+	Info() LogEntry
+	// Warn defines the [sentry.LogLevel] for the log entry.
+	Warn() LogEntry
+	// Error defines the [sentry.LogLevel] for the log entry.
+	Error() LogEntry
+	// Fatal defines the [sentry.LogLevel] for the log entry.
+	Fatal() LogEntry
+	// Panic defines the [sentry.LogLevel] for the log entry.
+	Panic() LogEntry
+}
+
+// LogEntry defines the interface for a log entry that supports chaining attributes.
+type LogEntry interface {
+	WithCtx(ctx context.Context) LogEntry
+	String(key, value string) LogEntry
+	Int(key string, value int) LogEntry
+	Int64(key string, value int64) LogEntry
+	Float64(key string, value float64) LogEntry
+	Bool(key string, value bool) LogEntry
+	Attributes(attrs ...attribute.Builder) LogEntry
+	Emit(args ...interface{})
+	Emitf(format string, args ...interface{})
 }
 
 // Attachment allows associating files with your events to aid in investigation.

--- a/interfaces.go
+++ b/interfaces.go
@@ -134,13 +134,21 @@ type Logger interface {
 
 // LogEntry defines the interface for a log entry that supports chaining attributes.
 type LogEntry interface {
+	// WithCtx creates a new LogEntry with the specified context without overwriting the previous one.
 	WithCtx(ctx context.Context) LogEntry
+	// String adds a string attribute to the LogEntry.
 	String(key, value string) LogEntry
+	// Int adds an int attribute to the LogEntry.
 	Int(key string, value int) LogEntry
+	// Int64 adds an int64 attribute to the LogEntry.
 	Int64(key string, value int64) LogEntry
+	// Float64 adds a float64 attribute to the LogEntry.
 	Float64(key string, value float64) LogEntry
+	// Bool adds a bool attribute to the LogEntry.
 	Bool(key string, value bool) LogEntry
+	// Emit emits the LogEntry with the provided arguments.
 	Emit(args ...interface{})
+	// Emitf emits the LogEntry using a format string and arguments.
 	Emitf(format string, args ...interface{})
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -128,6 +128,8 @@ type Logger interface {
 	Fatal() LogEntry
 	// Panic defines the [sentry.LogLevel] for the log entry.
 	Panic() LogEntry
+	// GetCtx returns the [context.Context] set on the logger.
+	GetCtx() context.Context
 }
 
 // LogEntry defines the interface for a log entry that supports chaining attributes.

--- a/interfaces.go
+++ b/interfaces.go
@@ -637,10 +637,10 @@ type AttrType string
 
 const (
 	AttributeInvalid AttrType = ""
-	AttributeBool             = "boolean"
-	AttributeInt              = "integer"
-	AttributeFloat            = "double"
-	AttributeString           = "string"
+	AttributeBool    AttrType = "boolean"
+	AttributeInt     AttrType = "integer"
+	AttributeFloat   AttrType = "double"
+	AttributeString  AttrType = "string"
 )
 
 type Attribute struct {

--- a/log.go
+++ b/log.go
@@ -73,7 +73,7 @@ func NewLogger(ctx context.Context) Logger {
 func (l *sentryLogger) Write(p []byte) (int, error) {
 	// Avoid sending double newlines to Sentry
 	msg := strings.TrimRight(string(p), "\n")
-	l.Info().WithCtx(context.Background()).Emit(msg)
+	l.Info().Emit(msg)
 	return len(p), nil
 }
 
@@ -193,7 +193,7 @@ func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {
 func (l *sentryLogger) Trace() LogEntry {
 	return &logEntry{
 		logger:     l,
-		ctx:        context.Background(),
+		ctx:        l.ctx,
 		level:      LogLevelTrace,
 		severity:   LogSeverityTrace,
 		attributes: make(map[string]Attribute),
@@ -203,7 +203,7 @@ func (l *sentryLogger) Trace() LogEntry {
 func (l *sentryLogger) Debug() LogEntry {
 	return &logEntry{
 		logger:     l,
-		ctx:        context.Background(),
+		ctx:        l.ctx,
 		level:      LogLevelDebug,
 		severity:   LogSeverityDebug,
 		attributes: make(map[string]Attribute),
@@ -213,7 +213,7 @@ func (l *sentryLogger) Debug() LogEntry {
 func (l *sentryLogger) Info() LogEntry {
 	return &logEntry{
 		logger:     l,
-		ctx:        context.Background(),
+		ctx:        l.ctx,
 		level:      LogLevelInfo,
 		severity:   LogSeverityInfo,
 		attributes: make(map[string]Attribute),
@@ -223,7 +223,7 @@ func (l *sentryLogger) Info() LogEntry {
 func (l *sentryLogger) Warn() LogEntry {
 	return &logEntry{
 		logger:     l,
-		ctx:        context.Background(),
+		ctx:        l.ctx,
 		level:      LogLevelWarn,
 		severity:   LogSeverityWarning,
 		attributes: make(map[string]Attribute),
@@ -233,7 +233,7 @@ func (l *sentryLogger) Warn() LogEntry {
 func (l *sentryLogger) Error() LogEntry {
 	return &logEntry{
 		logger:     l,
-		ctx:        context.Background(),
+		ctx:        l.ctx,
 		level:      LogLevelError,
 		severity:   LogSeverityError,
 		attributes: make(map[string]Attribute),
@@ -243,7 +243,7 @@ func (l *sentryLogger) Error() LogEntry {
 func (l *sentryLogger) Fatal() LogEntry {
 	return &logEntry{
 		logger:     l,
-		ctx:        context.Background(),
+		ctx:        l.ctx,
 		level:      LogLevelFatal,
 		severity:   LogSeverityFatal,
 		attributes: make(map[string]Attribute),
@@ -253,7 +253,7 @@ func (l *sentryLogger) Fatal() LogEntry {
 func (l *sentryLogger) Panic() LogEntry {
 	return &logEntry{
 		logger:      l,
-		ctx:         context.Background(),
+		ctx:         l.ctx,
 		level:       LogLevelFatal,
 		severity:    LogSeverityFatal,
 		attributes:  make(map[string]Attribute),

--- a/log.go
+++ b/log.go
@@ -3,6 +3,7 @@ package sentry
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -266,8 +267,14 @@ func (l *sentryLogger) GetCtx() context.Context {
 }
 
 func (e *logEntry) WithCtx(ctx context.Context) LogEntry {
-	e.ctx = ctx
-	return e
+	return &logEntry{
+		logger:      e.logger,
+		ctx:         ctx,
+		level:       e.level,
+		severity:    e.severity,
+		attributes:  maps.Clone(e.attributes),
+		shouldPanic: e.shouldPanic,
+	}
 }
 
 func (e *logEntry) String(key, value string) LogEntry {

--- a/log.go
+++ b/log.go
@@ -104,7 +104,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		}
 		for i, p := range args {
 			attrs[fmt.Sprintf("sentry.message.parameters.%d", i)] = Attribute{
-				Value: fmt.Sprint(p), Type: AttributeString,
+				Value: fmt.Sprintf("%+v", p), Type: AttributeString,
 			}
 		}
 	}

--- a/log.go
+++ b/log.go
@@ -174,7 +174,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 	}
 }
 
-// SetAttributes permanently attaches attributes to the logger instance
+// SetAttributes permanently attaches attributes to the logger instance.
 func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {
 	for _, v := range attrs {
 		t, ok := mapTypesToStr[v.Value.Type()]
@@ -261,7 +261,7 @@ func (l *sentryLogger) Panic() LogEntry {
 	}
 }
 
-// WithCtx sets the context for this log entry
+// WithCtx sets the context for this log entry.
 func (e *logEntry) WithCtx(ctx context.Context) LogEntry {
 	e.ctx = ctx
 	return e
@@ -292,7 +292,7 @@ func (e *logEntry) Bool(key string, value bool) LogEntry {
 	return e
 }
 
-// Attributes method for adding multiple attributes at once
+// Attributes method for adding multiple attributes at once.
 func (e *logEntry) Attributes(attrs ...attribute.Builder) LogEntry {
 	for _, v := range attrs {
 		t, ok := mapTypesToStr[v.Value.Type()]
@@ -308,20 +308,19 @@ func (e *logEntry) Attributes(attrs ...attribute.Builder) LogEntry {
 	return e
 }
 
-// Emit sends the log entry with the specified message
+// Emit sends the log entry with the specified message.
 func (e *logEntry) Emit(args ...interface{}) {
 	e.logger.log(e.ctx, e.level, e.severity, fmt.Sprint(args...), e.attributes)
 
 	if e.level == LogLevelFatal {
 		if e.shouldPanic {
 			panic(fmt.Sprint(args...))
-		} else {
-			os.Exit(1)
 		}
+		os.Exit(1)
 	}
 }
 
-// Emitf sends the log entry with a formatted message
+// Emitf sends the log entry with a formatted message.
 func (e *logEntry) Emitf(format string, args ...interface{}) {
 	e.logger.log(e.ctx, e.level, e.severity, format, e.attributes, args...)
 
@@ -329,8 +328,7 @@ func (e *logEntry) Emitf(format string, args ...interface{}) {
 		if e.shouldPanic {
 			formattedMessage := fmt.Sprintf(format, args...)
 			panic(formattedMessage)
-		} else {
-			os.Exit(1)
 		}
+		os.Exit(1)
 	}
 }

--- a/log.go
+++ b/log.go
@@ -43,6 +43,15 @@ type sentryLogger struct {
 	attributes map[string]Attribute
 }
 
+type logEntry struct {
+	logger      *sentryLogger
+	ctx         context.Context
+	level       LogLevel
+	severity    int
+	attributes  map[string]Attribute
+	shouldPanic bool
+}
+
 // NewLogger returns a Logger that emits logs to Sentry. If logging is turned off, all logs get discarded.
 func NewLogger(ctx context.Context) Logger {
 	var hub *Hub
@@ -63,11 +72,11 @@ func NewLogger(ctx context.Context) Logger {
 func (l *sentryLogger) Write(p []byte) (int, error) {
 	// Avoid sending double newlines to Sentry
 	msg := strings.TrimRight(string(p), "\n")
-	l.log(context.Background(), LogLevelInfo, LogSeverityInfo, msg)
+	l.Info().WithCtx(context.Background()).Emit(msg)
 	return len(p), nil
 }
 
-func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, message string, args ...interface{}) {
+func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, message string, entryAttrs map[string]Attribute, args ...interface{}) {
 	if message == "" {
 		return
 	}
@@ -99,13 +108,11 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		}
 	}
 
-	// If `log` was called with SetAttributes, pass the attributes to attrs
-	if len(l.attributes) > 0 {
-		for k, v := range l.attributes {
-			attrs[k] = v
-		}
-		// flush attributes from logger after send
-		clear(l.attributes)
+	for k, v := range l.attributes {
+		attrs[k] = v
+	}
+	for k, v := range entryAttrs {
+		attrs[k] = v
 	}
 
 	// Set default attributes
@@ -167,6 +174,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 	}
 }
 
+// SetAttributes permanently attaches attributes to the logger instance
 func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {
 	for _, v := range attrs {
 		t, ok := mapTypesToStr[v.Value.Type()]
@@ -182,49 +190,147 @@ func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {
 	}
 }
 
-func (l *sentryLogger) Trace(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelTrace, LogSeverityTrace, fmt.Sprint(v...))
+func (l *sentryLogger) Trace() LogEntry {
+	return &logEntry{
+		logger:     l,
+		ctx:        context.Background(),
+		level:      LogLevelTrace,
+		severity:   LogSeverityTrace,
+		attributes: make(map[string]Attribute),
+	}
 }
-func (l *sentryLogger) Debug(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelDebug, LogSeverityDebug, fmt.Sprint(v...))
+
+func (l *sentryLogger) Debug() LogEntry {
+	return &logEntry{
+		logger:     l,
+		ctx:        context.Background(),
+		level:      LogLevelDebug,
+		severity:   LogSeverityDebug,
+		attributes: make(map[string]Attribute),
+	}
 }
-func (l *sentryLogger) Info(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelInfo, LogSeverityInfo, fmt.Sprint(v...))
+
+func (l *sentryLogger) Info() LogEntry {
+	return &logEntry{
+		logger:     l,
+		ctx:        context.Background(),
+		level:      LogLevelInfo,
+		severity:   LogSeverityInfo,
+		attributes: make(map[string]Attribute),
+	}
 }
-func (l *sentryLogger) Warn(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelWarn, LogSeverityWarning, fmt.Sprint(v...))
+
+func (l *sentryLogger) Warn() LogEntry {
+	return &logEntry{
+		logger:     l,
+		ctx:        context.Background(),
+		level:      LogLevelWarn,
+		severity:   LogSeverityWarning,
+		attributes: make(map[string]Attribute),
+	}
 }
-func (l *sentryLogger) Error(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelError, LogSeverityError, fmt.Sprint(v...))
+
+func (l *sentryLogger) Error() LogEntry {
+	return &logEntry{
+		logger:     l,
+		ctx:        context.Background(),
+		level:      LogLevelError,
+		severity:   LogSeverityError,
+		attributes: make(map[string]Attribute),
+	}
 }
-func (l *sentryLogger) Fatal(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelFatal, LogSeverityFatal, fmt.Sprint(v...))
-	os.Exit(1)
+
+func (l *sentryLogger) Fatal() LogEntry {
+	return &logEntry{
+		logger:     l,
+		ctx:        context.Background(),
+		level:      LogLevelFatal,
+		severity:   LogSeverityFatal,
+		attributes: make(map[string]Attribute),
+	}
 }
-func (l *sentryLogger) Panic(ctx context.Context, v ...interface{}) {
-	l.log(ctx, LogLevelFatal, LogSeverityFatal, fmt.Sprint(v...))
-	panic(fmt.Sprint(v...))
+
+func (l *sentryLogger) Panic() LogEntry {
+	return &logEntry{
+		logger:      l,
+		ctx:         context.Background(),
+		level:       LogLevelFatal,
+		severity:    LogSeverityFatal,
+		attributes:  make(map[string]Attribute),
+		shouldPanic: true, // this should panic instead of exit
+	}
 }
-func (l *sentryLogger) Tracef(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelTrace, LogSeverityTrace, format, v...)
+
+// WithCtx sets the context for this log entry
+func (e *logEntry) WithCtx(ctx context.Context) LogEntry {
+	e.ctx = ctx
+	return e
 }
-func (l *sentryLogger) Debugf(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelDebug, LogSeverityDebug, format, v...)
+
+func (e *logEntry) String(key, value string) LogEntry {
+	e.attributes[key] = Attribute{Value: value, Type: "string"}
+	return e
 }
-func (l *sentryLogger) Infof(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelInfo, LogSeverityInfo, format, v...)
+
+func (e *logEntry) Int(key string, value int) LogEntry {
+	e.attributes[key] = Attribute{Value: int64(value), Type: "integer"}
+	return e
 }
-func (l *sentryLogger) Warnf(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelWarn, LogSeverityWarning, format, v...)
+
+func (e *logEntry) Int64(key string, value int64) LogEntry {
+	e.attributes[key] = Attribute{Value: value, Type: "integer"}
+	return e
 }
-func (l *sentryLogger) Errorf(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelError, LogSeverityError, format, v...)
+
+func (e *logEntry) Float64(key string, value float64) LogEntry {
+	e.attributes[key] = Attribute{Value: value, Type: "double"}
+	return e
 }
-func (l *sentryLogger) Fatalf(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelFatal, LogSeverityFatal, format, v...)
-	os.Exit(1)
+
+func (e *logEntry) Bool(key string, value bool) LogEntry {
+	e.attributes[key] = Attribute{Value: value, Type: "boolean"}
+	return e
 }
-func (l *sentryLogger) Panicf(ctx context.Context, format string, v ...interface{}) {
-	l.log(ctx, LogLevelFatal, LogSeverityFatal, format, v...)
-	panic(fmt.Sprint(v...))
+
+// Attributes method for adding multiple attributes at once
+func (e *logEntry) Attributes(attrs ...attribute.Builder) LogEntry {
+	for _, v := range attrs {
+		t, ok := mapTypesToStr[v.Value.Type()]
+		if !ok || t == "" {
+			DebugLogger.Printf("invalid attribute type set: %v", t)
+			continue
+		}
+		e.attributes[v.Key] = Attribute{
+			Value: v.Value.AsInterface(),
+			Type:  t,
+		}
+	}
+	return e
+}
+
+// Emit sends the log entry with the specified message
+func (e *logEntry) Emit(args ...interface{}) {
+	e.logger.log(e.ctx, e.level, e.severity, fmt.Sprint(args...), e.attributes)
+
+	if e.level == LogLevelFatal {
+		if e.shouldPanic {
+			panic(fmt.Sprint(args...))
+		} else {
+			os.Exit(1)
+		}
+	}
+}
+
+// Emitf sends the log entry with a formatted message
+func (e *logEntry) Emitf(format string, args ...interface{}) {
+	e.logger.log(e.ctx, e.level, e.severity, format, e.attributes, args...)
+
+	if e.level == LogLevelFatal {
+		if e.shouldPanic {
+			formattedMessage := fmt.Sprintf(format, args...)
+			panic(formattedMessage)
+		} else {
+			os.Exit(1)
+		}
+	}
 }

--- a/log.go
+++ b/log.go
@@ -144,7 +144,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 			}
 		}
 	}
-	if spanID.String() != "0000000000000000" {
+	if span != nil {
 		attrs["sentry.trace.parent_span_id"] = Attribute{Value: spanID.String(), Type: AttributeString}
 	}
 	if sdkIdentifier := l.client.sdkIdentifier; sdkIdentifier != "" {

--- a/log_fallback.go
+++ b/log_fallback.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/getsentry/sentry-go/attribute"
 )
@@ -11,55 +10,79 @@ import (
 // Fallback, no-op logger if logging is disabled.
 type noopLogger struct{}
 
-func (*noopLogger) Trace(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelTrace)
+// noopLogEntry implements LogEntry for the no-op logger
+type noopLogEntry struct {
+	level LogLevel
 }
-func (*noopLogger) Debug(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelDebug)
+
+func (n *noopLogEntry) WithCtx(_ context.Context) LogEntry {
+	return n
 }
-func (*noopLogger) Info(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+
+func (n *noopLogEntry) String(_, _ string) LogEntry {
+	return n
 }
-func (*noopLogger) Warn(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelWarn)
+
+func (n *noopLogEntry) Int(_ string, _ int) LogEntry {
+	return n
 }
-func (*noopLogger) Error(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelError)
+
+func (n *noopLogEntry) Int64(_ string, _ int64) LogEntry {
+	return n
 }
-func (*noopLogger) Fatal(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
-	os.Exit(1)
+
+func (n *noopLogEntry) Float64(_ string, _ float64) LogEntry {
+	return n
 }
-func (*noopLogger) Panic(_ context.Context, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
-	panic(fmt.Sprintf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal))
+
+func (n *noopLogEntry) Bool(_ string, _ bool) LogEntry {
+	return n
 }
-func (*noopLogger) Tracef(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelTrace)
+
+func (n *noopLogEntry) Attributes(_ ...attribute.Builder) LogEntry {
+	return n
 }
-func (*noopLogger) Debugf(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelDebug)
+
+func (n *noopLogEntry) Emit(_ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
 }
-func (*noopLogger) Infof(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+
+func (n *noopLogEntry) Emitf(_ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
 }
-func (*noopLogger) Warnf(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelWarn)
+
+func (*noopLogger) Trace() LogEntry {
+	return &noopLogEntry{level: LogLevelTrace}
 }
-func (*noopLogger) Errorf(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelError)
+
+func (*noopLogger) Debug() LogEntry {
+	return &noopLogEntry{level: LogLevelDebug}
 }
-func (*noopLogger) Fatalf(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
-	os.Exit(1)
+
+func (*noopLogger) Info() LogEntry {
+	return &noopLogEntry{level: LogLevelInfo}
 }
-func (*noopLogger) Panicf(_ context.Context, _ string, _ ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
-	panic(fmt.Sprintf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal))
+
+func (*noopLogger) Warn() LogEntry {
+	return &noopLogEntry{level: LogLevelWarn}
 }
+
+func (*noopLogger) Error() LogEntry {
+	return &noopLogEntry{level: LogLevelError}
+}
+
+func (*noopLogger) Fatal() LogEntry {
+	return &noopLogEntry{level: LogLevelFatal}
+}
+
+func (*noopLogger) Panic() LogEntry {
+	return &noopLogEntry{level: LogLevelFatal}
+}
+
 func (*noopLogger) SetAttributes(...attribute.Builder) {
 	DebugLogger.Printf("No attributes attached. Turn on logging via EnableLogs")
 }
+
 func (*noopLogger) Write(_ []byte) (n int, err error) {
-	return 0, fmt.Errorf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+	return 0, fmt.Errorf("log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
 }

--- a/log_fallback.go
+++ b/log_fallback.go
@@ -10,7 +10,7 @@ import (
 // Fallback, no-op logger if logging is disabled.
 type noopLogger struct{}
 
-// noopLogEntry implements LogEntry for the no-op logger
+// noopLogEntry implements LogEntry for the no-op logger.
 type noopLogEntry struct {
 	level LogLevel
 }

--- a/log_fallback.go
+++ b/log_fallback.go
@@ -51,6 +51,8 @@ func (n *noopLogEntry) Emitf(_ string, _ ...interface{}) {
 	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
 }
 
+func (n *noopLogger) GetCtx() context.Context { return context.Background() }
+
 func (*noopLogger) Trace() LogEntry {
 	return &noopLogEntry{level: LogLevelTrace}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"strings"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/getsentry/sentry-go/attribute"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/log_test.go
+++ b/log_test.go
@@ -450,7 +450,6 @@ func TestSentryLogger_LogEntryAttributes(t *testing.T) {
 		Int64("key.int64", 17).
 		Float64("key.float", 42.2).
 		Bool("key.bool", true).
-		Attributes(attribute.Int("key.attr.int", 43)).
 		Emit(msg)
 
 	Flush(20 * time.Millisecond)
@@ -461,7 +460,6 @@ func TestSentryLogger_LogEntryAttributes(t *testing.T) {
 	}
 	event := gotEvents[0]
 	assertEqual(t, event.Logs[0].Attributes["key.int"].Value, int64(42))
-	assertEqual(t, event.Logs[0].Attributes["key.attr.int"].Value, int64(43))
 	assertEqual(t, event.Logs[0].Attributes["key.int64"].Value, int64(17))
 	assertEqual(t, event.Logs[0].Attributes["key.float"].Value, 42.2)
 	assertEqual(t, event.Logs[0].Attributes["key.bool"].Value, true)

--- a/log_test.go
+++ b/log_test.go
@@ -3,6 +3,7 @@ package sentry
 import (
 	"bytes"
 	"context"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"strings"
 	"testing"
@@ -691,4 +692,22 @@ func Test_sentryLogger_UserAttributes(t *testing.T) {
 	} else if val.Value != "test@example.com" {
 		t.Errorf("unexpected user.email: got %v, want %v", val.Value, "test@example.com")
 	}
+}
+
+func TestLogEntryWithCtx_ShouldCopy(t *testing.T) {
+	ctx, _ := setupMockTransport()
+	l := NewLogger(ctx)
+
+	// using WithCtx should return a new log entry with the new ctx
+	newCtx := context.Background()
+	lentry := l.Info().String("key", "value").(*logEntry)
+	newlentry := lentry.WithCtx(newCtx).(*logEntry)
+	lentry.String("key2", "value")
+
+	assert.Equal(t, lentry.ctx, ctx)
+	assert.Equal(t, newlentry.ctx, newCtx)
+	assert.Contains(t, lentry.attributes, "key")
+	assert.Contains(t, lentry.attributes, "key2")
+	assert.Contains(t, newlentry.attributes, "key")
+	assert.NotContains(t, newlentry.attributes, "key2")
 }

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -43,6 +43,8 @@ const (
 	// These fields are simply omitted, as they are duplicated by the Sentry SDK.
 	FieldGoVersion = "go_version"
 	FieldMaxProcs  = "go_maxprocs"
+
+	LogrusOrigin = "auto.logger.logrus"
 )
 
 var levelMap = map[logrus.Level]sentry.Level{
@@ -289,12 +291,76 @@ func (h *logHook) key(key string) string {
 	return key
 }
 
+func logrusFieldToLogEntry(logEntry sentry.LogEntry, key string, value interface{}) sentry.LogEntry {
+	switch val := value.(type) {
+	case int8:
+		return logEntry.Int64(key, int64(val))
+	case int16:
+		return logEntry.Int64(key, int64(val))
+	case int32:
+		return logEntry.Int64(key, int64(val))
+	case int64:
+		return logEntry.Int64(key, val)
+	case int:
+		return logEntry.Int64(key, int64(val))
+	case uint, uint8, uint16, uint32, uint64:
+		uval := reflect.ValueOf(val).Convert(reflect.TypeOf(uint64(0))).Uint()
+		if uval <= math.MaxInt64 {
+			return logEntry.Int64(key, int64(uval))
+		} else {
+			// For values larger than int64 can handle, we use string
+			return logEntry.String(key, strconv.FormatUint(uval, 10))
+		}
+	case string:
+		return logEntry.String(key, val)
+	case float32:
+		return logEntry.Float64(key, float64(val))
+	case float64:
+		return logEntry.Float64(key, val)
+	case bool:
+		return logEntry.Bool(key, val)
+	case time.Time:
+		return logEntry.String(key, val.Format(time.RFC3339))
+	case time.Duration:
+		return logEntry.String(key, val.String())
+	default:
+		// Fallback to string conversion for unknown types
+		return logEntry.String(key, fmt.Sprint(value))
+	}
+}
+
 func (h *logHook) Fire(entry *logrus.Entry) error {
 	ctx := context.Background()
 	if entry.Context != nil {
 		ctx = entry.Context
 	}
 
+	// Create the base log entry for the appropriate level
+	var logEntry sentry.LogEntry
+	switch entry.Level {
+	case logrus.TraceLevel:
+		logEntry = h.logger.Trace().WithCtx(ctx)
+	case logrus.DebugLevel:
+		logEntry = h.logger.Debug().WithCtx(ctx)
+	case logrus.InfoLevel:
+		logEntry = h.logger.Info().WithCtx(ctx)
+	case logrus.WarnLevel:
+		logEntry = h.logger.Warn().WithCtx(ctx)
+	case logrus.ErrorLevel:
+		logEntry = h.logger.Error().WithCtx(ctx)
+	case logrus.FatalLevel:
+		logEntry = h.logger.Fatal().WithCtx(ctx)
+	case logrus.PanicLevel:
+		logEntry = h.logger.Panic().WithCtx(ctx)
+	default:
+		sentry.DebugLogger.Printf("Invalid logrus logging level: %v. Dropping log.", entry.Level)
+		if h.fallback != nil {
+			return h.fallback(entry)
+		}
+		return errors.New("invalid log level")
+	}
+
+	// Add all the fields as attributes to this specific log entry
 	for k, v := range entry.Data {
 		// Skip specific fields that might be handled separately
 		if k == h.key(FieldRequest) || k == h.key(FieldUser) ||
@@ -303,63 +369,11 @@ func (h *logHook) Fire(entry *logrus.Entry) error {
 			continue
 		}
 
-		switch val := v.(type) {
-		case int8:
-			h.logger.SetAttributes(attribute.Int(k, int(val)))
-		case int16:
-			h.logger.SetAttributes(attribute.Int(k, int(val)))
-		case int32:
-			h.logger.SetAttributes(attribute.Int(k, int(val)))
-		case int64:
-			h.logger.SetAttributes(attribute.Int(k, int(val)))
-		case int:
-			h.logger.SetAttributes(attribute.Int(k, val))
-		case uint, uint8, uint16, uint32, uint64:
-			uval := reflect.ValueOf(val).Convert(reflect.TypeOf(uint64(0))).Uint()
-			if uval <= math.MaxInt64 {
-				h.logger.SetAttributes(attribute.Int64(k, int64(uval)))
-			} else {
-				// For values larger than int64 can handle, we are using string.
-				h.logger.SetAttributes(attribute.String(k, strconv.FormatUint(uval, 10)))
-			}
-		case string:
-			h.logger.SetAttributes(attribute.String(k, val))
-		case float32:
-			h.logger.SetAttributes(attribute.Float64(k, float64(val)))
-		case float64:
-			h.logger.SetAttributes(attribute.Float64(k, val))
-		case bool:
-			h.logger.SetAttributes(attribute.Bool(k, val))
-		default:
-			// can't drop argument, fallback to string conversion
-			h.logger.SetAttributes(attribute.String(k, fmt.Sprint(v)))
-		}
+		logEntry = logrusFieldToLogEntry(logEntry, k, v)
 	}
 
-	h.logger.SetAttributes(attribute.String("sentry.origin", "auto.logger.logrus"))
-
-	switch entry.Level {
-	case logrus.TraceLevel:
-		h.logger.Trace().WithCtx(ctx).Emit(entry.Message)
-	case logrus.DebugLevel:
-		h.logger.Debug().WithCtx(ctx).Emit(entry.Message)
-	case logrus.InfoLevel:
-		h.logger.Info().WithCtx(ctx).Emit(entry.Message)
-	case logrus.WarnLevel:
-		h.logger.Warn().WithCtx(ctx).Emit(entry.Message)
-	case logrus.ErrorLevel:
-		h.logger.Error().WithCtx(ctx).Emit(entry.Message)
-	case logrus.FatalLevel:
-		h.logger.Fatal().WithCtx(ctx).Emit(entry.Message)
-	case logrus.PanicLevel:
-		h.logger.Panic().WithCtx(ctx).Emit(entry.Message)
-	default:
-		sentry.DebugLogger.Printf("Invalid logrus logging level: %v. Dropping log.", entry.Level)
-		if h.fallback != nil {
-			return h.fallback(entry)
-		}
-		return errors.New("invalid log level")
-	}
+	// Emit the log entry with the message
+	logEntry.Emit(entry.Message)
 	return nil
 }
 
@@ -395,8 +409,11 @@ func NewLogHook(levels []logrus.Level, opts sentry.ClientOptions) (Hook, error) 
 func NewLogHookFromClient(levels []logrus.Level, client *sentry.Client) Hook {
 	defaultHub := sentry.NewHub(client, sentry.NewScope())
 	ctx := sentry.SetHubOnContext(context.Background(), defaultHub)
+	logger := sentry.NewLogger(ctx)
+	logger.SetAttributes(attribute.String("sentry.origin", LogrusOrigin))
+
 	return &logHook{
-		logger: sentry.NewLogger(ctx),
+		logger: logger,
 		levels: levels,
 		hubProvider: func() *sentry.Hub {
 			// Default to using the same hub if no specific provider is set

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -340,19 +340,19 @@ func (h *logHook) Fire(entry *logrus.Entry) error {
 
 	switch entry.Level {
 	case logrus.TraceLevel:
-		h.logger.Trace(ctx, entry.Message)
+		h.logger.Trace().WithCtx(ctx).Emit(entry.Message)
 	case logrus.DebugLevel:
-		h.logger.Debug(ctx, entry.Message)
+		h.logger.Debug().WithCtx(ctx).Emit(entry.Message)
 	case logrus.InfoLevel:
-		h.logger.Info(ctx, entry.Message)
+		h.logger.Info().WithCtx(ctx).Emit(entry.Message)
 	case logrus.WarnLevel:
-		h.logger.Warn(ctx, entry.Message)
+		h.logger.Warn().WithCtx(ctx).Emit(entry.Message)
 	case logrus.ErrorLevel:
-		h.logger.Error(ctx, entry.Message)
+		h.logger.Error().WithCtx(ctx).Emit(entry.Message)
 	case logrus.FatalLevel:
-		h.logger.Fatal(ctx, entry.Message)
+		h.logger.Fatal().WithCtx(ctx).Emit(entry.Message)
 	case logrus.PanicLevel:
-		h.logger.Panic(ctx, entry.Message)
+		h.logger.Panic().WithCtx(ctx).Emit(entry.Message)
 	default:
 		sentry.DebugLogger.Printf("Invalid logrus logging level: %v. Dropping log.", entry.Level)
 		if h.fallback != nil {

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -657,8 +657,6 @@ func TestLogHookFire(t *testing.T) {
 				Context: context.Background(),
 			}
 
-			// Since we're using a real logger, which is hard to verify,
-			// we're just checking that Fire doesn't error
 			err := logHook.Fire(entry)
 			assert.NoError(t, err)
 		})

--- a/slog/sentryslog.go
+++ b/slog/sentryslog.go
@@ -303,7 +303,7 @@ func (h *logHandler) WithAttrs(attrs []slog.Attr) *logHandler {
 		option: h.option,
 		attrs:  appendAttrsToGroup(h.groups, h.attrs, attrs...),
 		groups: groupsCopy,
-		logger: sentry.NewLogger(h.logger.GetCtx()),
+		logger: h.logger,
 	}
 }
 
@@ -321,7 +321,7 @@ func (h *logHandler) WithGroup(name string) *logHandler {
 		option: h.option,
 		attrs:  h.attrs,
 		groups: newGroups,
-		logger: sentry.NewLogger(h.logger.GetCtx()),
+		logger: h.logger,
 	}
 }
 

--- a/slog/sentryslog.go
+++ b/slog/sentryslog.go
@@ -44,7 +44,9 @@ var (
 	}
 )
 
+// LevelFatal is a custom [slog.Level] that maps to [sentry.LevelFatal]
 const LevelFatal = slog.Level(12)
+const SlogOrigin = "auto.logger.slog"
 
 type Option struct {
 	// Deprecated: Use EventLevel instead. Level is kept for backwards compatibility and defaults to EventLevel.
@@ -104,6 +106,8 @@ func (o Option) NewSentryHandler(ctx context.Context) slog.Handler {
 	}
 
 	logger := sentry.NewLogger(ctx)
+	logger.SetAttributes(attribute.String("sentry.origin", SlogOrigin))
+
 	eventHandler := &eventHandler{
 		option: o,
 		attrs:  []slog.Attr{},
@@ -242,32 +246,49 @@ func (h *logHandler) Handle(ctx context.Context, record slog.Record) error {
 	attrs = replaceAttrs(h.option.ReplaceAttr, []string{}, attrs...)
 	attrs = removeEmptyAttrs(attrs)
 
-	var sentryAttributes []attribute.Builder
-	for _, attr := range attrs {
-		sentryAttributes = append(sentryAttributes, attrToSentryLog("", attr)...)
-	}
-	h.logger.SetAttributes(sentryAttributes...)
-	h.logger.SetAttributes(attribute.String("sentry.origin", "auto.logger.slog"))
-
 	// Use level ranges instead of exact matches to support custom levels
 	switch {
 	case record.Level < slog.LevelDebug:
 		// Levels below Debug (e.g., Trace)
-		h.logger.Trace().WithCtx(ctx).Emit(record.Message)
+		logEntry := h.logger.Trace().WithCtx(ctx)
+		for _, attr := range attrs {
+			logEntry = slogAttrToLogEntry(logEntry, "", attr)
+		}
+		logEntry.Emit(record.Message)
 	case record.Level < slog.LevelInfo:
 		// Debug level range: -4 to -1
-		h.logger.Debug().WithCtx(ctx).Emit(record.Message)
+		logEntry := h.logger.Debug().WithCtx(ctx)
+		for _, attr := range attrs {
+			logEntry = slogAttrToLogEntry(logEntry, "", attr)
+		}
+		logEntry.Emit(record.Message)
 	case record.Level < slog.LevelWarn:
 		// Info level range: 0 to 3
-		h.logger.Info().WithCtx(ctx).Emit(record.Message)
+		logEntry := h.logger.Info().WithCtx(ctx)
+		for _, attr := range attrs {
+			logEntry = slogAttrToLogEntry(logEntry, "", attr)
+		}
+		logEntry.Emit(record.Message)
 	case record.Level < slog.LevelError:
 		// Warn level range: 4 to 7
-		h.logger.Warn().WithCtx(ctx).Emit(record.Message)
+		logEntry := h.logger.Warn().WithCtx(ctx)
+		for _, attr := range attrs {
+			logEntry = slogAttrToLogEntry(logEntry, "", attr)
+		}
+		logEntry.Emit(record.Message)
 	case record.Level < LevelFatal: // custom Fatal level, keep +4 increments
-		h.logger.Error().WithCtx(ctx).Emit(record.Message)
+		logEntry := h.logger.Error().WithCtx(ctx)
+		for _, attr := range attrs {
+			logEntry = slogAttrToLogEntry(logEntry, "", attr)
+		}
+		logEntry.Emit(record.Message)
 	default:
 		// Fatal level range: 12 and above
-		h.logger.Fatal().WithCtx(ctx).Emit(record.Message)
+		logEntry := h.logger.Fatal().WithCtx(ctx)
+		for _, attr := range attrs {
+			logEntry = slogAttrToLogEntry(logEntry, "", attr)
+		}
+		logEntry.Emit(record.Message)
 	}
 
 	return nil

--- a/slog/sentryslog.go
+++ b/slog/sentryslog.go
@@ -282,7 +282,7 @@ func (h *logHandler) WithAttrs(attrs []slog.Attr) *logHandler {
 		option: h.option,
 		attrs:  appendAttrsToGroup(h.groups, h.attrs, attrs...),
 		groups: groupsCopy,
-		logger: sentry.NewLogger(context.Background()),
+		logger: sentry.NewLogger(h.logger.GetCtx()),
 	}
 }
 
@@ -300,7 +300,7 @@ func (h *logHandler) WithGroup(name string) *logHandler {
 		option: h.option,
 		attrs:  h.attrs,
 		groups: newGroups,
-		logger: sentry.NewLogger(context.Background()),
+		logger: sentry.NewLogger(h.logger.GetCtx()),
 	}
 }
 


### PR DESCRIPTION
Closes #1042. See issue for more details.

## Description
Modifying existing API to make usage clearer. Introducing chaining of attributes:
- Multiple levels `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Panic`, `Fatal` that return a `LogEntry`
- Attribute API on each `LogEntry`, to set `String`, `Int`, ...
- WithCtx func to inject context to entry
- Emit & Emitf functions to create a message and send the log

 Example:
```go
loggerWithVersion := sentry.NewLogger(ctx)

// Setting  attributes (these persist across log calls)
loggerWithVersion.SetAttributes(
    attribute.String("permanent.version", "1.0.0"),
)

// Add attributes to log entry
loggerWithVersion.Info().WithCtx(ctx).
    String("key.string", "value").
    Int("key.int", 42).
    Bool("key.bool", true).
    // don't forget to call Emit to send the logs to Sentry
    Emitf("Message with parameters %d and %d", 1, 2)

logger := sentry.NewLogger(ctx)

// you can also use Attributes for setting many attributes in the log entry (these are temporary)
logger.Info().
    Attributes(
	attribute.String("key.temp.string", "value"),
	attribute.Int("key.temp.int", 42),
    ).Emit("doesn't contain permanent.version")
```
