### PR TITLE
Fix race conditions on log when accessing scope

### DIFF
--- a/log_race_test.go
+++ b/log_race_test.go
@@ -1,0 +1,376 @@
+package sentry
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go/attribute"
+	"github.com/getsentry/sentry-go/internal/testutils"
+)
+
+const (
+	loggingGoroutines = 50
+	loggingIterations = 100
+)
+
+type CtxKey int
+
+func TestLoggingRaceConditions(t *testing.T) {
+	testCases := []struct {
+		name    string
+		timeout time.Duration
+		testFn  func(*testing.T)
+	}{
+		{
+			name:    "ConcurrentLoggerSetAttributes",
+			timeout: 5 * time.Second,
+			testFn:  testConcurrentLoggerSetAttributes,
+		},
+		{
+			name:    "ConcurrentLogEmission",
+			timeout: 5 * time.Second,
+			testFn:  testConcurrentLogEmission,
+		},
+		{
+			name:    "ConcurrentLogEntryOperations",
+			timeout: 5 * time.Second,
+			testFn:  testConcurrentLogEntryOperations,
+		},
+		{
+			name:    "ConcurrentLoggerCreationAndUsage",
+			timeout: testutils.FlushTimeout(),
+			testFn:  testConcurrentLoggerCreationAndUsage,
+		},
+		{
+			name:    "ConcurrentLogWithSpanOperations",
+			timeout: 5 * time.Second,
+			testFn:  testConcurrentLogWithSpanOperations,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			timeout := time.After(tc.timeout)
+			done := make(chan bool)
+
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("Test %s panicked: %v", tc.name, r)
+					}
+					done <- true
+				}()
+				tc.testFn(t)
+			}()
+
+			select {
+			case <-timeout:
+				t.Fatalf("Test %s didn't finish in time (timeout: %v) - likely deadlock", tc.name, tc.timeout)
+			case <-done:
+				t.Logf("Test %s completed successfully", tc.name)
+			}
+		})
+	}
+}
+
+func testConcurrentLoggerSetAttributes(t *testing.T) {
+	client, _ := NewClient(ClientOptions{
+		Dsn:        testDsn,
+		EnableLogs: true,
+	})
+	hub := NewHub(client, NewScope())
+	ctx := SetHubOnContext(context.Background(), hub)
+
+	logger := NewLogger(ctx)
+	if _, ok := logger.(*noopLogger); ok {
+		t.Skip("Logging is disabled, skipping test")
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < loggingGoroutines/2; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < loggingIterations; j++ {
+				attrs := []attribute.Builder{
+					attribute.String(fmt.Sprintf("attr-string-%d", id), fmt.Sprintf("value-%d-%d", id, j)),
+					attribute.Int64(fmt.Sprintf("attr-int-%d", id), int64(id*j)),
+					attribute.Float64(fmt.Sprintf("attr-float-%d", id), float64(id)+float64(j)*0.1),
+					attribute.Bool(fmt.Sprintf("attr-bool-%d", id), j%2 == 0),
+				}
+				logger.SetAttributes(attrs...)
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	for i := 0; i < loggingGoroutines/2; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < loggingIterations; j++ {
+				logger.Info().
+					String("worker_id", fmt.Sprintf("%d", id)).
+					Int("iteration", j).
+					Emit("Concurrent log message from worker", id)
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func testConcurrentLogEmission(_ *testing.T) {
+	client, _ := NewClient(ClientOptions{
+		Dsn:        testDsn,
+		EnableLogs: true,
+	})
+	hub := NewHub(client, NewScope())
+	ctx := SetHubOnContext(context.Background(), hub)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < loggingGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			logger := NewLogger(ctx)
+			if _, ok := logger.(*noopLogger); ok {
+				return
+			}
+
+			for j := 0; j < loggingIterations/5; j++ {
+				var localWg sync.WaitGroup
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Trace().
+						String("operation", "trace").
+						Int("worker", id).
+						Emit("Trace message from worker %d", id)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Debug().
+						String("operation", "debug").
+						Int("worker", id).
+						Emit("Debug message from worker %d", id)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Info().
+						String("operation", "info").
+						Int("worker", id).
+						Emit("Info message from worker %d", id)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Warn().
+						String("operation", "warn").
+						Int("worker", id).
+						Emit("Warning message from worker %d", id)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Error().
+						String("operation", "error").
+						Int("worker", id).
+						Emit("Error message from worker %d", id)
+				}()
+
+				localWg.Wait()
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func testConcurrentLogEntryOperations(t *testing.T) {
+	t.Skip("A single instance of a log entry should not be used concurrently")
+
+	client, _ := NewClient(ClientOptions{
+		Dsn:        testDsn,
+		EnableLogs: true,
+	})
+	hub := NewHub(client, NewScope())
+	ctx := SetHubOnContext(context.Background(), hub)
+
+	logger := NewLogger(ctx)
+	if _, ok := logger.(*noopLogger); ok {
+		t.Skip("Logging is disabled, skipping test")
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < loggingGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < loggingIterations/10; j++ {
+				entry := logger.Info()
+
+				var localWg sync.WaitGroup
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					entry.String("worker_id", fmt.Sprintf("worker-%d", id))
+					entry.Int("iteration", j)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					entry.Float64("progress", float64(j)/float64(loggingIterations/10))
+					entry.Bool("is_test", true)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					newCtx := context.WithValue(ctx, CtxKey(2), fmt.Sprintf("test_value_%d", id))
+					_ = entry.WithCtx(newCtx)
+				}()
+
+				localWg.Wait()
+				entry.Emit("Concurrent entry operations test %d-%d", id, j)
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func testConcurrentLoggerCreationAndUsage(_ *testing.T) {
+	client, _ := NewClient(ClientOptions{
+		Dsn:        testDsn,
+		EnableLogs: true,
+	})
+	hub := NewHub(client, NewScope())
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < loggingGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < loggingIterations/20; j++ {
+				ctx := context.WithValue(context.Background(), CtxKey(1), id)
+				ctx = SetHubOnContext(ctx, hub)
+
+				logger := NewLogger(ctx)
+				if _, ok := logger.(*noopLogger); ok {
+					continue
+				}
+
+				var localWg sync.WaitGroup
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.SetAttributes(
+						attribute.String("creation_worker", fmt.Sprintf("%d", id)),
+						attribute.Int64("creation_iteration", int64(j)),
+					)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Info().
+						String("immediate_usage", "true").
+						Emit("Logger created and used immediately by worker %d", id)
+				}()
+
+				localWg.Wait()
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func testConcurrentLogWithSpanOperations(_ *testing.T) {
+	client, _ := NewClient(ClientOptions{
+		Dsn:              testDsn,
+		EnableLogs:       true,
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+	})
+	hub := NewHub(client, NewScope())
+	ctx := SetHubOnContext(context.Background(), hub)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < loggingGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < loggingIterations/20; j++ {
+				transaction := StartTransaction(ctx, fmt.Sprintf("log-transaction-%d", id))
+				span := transaction.StartChild(fmt.Sprintf("log-span-%d", id))
+
+				spanCtx := span.Context()
+				logger := NewLogger(spanCtx)
+				if _, ok := logger.(*noopLogger); ok {
+					span.Finish()
+					transaction.Finish()
+					continue
+				}
+
+				var localWg sync.WaitGroup
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					span.SetTag("worker_id", fmt.Sprintf("%d", id))
+					span.SetData("iteration", j)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.SetAttributes(
+						attribute.String("span_operation", span.Op),
+						attribute.String("trace_id", span.TraceID.String()),
+					)
+				}()
+
+				localWg.Add(1)
+				go func() {
+					defer localWg.Done()
+					logger.Info().
+						String("span_context", "active").
+						String("span_id", span.SpanID.String()).
+						Emit("Log within span from worker %d", id)
+				}()
+
+				localWg.Wait()
+				span.Finish()
+				transaction.Finish()
+				runtime.Gosched()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/log_test.go
+++ b/log_test.go
@@ -3,6 +3,7 @@ package sentry
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -661,48 +662,48 @@ func Test_sentryLogger_TracePropagationWithTransaction(t *testing.T) {
 }
 
 func TestSentryLogger_DebugLogging(t *testing.T) {
-	var buf bytes.Buffer
-
 	tests := []struct {
-		name          string
-		debugEnabled  bool
-		message       string
-		expectedDebug string
+		name       string
+		enableLogs bool
+		message    string
 	}{
 		{
-			name:          "Debug enabled",
-			debugEnabled:  true,
-			message:       "test message",
-			expectedDebug: "test message\n",
+			name:       "Debug enabled",
+			enableLogs: true,
+			message:    "test message",
 		},
 		{
-			name:          "Debug disabled",
-			debugEnabled:  false,
-			message:       "test message",
-			expectedDebug: "",
+			name:       "Debug disabled",
+			enableLogs: false,
+			message:    "test message",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf.Reset()
+			var buf bytes.Buffer
+
 			ctx := context.Background()
 			mockClient, _ := NewClient(ClientOptions{
 				Transport:  &MockTransport{},
-				EnableLogs: true,
-				Debug:      tt.debugEnabled,
+				EnableLogs: tt.enableLogs,
+				Debug:      true,
 			})
 			hub := CurrentHub()
 			hub.BindClient(mockClient)
+
+			// set the debug logger output after NewClient, so that it doesn't change.
+			DebugLogger.SetOutput(&buf)
+			defer DebugLogger.SetOutput(io.Discard)
 
 			logger := NewLogger(ctx)
 			logger.Info().WithCtx(ctx).Emit(tt.message)
 
 			got := buf.String()
-			if !tt.debugEnabled {
-				assertEqual(t, len(got), 0)
-			} else if strings.Contains(got, tt.expectedDebug) {
-				t.Errorf("Debug output = %q, want %q", got, tt.expectedDebug)
+			if tt.enableLogs {
+				assertEqual(t, strings.Contains(got, "test message"), true)
+			} else {
+				assertEqual(t, strings.Contains(got, "test message"), false)
 			}
 		})
 	}

--- a/log_test.go
+++ b/log_test.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"bytes"
 	"context"
-	"log"
 	"strings"
 	"testing"
 	"time"
@@ -663,12 +662,6 @@ func Test_sentryLogger_TracePropagationWithTransaction(t *testing.T) {
 
 func TestSentryLogger_DebugLogging(t *testing.T) {
 	var buf bytes.Buffer
-	debugLogger := log.New(&buf, "", 0)
-	originalLogger := DebugLogger
-	DebugLogger = debugLogger
-	defer func() {
-		DebugLogger = originalLogger
-	}()
 
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Closes both #1048  and #1049.

## Description

Adds tests for the logger to identify race conditions and fix everything uncovered.

Changes include: 
* Add locks when using `SetAttributes` to guard for panics.
* Lock scope when trying to access propagation context on `log`.
