### PR TITLE
Fix nil pointer dereference with malformed URLs when tracing enabled

### DIFF
--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -151,10 +151,11 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 
 	r.Method = string(ctx.Method())
 
+	r.URL = &url.URL{Path: "/"}
+
 	uri := ctx.URI()
-	url, err := url.Parse(fmt.Sprintf("%s://%s%s", uri.Scheme(), uri.Host(), uri.Path()))
-	if err == nil {
-		r.URL = url
+	if parsedURL, err := url.Parse(fmt.Sprintf("%s://%s%s", uri.Scheme(), uri.Host(), uri.Path())); err == nil {
+		r.URL = parsedURL
 		r.URL.RawQuery = string(uri.QueryString())
 	}
 

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -151,10 +151,11 @@ func convert(ctx *fiber.Ctx) *http.Request {
 
 	r.Method = utils.CopyString(ctx.Method())
 
+	r.URL = &url.URL{Path: "/"}
+
 	uri := ctx.Request().URI()
-	url, err := url.Parse(fmt.Sprintf("%s://%s%s", uri.Scheme(), uri.Host(), uri.Path()))
-	if err == nil {
-		r.URL = url
+	if parsedURL, err := url.Parse(fmt.Sprintf("%s://%s%s", uri.Scheme(), uri.Host(), uri.Path())); err == nil {
+		r.URL = parsedURL
 		r.URL.RawQuery = string(uri.QueryString())
 	}
 


### PR DESCRIPTION
- Ensure convert() always returns http.Request with valid URL field
- Prevents panic in sentry.NewRequest() when transaction.Finish() is called
- Affects both Fiber and FastHTTP integrations

Fixes #1054

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
