### PR TITLE
feat(tracing): add SetMeasurement support to spans and transactions

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -372,30 +372,31 @@ type Context = map[string]interface{}
 
 // Event is the fundamental data structure that is sent to Sentry.
 type Event struct {
-	Breadcrumbs []*Breadcrumb          `json:"breadcrumbs,omitempty"`
-	Contexts    map[string]Context     `json:"contexts,omitempty"`
-	Dist        string                 `json:"dist,omitempty"`
-	Environment string                 `json:"environment,omitempty"`
-	EventID     EventID                `json:"event_id,omitempty"`
-	Extra       map[string]interface{} `json:"extra,omitempty"`
-	Fingerprint []string               `json:"fingerprint,omitempty"`
-	Level       Level                  `json:"level,omitempty"`
-	Message     string                 `json:"message,omitempty"`
-	Platform    string                 `json:"platform,omitempty"`
-	Release     string                 `json:"release,omitempty"`
-	Sdk         SdkInfo                `json:"sdk,omitempty"`
-	ServerName  string                 `json:"server_name,omitempty"`
-	Threads     []Thread               `json:"threads,omitempty"`
-	Tags        map[string]string      `json:"tags,omitempty"`
-	Timestamp   time.Time              `json:"timestamp"`
-	Transaction string                 `json:"transaction,omitempty"`
-	User        User                   `json:"user,omitempty"`
-	Logger      string                 `json:"logger,omitempty"`
-	Modules     map[string]string      `json:"modules,omitempty"`
-	Request     *Request               `json:"request,omitempty"`
-	Exception   []Exception            `json:"exception,omitempty"`
-	DebugMeta   *DebugMeta             `json:"debug_meta,omitempty"`
-	Attachments []*Attachment          `json:"-"`
+	Breadcrumbs  []*Breadcrumb          `json:"breadcrumbs,omitempty"`
+	Contexts     map[string]Context     `json:"contexts,omitempty"`
+	Dist         string                 `json:"dist,omitempty"`
+	Environment  string                 `json:"environment,omitempty"`
+	EventID      EventID                `json:"event_id,omitempty"`
+	Extra        map[string]interface{} `json:"extra,omitempty"`
+	Fingerprint  []string               `json:"fingerprint,omitempty"`
+	Level        Level                  `json:"level,omitempty"`
+	Message      string                 `json:"message,omitempty"`
+	Platform     string                 `json:"platform,omitempty"`
+	Release      string                 `json:"release,omitempty"`
+	Sdk          SdkInfo                `json:"sdk,omitempty"`
+	ServerName   string                 `json:"server_name,omitempty"`
+	Threads      []Thread               `json:"threads,omitempty"`
+	Tags         map[string]string      `json:"tags,omitempty"`
+	Measurements map[string]Measurement `json:"measurements,omitempty"`
+	Timestamp    time.Time              `json:"timestamp"`
+	Transaction  string                 `json:"transaction,omitempty"`
+	User         User                   `json:"user,omitempty"`
+	Logger       string                 `json:"logger,omitempty"`
+	Modules      map[string]string      `json:"modules,omitempty"`
+	Request      *Request               `json:"request,omitempty"`
+	Exception    []Exception            `json:"exception,omitempty"`
+	DebugMeta    *DebugMeta             `json:"debug_meta,omitempty"`
+	Attachments  []*Attachment          `json:"-"`
 
 	// The fields below are only relevant for transactions.
 

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -360,6 +360,34 @@ func TestSetData(t *testing.T) {
 	}
 }
 
+func TestSetMeasurement(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing: true,
+	})
+	tx := StartTransaction(ctx, "TestTransaction")
+	tx.SetMeasurement("tokens_used", 1234.56, "token")
+	tx.Finish()
+
+	if tx.measurements["tokens_used"].Value != 1234.56 {
+		t.Fatalf("Expected tokens_used = 1234.56, got %v", tx.measurements["tokens_used"].Value)
+	}
+	if tx.measurements["tokens_used"].Unit != "token" {
+		t.Fatalf("Expected unit = token, got %s", tx.measurements["tokens_used"].Unit)
+	}
+
+	events := GetHubFromContext(ctx).Client().Transport.(*MockTransport).Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	meas := events[0].Measurements
+	if meas["tokens_used"].Value != 1234.56 {
+		t.Errorf("Expected measurement value to be 1234.56, got %f", meas["tokens_used"].Value)
+	}
+	if meas["tokens_used"].Unit != "token" {
+		t.Errorf("Expected measurement unit to be token, got %s", meas["tokens_used"].Unit)
+	}
+}
+
 func TestWithDescription(t *testing.T) {
 	ctx := NewTestContext(ClientOptions{
 		EnableTracing: true,


### PR DESCRIPTION
This PR adds support for custom **span measurements** in the Go SDK (`sentry-go`) by introducing a new method:

```go
SetMeasurement(name string, value float64, unit string)
```

This method allows instrumentation of custom metrics (e.g., `duration_ms`, `tokens_used`, etc.) and sends them under the `measurements` field in the transaction payload.

---

## Why

Currently, the Go SDK lacks support for custom `measurements` on spans/transactions — a feature already available in the JS and Python SDKs.

---

## How

- Adds `Span.SetMeasurement` method
- Adds a `measurements` map to the `Span` struct
- Exports this map as part of the final `Event` in `toEvent()`
- Includes unit and value
- Adds `Measurement` struct matching expected envelope format
- Includes a test case (`TestSetMeasurement`) to verify behavior

---

## Example

```go
tx := sentry.StartTransaction(ctx, "Predict")
tx.SetMeasurement("tokens_used", 1423.0, "token")
tx.SetMeasurement("duration_ms", 512.6, "millisecond")
tx.Finish()
```

Sends:

```json
"measurements": {
  "tokens_used": {
    "value": 1423.0,
    "unit": "token"
  },
  "duration_ms": {
    "value": 512.6,
    "unit": "millisecond"
  }
}
```

---

## Notes

- This change is fully backward-compatible.
- If no measurements are set, nothing is serialized.
