### PR TITLE
Fix missing FailureIssueThreshold and RecoveryThreshold in MonitorConfig JSON serialization

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -595,10 +595,12 @@ func (e *Event) checkInMarshalJSON() ([]byte, error) {
 
 	if e.MonitorConfig != nil {
 		checkIn.MonitorConfig = &MonitorConfig{
-			Schedule:      e.MonitorConfig.Schedule,
-			CheckInMargin: e.MonitorConfig.CheckInMargin,
-			MaxRuntime:    e.MonitorConfig.MaxRuntime,
-			Timezone:      e.MonitorConfig.Timezone,
+			Schedule:              e.MonitorConfig.Schedule,
+			CheckInMargin:         e.MonitorConfig.CheckInMargin,
+			MaxRuntime:            e.MonitorConfig.MaxRuntime,
+			Timezone:              e.MonitorConfig.Timezone,
+			FailureIssueThreshold: e.MonitorConfig.FailureIssueThreshold,
+			RecoveryThreshold:     e.MonitorConfig.RecoveryThreshold,
 		}
 	}
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -180,6 +180,28 @@ func TestCheckInEventMarshalJSON(t *testing.T) {
 				Timezone:      "America/Los_Angeles",
 			},
 		},
+		{
+			Release:     "1.0.0",
+			Environment: "dev",
+			Type:        checkInType,
+			CheckIn: &CheckIn{
+				ID:          "c2f0ce1334c74564bf6631f6161173f5",
+				MonitorSlug: "my-monitor",
+				Status:      "ok",
+				Duration:    time.Second * 10,
+			},
+			MonitorConfig: &MonitorConfig{
+				Schedule: &crontabSchedule{
+					Type:  "crontab",
+					Value: "* * * * *",
+				},
+				CheckInMargin:         2,
+				MaxRuntime:            1,
+				Timezone:              "UTC",
+				FailureIssueThreshold: 5,
+				RecoveryThreshold:     1,
+			},
+		},
 	}
 
 	var buf bytes.Buffer

--- a/testdata/json/checkin/003.json
+++ b/testdata/json/checkin/003.json
@@ -1,0 +1,19 @@
+{
+  "check_in_id": "c2f0ce1334c74564bf6631f6161173f5",
+  "monitor_slug": "my-monitor",
+  "status": "ok",
+  "duration": 10,
+  "release": "1.0.0",
+  "environment": "dev",
+  "monitor_config": {
+    "schedule": {
+      "type": "crontab",
+      "value": "* * * * *"
+    },
+    "checkin_margin": 2,
+    "max_runtime": 1,
+    "timezone": "UTC",
+    "failure_issue_threshold": 5,
+    "recovery_threshold": 1
+  }
+}


### PR DESCRIPTION
The checkInMarshalJSON function was missing FailureIssueThreshold and RecoveryThreshold fields when serializing MonitorConfig, causing these values to be omitted from the JSON payload sent to Sentry's API. This results in Sentry using default values instead of the configured values.

This adds the missing fields to the JSON serialization and includes a regression test to prevent future occurrences.

**Root Cause:**
- `checkInMarshalJSON` in `interfaces.go` was not including FailureIssueThreshold and RecoveryThreshold fields
- These fields were never sent to Sentry's API, regardless of SDK configuration
- Sentry defaults to FailureIssueThreshold=1 and RecoveryThreshold=1 when not provided

**Changes:**
- Fixed `checkInMarshalJSON` in `interfaces.go` to include missing fields in JSON payload
- Added regression test in `marshal_test.go` with corresponding golden file

**Impact:**
- Monitor configurations will now use the SDK-configured thresholds instead of defaults
- The Sentry UI will display the correct configured values

**Testing:**
- `go test -run TestCheckInEventMarshalJSON` - New test passes

Fixes #1059