### PR TITLE
Fix flaky tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -513,7 +513,7 @@ func (client *Client) Flush(timeout time.Duration) bool {
 	if client.batchLogger != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		client.batchLogger.Flush(ctx.Done())
+		return client.FlushWithContext(ctx)
 	}
 	return client.Transport.Flush(timeout)
 }

--- a/client.go
+++ b/client.go
@@ -511,17 +511,9 @@ func (client *Client) RecoverWithContext(
 // call to Init.
 func (client *Client) Flush(timeout time.Duration) bool {
 	if client.batchLogger != nil {
-		start := time.Now()
-		timeoutCh := make(chan struct{})
-		time.AfterFunc(timeout, func() {
-			close(timeoutCh)
-		})
-		client.batchLogger.Flush(timeoutCh)
-		// update the timeout with the time passed
-		timeout -= time.Since(start)
-		if timeout <= 0 {
-			return false
-		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		client.batchLogger.Flush(ctx.Done())
 	}
 	return client.Transport.Flush(timeout)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -871,7 +873,17 @@ func TestSDKIdentifier(t *testing.T) {
 }
 
 func TestClientSetsUpTransport(t *testing.T) {
-	client, _, _ := setupClientTest()
+	client, _ := NewClient(ClientOptions{
+		Dsn: testDsn,
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return nil, fmt.Errorf("mock transport - no real connections")
+				},
+			},
+		},
+		Transport: &MockTransport{},
+	})
 	require.IsType(t, &MockTransport{}, client.Transport)
 
 	client, _ = NewClient(ClientOptions{})

--- a/client_test.go
+++ b/client_test.go
@@ -871,8 +871,8 @@ func TestSDKIdentifier(t *testing.T) {
 }
 
 func TestClientSetsUpTransport(t *testing.T) {
-	client, _ := NewClient(ClientOptions{Dsn: testDsn})
-	require.IsType(t, &HTTPTransport{}, client.Transport)
+	client, _, _ := setupClientTest()
+	require.IsType(t, &MockTransport{}, client.Transport)
 
 	client, _ = NewClient(ClientOptions{})
 	require.IsType(t, &noopTransport{}, client.Transport)

--- a/log_race_test.go
+++ b/log_race_test.go
@@ -81,6 +81,7 @@ func testConcurrentLoggerSetAttributes(t *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
 		EnableLogs: true,
+		Transport:  &MockTransport{}, // Use mock transport to avoid real network calls
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)
@@ -130,6 +131,7 @@ func testConcurrentLogEmission(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
 		EnableLogs: true,
+		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)
@@ -208,6 +210,7 @@ func testConcurrentLogEntryOperations(t *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
 		EnableLogs: true,
+		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)
@@ -263,6 +266,7 @@ func testConcurrentLoggerCreationAndUsage(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
 		EnableLogs: true,
+		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 
@@ -315,6 +319,7 @@ func testConcurrentLogWithSpanOperations(_ *testing.T) {
 		EnableLogs:       true,
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		Transport:        &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)

--- a/log_race_test.go
+++ b/log_race_test.go
@@ -81,7 +81,7 @@ func testConcurrentLoggerSetAttributes(t *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
 		EnableLogs: true,
-		Transport:  &MockTransport{}, // Use mock transport to avoid real network calls
+		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)

--- a/transport.go
+++ b/transport.go
@@ -441,11 +441,9 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 // have the SDK send events over the network synchronously, configure it to use
 // the HTTPSyncTransport in the call to Init.
 func (t *HTTPTransport) Flush(timeout time.Duration) bool {
-	timeoutCh := make(chan struct{})
-	time.AfterFunc(timeout, func() {
-		close(timeoutCh)
-	})
-	return t.flushInternal(timeoutCh)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return t.FlushWithContext(ctx)
 }
 
 // FlushWithContext works like Flush, but it accepts a context.Context instead of a timeout.

--- a/transport_test.go
+++ b/transport_test.go
@@ -793,7 +793,7 @@ func TestHTTPTransportDoesntLeakGoroutines(t *testing.T) {
 		Dsn: "https://test@foobar/1",
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 					return nil, fmt.Errorf("mock transport - no real connections")
 				},
 			},
@@ -810,7 +810,7 @@ func TestHTTPTransportClose(t *testing.T) {
 		Dsn: "https://test@foobar/1",
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 					return nil, fmt.Errorf("mock transport - no real connections")
 				},
 			},

--- a/transport_test.go
+++ b/transport_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -789,19 +790,31 @@ func TestHTTPTransportDoesntLeakGoroutines(t *testing.T) {
 
 	transport := NewHTTPTransport()
 	transport.Configure(ClientOptions{
-		Dsn:        "https://test@foobar/1",
-		HTTPClient: http.DefaultClient,
+		Dsn: "https://test@foobar/1",
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return nil, fmt.Errorf("mock transport - no real connections")
+				},
+			},
+		},
 	})
 
-	transport.Flush(0)
+	transport.Flush(testutils.FlushTimeout())
 	transport.Close()
 }
 
 func TestHTTPTransportClose(t *testing.T) {
 	transport := NewHTTPTransport()
 	transport.Configure(ClientOptions{
-		Dsn:        "https://test@foobar/1",
-		HTTPClient: http.DefaultClient,
+		Dsn: "https://test@foobar/1",
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return nil, fmt.Errorf("mock transport - no real connections")
+				},
+			},
+		},
 	})
 
 	transport.Close()


### PR DESCRIPTION
### Description

This aims to fix flakiness of `TestHTTPTransportDoesntLeakGoroutines`. The test would report goroutines stuck in network I/O operations, where the `http.DefaultClient` would hang and then the `goleak.VerifyNone` would incorrectly spot them as leaked goroutines on the transport. The solution is adding a `mockTransport` to each test client we create on the tests. 

In addition also added a small fix that might also cause goroutine issues. When using the `time.After` func, a goroutine would be spawned. Using `ctx.Done()` eliminates the goroutine and also improves readability.