### PR TITLE
add missing rate limit categories

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -605,7 +605,7 @@ func (e *Event) checkInMarshalJSON() ([]byte, error) {
 	return json.Marshal(checkIn)
 }
 
-func (e *Event) ToCategory() ratelimit.Category {
+func (e *Event) toCategory() ratelimit.Category {
 	switch e.Type {
 	case "":
 		return ratelimit.CategoryError

--- a/interfaces.go
+++ b/interfaces.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go/attribute"
+	"github.com/getsentry/sentry-go/internal/ratelimit"
 )
 
 const eventType = "event"
@@ -602,6 +603,21 @@ func (e *Event) checkInMarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(checkIn)
+}
+
+func (e *Event) ToCategory() ratelimit.Category {
+	switch e.Type {
+	case "":
+		return ratelimit.CategoryError
+	case transactionType:
+		return ratelimit.CategoryTransaction
+	case logEvent.Type:
+		return ratelimit.CategoryLog
+	case checkInType:
+		return ratelimit.CategoryUptime
+	default:
+		return ratelimit.CategoryDefault
+	}
 }
 
 // NewEvent creates a new Event.

--- a/interfaces.go
+++ b/interfaces.go
@@ -614,9 +614,9 @@ func (e *Event) ToCategory() ratelimit.Category {
 	case logEvent.Type:
 		return ratelimit.CategoryLog
 	case checkInType:
-		return ratelimit.CategoryUptime
+		return ratelimit.CategoryMonitor
 	default:
-		return ratelimit.CategoryDefault
+		return ratelimit.CategoryUnknown
 	}
 }
 

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getsentry/sentry-go/internal/ratelimit"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -516,6 +517,29 @@ func TestStructSnapshots(t *testing.T) {
 
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("struct %s mismatch (-want +got):\n%s", test.testName, diff)
+			}
+		})
+	}
+}
+
+func TestEvent_ToCategory(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+		want      ratelimit.Category
+	}{
+		{"error", "", ratelimit.CategoryError},
+		{"transaction", transactionType, ratelimit.CategoryTransaction},
+		{"log", logEvent.Type, ratelimit.CategoryLog},
+		{"checkin", checkInType, ratelimit.CategoryMonitor},
+		{"unknown", "foobar", ratelimit.CategoryUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Event{Type: tc.eventType}
+			got := e.ToCategory()
+			if got != tc.want {
+				t.Errorf("Type %q: got %v, want %v", tc.eventType, got, tc.want)
 			}
 		})
 	}

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -537,7 +537,7 @@ func TestEvent_ToCategory(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := &Event{Type: tc.eventType}
-			got := e.ToCategory()
+			got := e.toCategory()
 			if got != tc.want {
 				t.Errorf("Type %q: got %v, want %v", tc.eventType, got, tc.want)
 			}

--- a/internal/ratelimit/category.go
+++ b/internal/ratelimit/category.go
@@ -14,32 +14,49 @@ import (
 // and, therefore, rate limited.
 type Category string
 
-// Known rate limit categories. As a special case, the CategoryAll applies to
-// all known payload types.
+// Known rate limit categories that are specified in rate limit headers.
 const (
-	CategoryAll         Category = ""
+	CategoryAll         Category = "" // Special category for empty categories (applies to all)
+	CategoryDefault     Category = "default"
 	CategoryError       Category = "error"
 	CategoryTransaction Category = "transaction"
+	CategoryLog         Category = "log_item"
+	CategoryUptime      Category = "uptime"
 )
 
 // knownCategories is the set of currently known categories. Other categories
 // are ignored for the purpose of rate-limiting.
 var knownCategories = map[Category]struct{}{
 	CategoryAll:         {},
+	CategoryDefault:     {},
 	CategoryError:       {},
 	CategoryTransaction: {},
+	CategoryLog:         {},
+	CategoryUptime:      {},
 }
 
 // String returns the category formatted for debugging.
 func (c Category) String() string {
-	if c == "" {
+	switch c {
+	case CategoryAll:
 		return "CategoryAll"
+	case CategoryDefault:
+		return "CategoryDefault"
+	case CategoryError:
+		return "CategoryError"
+	case CategoryTransaction:
+		return "CategoryTransaction"
+	case CategoryLog:
+		return "CategoryLog"
+	case CategoryUptime:
+		return "CategoryUptime"
+	default:
+		// For unknown categories, use the original formatting logic
+		caser := cases.Title(language.English)
+		rv := "Category"
+		for _, w := range strings.Fields(string(c)) {
+			rv += caser.String(w)
+		}
+		return rv
 	}
-
-	caser := cases.Title(language.English)
-	rv := "Category"
-	for _, w := range strings.Fields(string(c)) {
-		rv += caser.String(w)
-	}
-	return rv
 }

--- a/internal/ratelimit/category.go
+++ b/internal/ratelimit/category.go
@@ -16,23 +16,22 @@ type Category string
 
 // Known rate limit categories that are specified in rate limit headers.
 const (
-	CategoryAll         Category = "" // Special category for empty categories (applies to all)
-	CategoryDefault     Category = "default"
+	CategoryUnknown     Category = "unknown" // Unknown category should not get rate limited
+	CategoryAll         Category = ""        // Special category for empty categories (applies to all)
 	CategoryError       Category = "error"
 	CategoryTransaction Category = "transaction"
 	CategoryLog         Category = "log_item"
-	CategoryUptime      Category = "uptime"
+	CategoryMonitor     Category = "monitor"
 )
 
 // knownCategories is the set of currently known categories. Other categories
 // are ignored for the purpose of rate-limiting.
 var knownCategories = map[Category]struct{}{
 	CategoryAll:         {},
-	CategoryDefault:     {},
 	CategoryError:       {},
 	CategoryTransaction: {},
 	CategoryLog:         {},
-	CategoryUptime:      {},
+	CategoryMonitor:     {},
 }
 
 // String returns the category formatted for debugging.
@@ -40,16 +39,14 @@ func (c Category) String() string {
 	switch c {
 	case CategoryAll:
 		return "CategoryAll"
-	case CategoryDefault:
-		return "CategoryDefault"
 	case CategoryError:
 		return "CategoryError"
 	case CategoryTransaction:
 		return "CategoryTransaction"
 	case CategoryLog:
 		return "CategoryLog"
-	case CategoryUptime:
-		return "CategoryUptime"
+	case CategoryMonitor:
+		return "CategoryMonitor"
 	default:
 		// For unknown categories, use the original formatting logic
 		caser := cases.Title(language.English)

--- a/internal/ratelimit/category_test.go
+++ b/internal/ratelimit/category_test.go
@@ -9,6 +9,7 @@ func TestCategory_String(t *testing.T) {
 		category Category
 		expected string
 	}{
+		{CategoryAll, "CategoryAll"},
 		{CategoryError, "CategoryError"},
 		{CategoryTransaction, "CategoryTransaction"},
 		{CategoryMonitor, "CategoryMonitor"},

--- a/internal/ratelimit/category_test.go
+++ b/internal/ratelimit/category_test.go
@@ -1,23 +1,62 @@
 package ratelimit
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestCategoryString(t *testing.T) {
+func TestCategory_String(t *testing.T) {
 	tests := []struct {
-		Category Category
-		want     string
+		category Category
+		expected string
 	}{
-		{CategoryAll, "CategoryAll"},
+		{CategoryDefault, "CategoryDefault"},
 		{CategoryError, "CategoryError"},
 		{CategoryTransaction, "CategoryTransaction"},
-		{Category("unknown"), "CategoryUnknown"},
-		{Category("two words"), "CategoryTwoWords"},
+		{CategoryUptime, "CategoryUptime"},
+		{CategoryLog, "CategoryLog"},
+		{Category("custom type"), "CategoryCustomType"},
+		{Category("multi word type"), "CategoryMultiWordType"},
 	}
+
 	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			got := tt.Category.String()
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
+		t.Run(string(tt.category), func(t *testing.T) {
+			result := tt.category.String()
+			if result != tt.expected {
+				t.Errorf("Category(%q).String() = %q, want %q", tt.category, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKnownCategories(t *testing.T) {
+	expectedCategories := []Category{
+		CategoryAll,
+		CategoryDefault,
+		CategoryError,
+		CategoryTransaction,
+		CategoryUptime,
+		CategoryLog,
+	}
+
+	for _, category := range expectedCategories {
+		t.Run(string(category), func(t *testing.T) {
+			if _, exists := knownCategories[category]; !exists {
+				t.Errorf("Category %q should be in knownCategories map", category)
+			}
+		})
+	}
+
+	// Test that unknown categories are not in the map
+	unknownCategories := []Category{
+		Category("unknown"),
+		Category("custom"),
+		Category("random"),
+	}
+
+	for _, category := range unknownCategories {
+		t.Run("unknown_"+string(category), func(t *testing.T) {
+			if _, exists := knownCategories[category]; exists {
+				t.Errorf("Unknown category %q should not be in knownCategories map", category)
 			}
 		})
 	}

--- a/internal/ratelimit/category_test.go
+++ b/internal/ratelimit/category_test.go
@@ -9,10 +9,9 @@ func TestCategory_String(t *testing.T) {
 		category Category
 		expected string
 	}{
-		{CategoryDefault, "CategoryDefault"},
 		{CategoryError, "CategoryError"},
 		{CategoryTransaction, "CategoryTransaction"},
-		{CategoryUptime, "CategoryUptime"},
+		{CategoryMonitor, "CategoryMonitor"},
 		{CategoryLog, "CategoryLog"},
 		{Category("custom type"), "CategoryCustomType"},
 		{Category("multi word type"), "CategoryMultiWordType"},
@@ -31,10 +30,9 @@ func TestCategory_String(t *testing.T) {
 func TestKnownCategories(t *testing.T) {
 	expectedCategories := []Category{
 		CategoryAll,
-		CategoryDefault,
 		CategoryError,
 		CategoryTransaction,
-		CategoryUptime,
+		CategoryMonitor,
 		CategoryLog,
 	}
 

--- a/internal/ratelimit/rate_limits_test.go
+++ b/internal/ratelimit/rate_limits_test.go
@@ -60,8 +60,7 @@ func TestParseXSentryRateLimits(t *testing.T) {
 			// ignore unknown categories
 			"8:error;default;unknown",
 			Map{
-				CategoryError:   Deadline(now.Add(8 * time.Second)),
-				CategoryDefault: Deadline(now.Add(8 * time.Second)),
+				CategoryError: Deadline(now.Add(8 * time.Second)),
 			},
 		},
 		{

--- a/internal/ratelimit/rate_limits_test.go
+++ b/internal/ratelimit/rate_limits_test.go
@@ -59,7 +59,10 @@ func TestParseXSentryRateLimits(t *testing.T) {
 		{
 			// ignore unknown categories
 			"8:error;default;unknown",
-			Map{CategoryError: Deadline(now.Add(8 * time.Second))},
+			Map{
+				CategoryError:   Deadline(now.Add(8 * time.Second)),
+				CategoryDefault: Deadline(now.Add(8 * time.Second)),
+			},
 		},
 		{
 			"30:error:scope1, 20:error:scope2, 40:error",

--- a/transport.go
+++ b/transport.go
@@ -262,17 +262,6 @@ func getRequestFromEvent(ctx context.Context, event *Event, dsn *Dsn) (r *http.R
 	)
 }
 
-func categoryFor(eventType string) ratelimit.Category {
-	switch eventType {
-	case "":
-		return ratelimit.CategoryError
-	case transactionType:
-		return ratelimit.CategoryTransaction
-	default:
-		return ratelimit.Category(eventType)
-	}
-}
-
 // ================================
 // HTTPTransport
 // ================================
@@ -381,7 +370,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 		return
 	}
 
-	category := categoryFor(event.Type)
+	category := event.ToCategory()
 
 	if t.disabled(category) {
 		return
@@ -653,7 +642,7 @@ func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Eve
 		return
 	}
 
-	if t.disabled(categoryFor(event.Type)) {
+	if t.disabled(event.ToCategory()) {
 		return
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -370,7 +370,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 		return
 	}
 
-	category := event.ToCategory()
+	category := event.toCategory()
 
 	if t.disabled(category) {
 		return
@@ -642,7 +642,7 @@ func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Eve
 		return
 	}
 
-	if t.disabled(event.ToCategory()) {
+	if t.disabled(event.toCategory()) {
 		return
 	}
 


### PR DESCRIPTION
Closes #1081. 
Properly handle rate limits by:
- Add missing types for Logs and CheckIns. 
- Add CategoryUnknown to enum for debugging purposes. Unknown categories should not get rate limited.
- Tidy: move category transformation to Event.