### PR TITLE
Run tests on Go 1.25 and remove Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-go-${{ matrix.go }}-
       - name: Tidy for min version
         run: make mod-tidy
-        if: ${{ matrix.go == '1.22' }}
+        if: ${{ matrix.go == '1.23' }}
       - name: Build
         run: make build
       - name: Vet
@@ -62,6 +62,6 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        go: ["1.24", "1.23", "1.22"]
+        go: ["1.25", "1.24", "1.23"]
         os: [ubuntu, windows, macos]
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ mod-tidy: ## Check go.mod tidiness
 	set -e ; \
 	for dir in $(ALL_GO_MOD_DIRS); do \
 		echo ">>> Running 'go mod tidy' for module: $${dir}"; \
-		(cd "$${dir}" && go mod tidy -go=1.22 -compat=1.22); \
+		(cd "$${dir}" && go mod tidy -go=1.23 -compat=1.23); \
 	done; \
 	git diff --exit-code;
 .PHONY: mod-tidy

--- a/echo/go.mod
+++ b/echo/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/echo
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/fasthttp/go.mod
+++ b/fasthttp/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/fasthttp
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/fiber/go.mod
+++ b/fiber/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/fiber
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/gin/go.mod
+++ b/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/gin
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.22
+go 1.23
 
 require (
 	github.com/go-errors/errors v1.4.2

--- a/iris/go.mod
+++ b/iris/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/iris
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/logrus/go.mod
+++ b/logrus/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/logrus
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/negroni/go.mod
+++ b/negroni/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/negroni
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/otel
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/slog/go.mod
+++ b/slog/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/slog
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/zerolog/go.mod
+++ b/zerolog/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/zerolog
 
-go 1.22
+go 1.23
 
 replace github.com/getsentry/sentry-go => ../
 


### PR DESCRIPTION
Once merged, update the Required Status checks to include the newly added Go 1.25 checks. Go 1.22 was already removed to being able to merge this one.