### PR TITLE
ref: create debuglog package

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"net/http"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go/internal/debug"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 // The identifier of the SDK.
@@ -78,8 +78,8 @@ type usageError struct {
 }
 
 // DebugLogger is an instance of log.Logger that is used to provide debug information about running Sentry Client
-// can be enabled by either using DebugLogger.SetOutput directly or with Debug client option.
-var DebugLogger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
+// can be enabled by either using debuglog.SetOutput directly or with Debug client option.
+var DebugLogger = debuglog.GetLogger()
 
 // EventProcessor is a function that processes an event.
 // Event processors are used to change an event before it is sent to Sentry.
@@ -296,7 +296,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		if debugWriter == nil {
 			debugWriter = os.Stderr
 		}
-		DebugLogger.SetOutput(debugWriter)
+		debuglog.SetOutput(debugWriter)
 	}
 
 	if options.Dsn == "" {
@@ -401,12 +401,12 @@ func (client *Client) setupIntegrations() {
 
 	for _, integration := range integrations {
 		if client.integrationAlreadyInstalled(integration.Name()) {
-			DebugLogger.Printf("Integration %s is already installed\n", integration.Name())
+			debuglog.Printf("Integration %s is already installed\n", integration.Name())
 			continue
 		}
 		client.integrations = append(client.integrations, integration)
 		integration.SetupOnce(client)
-		DebugLogger.Printf("Integration installed: %s\n", integration.Name())
+		debuglog.Printf("Integration installed: %s\n", integration.Name())
 	}
 
 	sort.Slice(client.integrations, func(i, j int) bool {
@@ -647,7 +647,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	// options.TracesSampler when they are started. Other events
 	// (errors, messages) are sampled here. Does not apply to check-ins.
 	if event.Type != transactionType && event.Type != checkInType && !sample(client.options.SampleRate) {
-		DebugLogger.Println("Event dropped due to SampleRate hit.")
+		debuglog.Println("Event dropped due to SampleRate hit.")
 		return nil
 	}
 
@@ -663,7 +663,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	case transactionType:
 		if client.options.BeforeSendTransaction != nil {
 			if event = client.options.BeforeSendTransaction(event, hint); event == nil {
-				DebugLogger.Println("Transaction dropped due to BeforeSendTransaction callback.")
+				debuglog.Println("Transaction dropped due to BeforeSendTransaction callback.")
 				return nil
 			}
 		}
@@ -671,7 +671,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	default:
 		if client.options.BeforeSend != nil {
 			if event = client.options.BeforeSend(event, hint); event == nil {
-				DebugLogger.Println("Event dropped due to BeforeSend callback.")
+				debuglog.Println("Event dropped due to BeforeSend callback.")
 				return nil
 			}
 		}
@@ -738,7 +738,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			DebugLogger.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
+			debuglog.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
 			return nil
 		}
 	}
@@ -747,7 +747,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			DebugLogger.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
+			debuglog.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
 			return nil
 		}
 	}

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 	"github.com/valyala/fasthttp"
 )
 
@@ -143,7 +144,7 @@ func GetSpanFromContext(ctx *fasthttp.RequestCtx) *sentry.Span {
 func convert(ctx *fasthttp.RequestCtx) *http.Request {
 	defer func() {
 		if err := recover(); err != nil {
-			sentry.DebugLogger.Printf("%v", err)
+			debuglog.Printf("%v", err)
 		}
 	}()
 

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v2/utils"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 const (
@@ -143,7 +144,7 @@ func GetSpanFromContext(ctx *fiber.Ctx) *sentry.Span {
 func convert(ctx *fiber.Ctx) *http.Request {
 	defer func() {
 		if err := recover(); err != nil {
-			sentry.DebugLogger.Printf("%v", err)
+			debuglog.Printf("%v", err)
 		}
 	}()
 

--- a/hub.go
+++ b/hub.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 type contextKey int
@@ -308,7 +310,7 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 			hint = &BreadcrumbHint{}
 		}
 		if breadcrumb = client.options.BeforeBreadcrumb(breadcrumb, hint); breadcrumb == nil {
-			DebugLogger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
+			debuglog.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
 			return
 		}
 	}

--- a/integrations.go
+++ b/integrations.go
@@ -8,6 +8,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 // ================================
@@ -32,7 +34,7 @@ func (mi *modulesIntegration) processor(event *Event, _ *EventHint) *Event {
 		mi.once.Do(func() {
 			info, ok := debug.ReadBuildInfo()
 			if !ok {
-				DebugLogger.Print("The Modules integration is not available in binaries built without module support.")
+				debuglog.Print("The Modules integration is not available in binaries built without module support.")
 				return
 			}
 			mi.modules = extractModules(info)
@@ -141,7 +143,7 @@ func (iei *ignoreErrorsIntegration) processor(event *Event, _ *EventHint) *Event
 	for _, suspect := range suspects {
 		for _, pattern := range iei.ignoreErrors {
 			if pattern.Match([]byte(suspect)) || strings.Contains(suspect, pattern.String()) {
-				DebugLogger.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
+				debuglog.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
 					"| Value matched: %s | Filter used: %s", suspect, pattern)
 				return nil
 			}
@@ -203,7 +205,7 @@ func (iei *ignoreTransactionsIntegration) processor(event *Event, _ *EventHint) 
 
 	for _, pattern := range iei.ignoreTransactions {
 		if pattern.Match([]byte(suspect)) || strings.Contains(suspect, pattern.String()) {
-			DebugLogger.Printf("Transaction dropped due to being matched by `IgnoreTransactions` option."+
+			debuglog.Printf("Transaction dropped due to being matched by `IgnoreTransactions` option."+
 				"| Value matched: %s | Filter used: %s", suspect, pattern)
 			return nil
 		}

--- a/internal/debuglog/log.go
+++ b/internal/debuglog/log.go
@@ -7,13 +7,9 @@ import (
 )
 
 var (
-	logger *log.Logger
+	logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
 	mu     sync.RWMutex
 )
-
-func init() {
-	logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
-}
 
 // SetLogger replaces the current debug logger with a new one.
 // This function is thread-safe and can be called concurrently.

--- a/internal/debuglog/log.go
+++ b/internal/debuglog/log.go
@@ -1,0 +1,69 @@
+package debuglog
+
+import (
+	"io"
+	"log"
+	"sync"
+)
+
+var (
+	logger *log.Logger
+	mu     sync.RWMutex
+)
+
+func init() {
+	logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
+}
+
+// SetLogger replaces the current debug logger with a new one.
+// This function is thread-safe and can be called concurrently.
+func SetLogger(l *log.Logger) {
+	mu.Lock()
+	defer mu.Unlock()
+	logger = l
+}
+
+func SetOutput(w io.Writer) {
+	logger.SetOutput(w)
+}
+
+// GetLogger returns the current logger instance.
+// This function is thread-safe and can be called concurrently.
+func GetLogger() *log.Logger {
+	mu.RLock()
+	defer mu.RUnlock()
+	return logger
+}
+
+// Printf calls Printf on the underlying logger.
+// This function is thread-safe and can be called concurrently.
+func Printf(format string, args ...interface{}) {
+	mu.RLock()
+	l := logger
+	mu.RUnlock()
+	if l != nil {
+		l.Printf(format, args...)
+	}
+}
+
+// Println calls Println on the underlying logger.
+// This function is thread-safe and can be called concurrently.
+func Println(args ...interface{}) {
+	mu.RLock()
+	l := logger
+	mu.RUnlock()
+	if l != nil {
+		l.Println(args...)
+	}
+}
+
+// Print calls Print on the underlying logger.
+// This function is thread-safe and can be called concurrently.
+func Print(args ...interface{}) {
+	mu.RLock()
+	l := logger
+	mu.RUnlock()
+	if l != nil {
+		l.Print(args...)
+	}
+}

--- a/internal/debuglog/log.go
+++ b/internal/debuglog/log.go
@@ -3,22 +3,12 @@ package debuglog
 import (
 	"io"
 	"log"
-	"sync"
 )
 
-var (
-	logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
-	mu     sync.RWMutex
-)
+// logger is the global debug logger instance.
+var logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
 
-// SetLogger replaces the current debug logger with a new one.
-// This function is thread-safe and can be called concurrently.
-func SetLogger(l *log.Logger) {
-	mu.Lock()
-	defer mu.Unlock()
-	logger = l
-}
-
+// SetOutput changes the output destination of the logger.
 func SetOutput(w io.Writer) {
 	logger.SetOutput(w)
 }
@@ -26,40 +16,20 @@ func SetOutput(w io.Writer) {
 // GetLogger returns the current logger instance.
 // This function is thread-safe and can be called concurrently.
 func GetLogger() *log.Logger {
-	mu.RLock()
-	defer mu.RUnlock()
 	return logger
 }
 
 // Printf calls Printf on the underlying logger.
-// This function is thread-safe and can be called concurrently.
 func Printf(format string, args ...interface{}) {
-	mu.RLock()
-	l := logger
-	mu.RUnlock()
-	if l != nil {
-		l.Printf(format, args...)
-	}
+	logger.Printf(format, args...)
 }
 
 // Println calls Println on the underlying logger.
-// This function is thread-safe and can be called concurrently.
 func Println(args ...interface{}) {
-	mu.RLock()
-	l := logger
-	mu.RUnlock()
-	if l != nil {
-		l.Println(args...)
-	}
+	logger.Println(args...)
 }
 
 // Print calls Print on the underlying logger.
-// This function is thread-safe and can be called concurrently.
 func Print(args ...interface{}) {
-	mu.RLock()
-	l := logger
-	mu.RUnlock()
-	if l != nil {
-		l.Print(args...)
-	}
+	logger.Print(args...)
 }

--- a/internal/debuglog/log_test.go
+++ b/internal/debuglog/log_test.go
@@ -74,7 +74,7 @@ func TestPrint(t *testing.T) {
 	}
 }
 
-func TestConcurrentAccess(t *testing.T) {
+func TestConcurrentAccess(_ *testing.T) {
 	original := GetLogger()
 	defer SetLogger(original)
 
@@ -124,10 +124,11 @@ func TestInitialization(t *testing.T) {
 	Print("test")
 }
 
-func TestNilLogger(t *testing.T) {
+func TestNilLogger(_ *testing.T) {
 	original := GetLogger()
 	defer SetLogger(original)
 
+	// a nil logger should not panic
 	SetLogger(nil)
 	Printf("test")
 	Println("test")

--- a/internal/debuglog/log_test.go
+++ b/internal/debuglog/log_test.go
@@ -1,0 +1,135 @@
+package debuglog
+
+import (
+	"bytes"
+	"io"
+	stdlog "log"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestSetLogger(t *testing.T) {
+	original := GetLogger()
+	defer SetLogger(original)
+
+	var buf bytes.Buffer
+	newLogger := stdlog.New(&buf, "[Test] ", stdlog.LstdFlags)
+	SetLogger(newLogger)
+
+	if GetLogger() != newLogger {
+		t.Error("SetLogger did not set the logger correctly")
+	}
+}
+
+func TestGetLogger(t *testing.T) {
+	logger := GetLogger()
+	if logger == nil {
+		t.Error("GetLogger returned nil")
+	}
+}
+
+func TestPrintf(t *testing.T) {
+	original := GetLogger()
+	defer SetLogger(original)
+
+	var buf bytes.Buffer
+	testLogger := stdlog.New(&buf, "", 0)
+	SetLogger(testLogger)
+	Printf("test %s %d", "message", 42)
+
+	output := buf.String()
+	if !strings.Contains(output, "test message 42") {
+		t.Errorf("Printf output incorrect: got %q", output)
+	}
+}
+
+func TestPrintln(t *testing.T) {
+	original := GetLogger()
+	defer SetLogger(original)
+
+	var buf bytes.Buffer
+	testLogger := stdlog.New(&buf, "", 0)
+	SetLogger(testLogger)
+	Println("test", "message")
+
+	output := buf.String()
+	if !strings.Contains(output, "test message") {
+		t.Errorf("Println output incorrect: got %q", output)
+	}
+}
+
+func TestPrint(t *testing.T) {
+	original := GetLogger()
+	defer SetLogger(original)
+
+	var buf bytes.Buffer
+	testLogger := stdlog.New(&buf, "", 0)
+	SetLogger(testLogger)
+	Print("test", "message")
+
+	output := buf.String()
+	if !strings.Contains(output, "testmessage") {
+		t.Errorf("Print output incorrect: got %q", output)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	original := GetLogger()
+	defer SetLogger(original)
+
+	var wg sync.WaitGroup
+	iterations := 100
+
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			Printf("concurrent message %d", n)
+		}(i)
+	}
+
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = GetLogger()
+		}()
+	}
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			newLogger := stdlog.New(io.Discard, "[Test] ", stdlog.LstdFlags)
+			SetLogger(newLogger)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestInitialization(t *testing.T) {
+	// The logger should be initialized on package load
+	logger := GetLogger()
+	if logger == nil {
+		t.Error("Logger was not initialized")
+	}
+
+	var buf bytes.Buffer
+	testLogger := stdlog.New(&buf, "", 0)
+	SetLogger(testLogger)
+	Printf("test")
+	Println("test")
+	Print("test")
+}
+
+func TestNilLogger(t *testing.T) {
+	original := GetLogger()
+	defer SetLogger(original)
+
+	SetLogger(nil)
+	Printf("test")
+	Println("test")
+	Print("test")
+}

--- a/log.go
+++ b/log.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go/attribute"
+	debuglog "github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 type LogLevel string
@@ -74,7 +75,7 @@ func NewLogger(ctx context.Context) Logger {
 		}
 	}
 
-	DebugLogger.Println("fallback to noopLogger: enableLogs disabled")
+	debuglog.Println("fallback to noopLogger: enableLogs disabled")
 	return &noopLogger{} // fallback: does nothing
 }
 
@@ -187,7 +188,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 	}
 
 	if l.client.options.Debug {
-		DebugLogger.Printf(message, args...)
+		debuglog.Printf(message, args...)
 	}
 }
 
@@ -198,7 +199,7 @@ func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {
 	for _, v := range attrs {
 		t, ok := mapTypesToStr[v.Value.Type()]
 		if !ok || t == "" {
-			DebugLogger.Printf("invalid attribute type set: %v", t)
+			debuglog.Printf("invalid attribute type set: %v", t)
 			continue
 		}
 

--- a/log_fallback.go
+++ b/log_fallback.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/getsentry/sentry-go/attribute"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 // Fallback, no-op logger if logging is disabled.
@@ -46,7 +47,7 @@ func (n *noopLogEntry) Attributes(_ ...attribute.Builder) LogEntry {
 }
 
 func (n *noopLogEntry) Emit(args ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
+	debuglog.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
 	if n.level == LogLevelFatal {
 		if n.shouldPanic {
 			panic(args)
@@ -56,7 +57,7 @@ func (n *noopLogEntry) Emit(args ...interface{}) {
 }
 
 func (n *noopLogEntry) Emitf(message string, args ...interface{}) {
-	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
+	debuglog.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
 	if n.level == LogLevelFatal {
 		if n.shouldPanic {
 			panic(fmt.Sprintf(message, args...))
@@ -96,7 +97,7 @@ func (*noopLogger) Panic() LogEntry {
 }
 
 func (*noopLogger) SetAttributes(...attribute.Builder) {
-	DebugLogger.Printf("No attributes attached. Turn on logging via EnableLogs")
+	debuglog.Printf("No attributes attached. Turn on logging via EnableLogs")
 }
 
 func (*noopLogger) Write(_ []byte) (n int, err error) {

--- a/log_test.go
+++ b/log_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go/attribute"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 	"github.com/getsentry/sentry-go/internal/testutils"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -693,8 +694,8 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 			hub.BindClient(mockClient)
 
 			// set the debug logger output after NewClient, so that it doesn't change.
-			DebugLogger.SetOutput(&buf)
-			defer DebugLogger.SetOutput(io.Discard)
+			debuglog.SetOutput(&buf)
+			defer debuglog.SetOutput(io.Discard)
 
 			logger := NewLogger(ctx)
 			logger.Info().WithCtx(ctx).Emit(tt.message)

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/attribute"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 	"github.com/sirupsen/logrus"
 )
 
@@ -353,7 +354,7 @@ func (h *logHook) Fire(entry *logrus.Entry) error {
 	case logrus.PanicLevel:
 		logEntry = h.logger.Panic().WithCtx(ctx)
 	default:
-		sentry.DebugLogger.Printf("Invalid logrus logging level: %v. Dropping log.", entry.Level)
+		debuglog.Printf("Invalid logrus logging level: %v. Dropping log.", entry.Level)
 		if h.fallback != nil {
 			return h.fallback(entry)
 		}

--- a/scope.go
+++ b/scope.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 // Scope holds contextual data for the current scope.
@@ -472,7 +474,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			DebugLogger.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
+			debuglog.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
 			return nil
 		}
 	}

--- a/slog/converter.go
+++ b/slog/converter.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 var (
@@ -171,6 +172,6 @@ func slogAttrToLogEntry(logEntry sentry.LogEntry, group string, a slog.Attr) sen
 		return logEntry
 	}
 
-	sentry.DebugLogger.Printf("Invalid type: dropping attribute with key: %v and value: %v", a.Key, a.Value)
+	debuglog.Printf("Invalid type: dropping attribute with key: %v and value: %v", a.Key, a.Value)
 	return logEntry
 }

--- a/span_recorder.go
+++ b/span_recorder.go
@@ -2,6 +2,8 @@ package sentry
 
 import (
 	"sync"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 // A spanRecorder stores a span tree that makes up a transaction. Safe for
@@ -24,7 +26,7 @@ func (r *spanRecorder) record(s *Span) {
 	if len(r.spans) >= maxSpans {
 		r.overflowOnce.Do(func() {
 			root := r.spans[0]
-			DebugLogger.Printf("Too many spans: dropping spans from transaction with TraceID=%s SpanID=%s limit=%d",
+			debuglog.Printf("Too many spans: dropping spans from transaction with TraceID=%s SpanID=%s limit=%d",
 				root.TraceID, root.SpanID, maxSpans)
 		})
 		// TODO(tracing): mark the transaction event in some way to

--- a/span_recorder_test.go
+++ b/span_recorder_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"testing"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 func Test_spanRecorder_record(t *testing.T) {
@@ -32,8 +34,8 @@ func Test_spanRecorder_record(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			logBuffer := bytes.Buffer{}
-			DebugLogger.SetOutput(&logBuffer)
-			defer DebugLogger.SetOutput(io.Discard)
+			debuglog.SetOutput(&logBuffer)
+			defer debuglog.SetOutput(io.Discard)
 			spanRecorder := spanRecorder{}
 
 			currentHub.BindClient(&Client{
@@ -54,7 +56,7 @@ func Test_spanRecorder_record(t *testing.T) {
 			} else {
 				assertEqual(t, len(spanRecorder.spans), tt.toRecordSpans, "expected no overflow")
 			}
-			// check if DebugLogger was called for overflow messages
+			// check if debuglog was called for overflow messages
 			if bytes.Contains(logBuffer.Bytes(), []byte("Too many spans")) && !tt.expectOverflow {
 				t.Error("unexpected overflow log")
 			}

--- a/tracing.go
+++ b/tracing.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
 )
 
 const (
@@ -379,7 +381,7 @@ func (s *Span) shouldIgnoreStatusCode() bool {
 				s.mu.Lock()
 				s.Sampled = SampledFalse
 				s.mu.Unlock()
-				DebugLogger.Printf("dropping transaction with status code %v: found in TraceIgnoreStatusCodes", statusCode)
+				debuglog.Printf("dropping transaction with status code %v: found in TraceIgnoreStatusCodes", statusCode)
 				return true
 			}
 		case 2:
@@ -388,11 +390,11 @@ func (s *Span) shouldIgnoreStatusCode() bool {
 				s.mu.Lock()
 				s.Sampled = SampledFalse
 				s.mu.Unlock()
-				DebugLogger.Printf("dropping transaction with status code %v: found in TraceIgnoreStatusCodes range [%d, %d]", statusCode, ignoredRange[0], ignoredRange[1])
+				debuglog.Printf("dropping transaction with status code %v: found in TraceIgnoreStatusCodes range [%d, %d]", statusCode, ignoredRange[0], ignoredRange[1])
 				return true
 			}
 		default:
-			DebugLogger.Printf("incorrect TraceIgnoreStatusCodes format: %v", ignoredRange)
+			debuglog.Printf("incorrect TraceIgnoreStatusCodes format: %v", ignoredRange)
 		}
 	}
 
@@ -505,14 +507,14 @@ func (s *Span) sample() Sampled {
 	// https://develop.sentry.dev/sdk/performance/#sampling
 	// #1 tracing is not enabled.
 	if !clientOptions.EnableTracing {
-		DebugLogger.Printf("Dropping transaction: EnableTracing is set to %t", clientOptions.EnableTracing)
+		debuglog.Printf("Dropping transaction: EnableTracing is set to %t", clientOptions.EnableTracing)
 		s.sampleRate = 0.0
 		return SampledFalse
 	}
 
 	// #2 explicit sampling decision via StartSpan/StartTransaction options.
 	if s.explicitSampled != SampledUndefined {
-		DebugLogger.Printf("Using explicit sampling decision from StartSpan/StartTransaction: %v", s.explicitSampled)
+		debuglog.Printf("Using explicit sampling decision from StartSpan/StartTransaction: %v", s.explicitSampled)
 		switch s.explicitSampled {
 		case SampledTrue:
 			s.sampleRate = 1.0
@@ -545,25 +547,25 @@ func (s *Span) sample() Sampled {
 			s.dynamicSamplingContext.Entries["sample_rate"] = strconv.FormatFloat(tracesSamplerSampleRate, 'f', -1, 64)
 		}
 		if tracesSamplerSampleRate < 0.0 || tracesSamplerSampleRate > 1.0 {
-			DebugLogger.Printf("Dropping transaction: Returned TracesSampler rate is out of range [0.0, 1.0]: %f", tracesSamplerSampleRate)
+			debuglog.Printf("Dropping transaction: Returned TracesSampler rate is out of range [0.0, 1.0]: %f", tracesSamplerSampleRate)
 			return SampledFalse
 		}
 		if tracesSamplerSampleRate == 0.0 {
-			DebugLogger.Printf("Dropping transaction: Returned TracesSampler rate is: %f", tracesSamplerSampleRate)
+			debuglog.Printf("Dropping transaction: Returned TracesSampler rate is: %f", tracesSamplerSampleRate)
 			return SampledFalse
 		}
 
 		if rng.Float64() < tracesSamplerSampleRate {
 			return SampledTrue
 		}
-		DebugLogger.Printf("Dropping transaction: TracesSampler returned rate: %f", tracesSamplerSampleRate)
+		debuglog.Printf("Dropping transaction: TracesSampler returned rate: %f", tracesSamplerSampleRate)
 
 		return SampledFalse
 	}
 
 	// #4 inherit parent decision.
 	if s.Sampled != SampledUndefined {
-		DebugLogger.Printf("Using sampling decision from parent: %v", s.Sampled)
+		debuglog.Printf("Using sampling decision from parent: %v", s.Sampled)
 		switch s.Sampled {
 		case SampledTrue:
 			s.sampleRate = 1.0
@@ -581,11 +583,11 @@ func (s *Span) sample() Sampled {
 		s.dynamicSamplingContext.Entries["sample_rate"] = strconv.FormatFloat(sampleRate, 'f', -1, 64)
 	}
 	if sampleRate < 0.0 || sampleRate > 1.0 {
-		DebugLogger.Printf("Dropping transaction: TracesSampleRate out of range [0.0, 1.0]: %f", sampleRate)
+		debuglog.Printf("Dropping transaction: TracesSampleRate out of range [0.0, 1.0]: %f", sampleRate)
 		return SampledFalse
 	}
 	if sampleRate == 0.0 {
-		DebugLogger.Printf("Dropping transaction: TracesSampleRate rate is: %f", sampleRate)
+		debuglog.Printf("Dropping transaction: TracesSampleRate rate is: %f", sampleRate)
 		return SampledFalse
 	}
 
@@ -608,7 +610,7 @@ func (s *Span) toEvent() *Event {
 	finished := make([]*Span, 0, len(children))
 	for _, child := range children {
 		if child.EndTime.IsZero() {
-			DebugLogger.Printf("Dropped unfinished span: Op=%q TraceID=%s SpanID=%s", child.Op, child.TraceID, child.SpanID)
+			debuglog.Printf("Dropped unfinished span: Op=%q TraceID=%s SpanID=%s", child.Op, child.TraceID, child.SpanID)
 			continue
 		}
 		finished = append(finished, child)

--- a/transport.go
+++ b/transport.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/getsentry/sentry-go/internal/debuglog"
 	"github.com/getsentry/sentry-go/internal/ratelimit"
 )
 
@@ -87,14 +88,14 @@ func getRequestBodyFromEvent(event *Event) []byte {
 	}
 	body, err = json.Marshal(event)
 	if err == nil {
-		DebugLogger.Println(msg)
+		debuglog.Println(msg)
 		return body
 	}
 
 	// This should _only_ happen when Event.Exception[0].Stacktrace.Frames[0].Vars is unserializable
 	// Which won't ever happen, as we don't use it now (although it's the part of public interface accepted by Sentry)
 	// Juuust in case something, somehow goes utterly wrong.
-	DebugLogger.Println("Event couldn't be marshaled, even with stripped contextual data. Skipping delivery. " +
+	debuglog.Println("Event couldn't be marshaled, even with stripped contextual data. Skipping delivery. " +
 		"Please notify the SDK owners with possibly broken payload.")
 	return nil
 }
@@ -321,7 +322,7 @@ func NewHTTPTransport() *HTTPTransport {
 func (t *HTTPTransport) Configure(options ClientOptions) {
 	dsn, err := NewDsn(options.Dsn)
 	if err != nil {
-		DebugLogger.Printf("%v\n", err)
+		debuglog.Printf("%v\n", err)
 		return
 	}
 	t.dsn = dsn
@@ -405,7 +406,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 		} else {
 			eventType = fmt.Sprintf("%s event", event.Level)
 		}
-		DebugLogger.Printf(
+		debuglog.Printf(
 			"Sending %s [%s] to %s project: %s",
 			eventType,
 			event.EventID,
@@ -413,7 +414,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 			t.dsn.projectID,
 		)
 	default:
-		DebugLogger.Println("Event dropped due to transport buffer being full.")
+		debuglog.Println("Event dropped due to transport buffer being full.")
 	}
 
 	t.buffer <- b
@@ -477,14 +478,14 @@ started:
 	// Wait until the current batch is done or the timeout.
 	select {
 	case <-b.done:
-		DebugLogger.Println("Buffer flushed successfully.")
+		debuglog.Println("Buffer flushed successfully.")
 		return true
 	case <-timeout:
 		goto fail
 	}
 
 fail:
-	DebugLogger.Println("Buffer flushing was canceled or timed out.")
+	debuglog.Println("Buffer flushing was canceled or timed out.")
 	return false
 }
 
@@ -524,15 +525,15 @@ func (t *HTTPTransport) worker() {
 
 				response, err := t.client.Do(item.request)
 				if err != nil {
-					DebugLogger.Printf("There was an issue with sending an event: %v", err)
+					debuglog.Printf("There was an issue with sending an event: %v", err)
 					continue
 				}
 				if response.StatusCode >= 400 && response.StatusCode <= 599 {
 					b, err := io.ReadAll(response.Body)
 					if err != nil {
-						DebugLogger.Printf("Error while reading response code: %v", err)
+						debuglog.Printf("Error while reading response code: %v", err)
 					}
-					DebugLogger.Printf("Sending %s failed with the following error: %s", eventType, string(b))
+					debuglog.Printf("Sending %s failed with the following error: %s", eventType, string(b))
 				}
 
 				t.mu.Lock()
@@ -559,7 +560,7 @@ func (t *HTTPTransport) disabled(c ratelimit.Category) bool {
 	defer t.mu.RUnlock()
 	disabled := t.limits.IsRateLimited(c)
 	if disabled {
-		DebugLogger.Printf("Too many requests for %q, backing off till: %v", c, t.limits.Deadline(c))
+		debuglog.Printf("Too many requests for %q, backing off till: %v", c, t.limits.Deadline(c))
 	}
 	return disabled
 }
@@ -605,7 +606,7 @@ func NewHTTPSyncTransport() *HTTPSyncTransport {
 func (t *HTTPSyncTransport) Configure(options ClientOptions) {
 	dsn, err := NewDsn(options.Dsn)
 	if err != nil {
-		DebugLogger.Printf("%v\n", err)
+		debuglog.Printf("%v\n", err)
 		return
 	}
 	t.dsn = dsn
@@ -660,7 +661,7 @@ func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Eve
 	default:
 		eventIdentifier = fmt.Sprintf("%s event", event.Level)
 	}
-	DebugLogger.Printf(
+	debuglog.Printf(
 		"Sending %s [%s] to %s project: %s",
 		eventIdentifier,
 		event.EventID,
@@ -670,15 +671,15 @@ func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Eve
 
 	response, err := t.client.Do(request)
 	if err != nil {
-		DebugLogger.Printf("There was an issue with sending an event: %v", err)
+		debuglog.Printf("There was an issue with sending an event: %v", err)
 		return
 	}
 	if response.StatusCode >= 400 && response.StatusCode <= 599 {
 		b, err := io.ReadAll(response.Body)
 		if err != nil {
-			DebugLogger.Printf("Error while reading response code: %v", err)
+			debuglog.Printf("Error while reading response code: %v", err)
 		}
-		DebugLogger.Printf("Sending %s failed with the following error: %s", eventIdentifier, string(b))
+		debuglog.Printf("Sending %s failed with the following error: %s", eventIdentifier, string(b))
 	}
 
 	t.mu.Lock()
@@ -710,7 +711,7 @@ func (t *HTTPSyncTransport) disabled(c ratelimit.Category) bool {
 	defer t.mu.Unlock()
 	disabled := t.limits.IsRateLimited(c)
 	if disabled {
-		DebugLogger.Printf("Too many requests for %q, backing off till: %v", c, t.limits.Deadline(c))
+		debuglog.Printf("Too many requests for %q, backing off till: %v", c, t.limits.Deadline(c))
 	}
 	return disabled
 }
@@ -726,11 +727,11 @@ type noopTransport struct{}
 var _ Transport = noopTransport{}
 
 func (noopTransport) Configure(ClientOptions) {
-	DebugLogger.Println("Sentry client initialized with an empty DSN. Using noopTransport. No events will be delivered.")
+	debuglog.Println("Sentry client initialized with an empty DSN. Using noopTransport. No events will be delivered.")
 }
 
 func (noopTransport) SendEvent(*Event) {
-	DebugLogger.Println("Event dropped due to noopTransport usage.")
+	debuglog.Println("Event dropped due to noopTransport usage.")
 }
 
 func (noopTransport) Flush(time.Duration) bool {

--- a/util.go
+++ b/util.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getsentry/sentry-go/internal/debuglog"
 	exec "golang.org/x/sys/execabs"
 )
 
@@ -62,7 +63,7 @@ func defaultRelease() (release string) {
 	}
 	for _, e := range envs {
 		if release = os.Getenv(e); release != "" {
-			DebugLogger.Printf("Using release from environment variable %s: %s", e, release)
+			debuglog.Printf("Using release from environment variable %s: %s", e, release)
 			return release
 		}
 	}
@@ -89,23 +90,23 @@ func defaultRelease() (release string) {
 			if err, ok := err.(*exec.ExitError); ok && len(err.Stderr) > 0 {
 				fmt.Fprintf(&s, ": %s", err.Stderr)
 			}
-			DebugLogger.Print(s.String())
+			debuglog.Print(s.String())
 		} else {
 			release = strings.TrimSpace(string(b))
-			DebugLogger.Printf("Using release from Git: %s", release)
+			debuglog.Printf("Using release from Git: %s", release)
 			return release
 		}
 	}
 
-	DebugLogger.Print("Some Sentry features will not be available. See https://docs.sentry.io/product/releases/.")
-	DebugLogger.Print("To stop seeing this message, pass a Release to sentry.Init or set the SENTRY_RELEASE environment variable.")
+	debuglog.Print("Some Sentry features will not be available. See https://docs.sentry.io/product/releases/.")
+	debuglog.Print("To stop seeing this message, pass a Release to sentry.Init or set the SENTRY_RELEASE environment variable.")
 	return ""
 }
 
 func revisionFromBuildInfo(info *debug.BuildInfo) string {
 	for _, setting := range info.Settings {
 		if setting.Key == "vcs.revision" && setting.Value != "" {
-			DebugLogger.Printf("Using release from debug info: %s", setting.Value)
+			debuglog.Printf("Using release from debug info: %s", setting.Value)
 			return setting.Value
 		}
 	}


### PR DESCRIPTION
### Description
Create a `debuglog` package to easily access the `sentry.DebugLogger` without depending on the root level. This change aims to remove any cyclic imports when internal packages are used on the top level, but also want to access the debug logger. 

#### Issues
* resolves: #1104 
* resolves: GO-88
