### PR TITLE
fix: logs should not pass from processEvent

### DIFF
--- a/batch_logger.go
+++ b/batch_logger.go
@@ -125,7 +125,8 @@ func (l *BatchLogger) run(ctx context.Context) {
 func (l *BatchLogger) processEvent(logs []Log) {
 	event := NewEvent()
 	event.Timestamp = time.Now()
+	event.EventID = EventID(uuid())
 	event.Type = logEvent.Type
 	event.Logs = logs
-	l.client.CaptureEvent(event, nil, nil)
+	l.client.Transport.SendEvent(event)
 }

--- a/transport.go
+++ b/transport.go
@@ -404,7 +404,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 		if event.Type == transactionType {
 			eventType = "transaction"
 		} else {
-			eventType = fmt.Sprintf("%s event", event.Level)
+			eventType = fmt.Sprintf("%s event", event.Type)
 		}
 		debuglog.Printf(
 			"Sending %s [%s] to %s project: %s",


### PR DESCRIPTION
### Description

Log entries should not pass from `processEvent`, so that we don't apply `BeforeSend` on them.