### PR TITLE
Set span in Sentry scope for transaction tracking

### DIFF
--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -97,6 +97,7 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 
 	scope := hub.Scope()
 	scope.SetRequest(r)
+	scope.SetSpan(transaction)
 	scope.SetRequestBody(ctx.Request().Body())
 	ctx.Locals(valuesKey, hub)
 	ctx.Locals(transactionKey, transaction)


### PR DESCRIPTION
### Description
This pull request makes a targeted improvement to the Sentry integration in the Fiber framework handler by ensuring that the current transaction span is set on the Sentry scope. This allows Sentry to correctly associate errors and events with the current transaction trace for better observability.
