### PR TITLE
fix: add fallback on non hashable errors

### DIFF
--- a/exception_test.go
+++ b/exception_test.go
@@ -377,3 +377,21 @@ func TestCircularReferenceProtection(t *testing.T) {
 		})
 	}
 }
+
+// unhashableSliceError is a non-comparable error type.
+type unhashableSliceError []string
+
+func (e unhashableSliceError) Error() string {
+	return "unhashable slice error"
+}
+
+func TestConvertErrorToExceptions_UnhashableError_NoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("convertErrorToExceptions panicked for unhashable error: %v", r)
+		}
+	}()
+
+	err := unhashableSliceError{"a", "b"}
+	_ = convertErrorToExceptions(err, -1)
+}


### PR DESCRIPTION
### Description

When checking for infinite recursion, there is a possibility that the error will be non comparable. In those cases we need to add a fallback to compare the error type and message to avoid panicking.

#### Issues
* resolves: #1112
* resolves: GO-90


