### PR TITLE
feat: change sentry.origin for logs

### DIFF
--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -47,7 +47,7 @@ const (
 	FieldGoVersion = "go_version"
 	FieldMaxProcs  = "go_maxprocs"
 
-	LogrusOrigin = "auto.logger.logrus"
+	LogrusOrigin = "auto.log.logrus"
 )
 
 var levelMap = map[logrus.Level]sentry.Level{

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -717,7 +717,7 @@ func TestLogHookFireWithDifferentDataTypes(t *testing.T) {
 			"string_slice":     {Value: "[one two three]", Type: "string"},
 			"string_map":       {Value: "map[a:1 b:2 c:3]", Type: "string"},
 			"complex":          {Value: "{test 42}", Type: "string"},
-			"sentry.origin":    {Value: "auto.logger.logrus", Type: "string"},
+			"sentry.origin":    {Value: "auto.log.logrus", Type: "string"},
 		},
 	}
 

--- a/slog/sentryslog.go
+++ b/slog/sentryslog.go
@@ -46,7 +46,7 @@ var (
 
 // LevelFatal is a custom [slog.Level] that maps to [sentry.LevelFatal]
 const LevelFatal = slog.Level(12)
-const SlogOrigin = "auto.logger.slog"
+const SlogOrigin = "auto.log.slog"
 
 type Option struct {
 	// Deprecated: Use EventLevel instead. Level is kept for backwards compatibility and defaults to EventLevel.

--- a/slog/sentryslog_test.go
+++ b/slog/sentryslog_test.go
@@ -431,7 +431,7 @@ func TestSentryHandler_AttrToSentryAttr(t *testing.T) {
 			value, found := mockTransport.Events()[0].Logs[0].Attributes[tt.expectedKey]
 			assert.True(t, found, "Attribute %s not found", tt.expectedKey)
 			assert.Equal(t, tt.expectedValue, value.Value, "For %s, expected value %v, got %v", tt.expectedKey, tt.expectedValue, value)
-			assert.Equal(t, "auto.logger.slog", mockTransport.Events()[0].Logs[0].Attributes["sentry.origin"].Value, "incorrect sentry.origin")
+			assert.Equal(t, "auto.log.slog", mockTransport.Events()[0].Logs[0].Attributes["sentry.origin"].Value, "incorrect sentry.origin")
 		})
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -275,7 +275,6 @@ func TestEnvelopeFromLogEvent(t *testing.T) {
 				"sentry.server.address": {Value: "test-server", Type: "string"},
 				"sentry.sdk.name":       {Value: "sentry.go", Type: "string"},
 				"sentry.sdk.version":    {Value: "0.0.1", Type: "string"},
-				"sentry.origin":         {Value: "auto.logger.log", Type: "string"},
 				"key.int":               {Value: 42, Type: "integer"},
 				"key.string":            {Value: "str", Type: "string"},
 				"key.float":             {Value: 42.2, Type: "double"},
@@ -293,7 +292,7 @@ func TestEnvelopeFromLogEvent(t *testing.T) {
 	got := b.String()
 	want := `{"event_id":"b81c5be4d31e48959103a1f878a1efcb","sent_at":"1970-01-01T00:00:00Z","dsn":"http://public@example.com/sentry/1","sdk":{"name":"sentry.go","version":"0.0.1"}}
 {"type":"log","item_count":1,"content_type":"application/vnd.sentry.items.log+json"}
-{"event_id":"b81c5be4d31e48959103a1f878a1efcb","sdk":{"name":"sentry.go","version":"0.0.1"},"user":{},"items":[{"timestamp":"0001-01-01T00:00:00Z","trace_id":"d49d9bf66f13450b81f65bc51cf49c03","level":"info","severity_number":9,"body":"test log message","attributes":{"key.bool":{"value":true,"type":"boolean"},"key.float":{"value":42.2,"type":"double"},"key.int":{"value":42,"type":"integer"},"key.string":{"value":"str","type":"string"},"sentry.environment":{"value":"testing","type":"string"},"sentry.origin":{"value":"auto.logger.log","type":"string"},"sentry.release":{"value":"v1.2.3","type":"string"},"sentry.sdk.name":{"value":"sentry.go","type":"string"},"sentry.sdk.version":{"value":"0.0.1","type":"string"},"sentry.server.address":{"value":"test-server","type":"string"}}}]}
+{"event_id":"b81c5be4d31e48959103a1f878a1efcb","sdk":{"name":"sentry.go","version":"0.0.1"},"user":{},"items":[{"timestamp":"0001-01-01T00:00:00Z","trace_id":"d49d9bf66f13450b81f65bc51cf49c03","level":"info","severity_number":9,"body":"test log message","attributes":{"key.bool":{"value":true,"type":"boolean"},"key.float":{"value":42.2,"type":"double"},"key.int":{"value":42,"type":"integer"},"key.string":{"value":"str","type":"string"},"sentry.environment":{"value":"testing","type":"string"},"sentry.release":{"value":"v1.2.3","type":"string"},"sentry.sdk.name":{"value":"sentry.go","type":"string"},"sentry.sdk.version":{"value":"0.0.1","type":"string"},"sentry.server.address":{"value":"test-server","type":"string"}}}]}
 `
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Envelope mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
### Description

Change the `sentry.origin` for logging integrations to adhere to the spec.

#### Issues
* resolves: #1108
* resolves: GO-89
