### PR TITLE
chore: set patch coverage to informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,5 +11,7 @@ coverage:
       default:
         # Do not fail the commit status if the coverage was reduced up to this value
         threshold: 0.5%
+    patch:
+      informational: true
 ignore:
   - "log_fallback.go"


### PR DESCRIPTION
### Description

Codecov patch coverage doesn't really work well, when changing already uncovered lines of code, and the target of almost 86% is quite limiting. This PR changes the patch coverage to be informational.