### PR TITLE
fix: add default name to patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@ coverage:
         # Do not fail the commit status if the coverage was reduced up to this value
         threshold: 0.5%
     patch:
-      informational: true
+      default:
+        informational: true
 ignore:
   - "log_fallback.go"


### PR DESCRIPTION
### Description

Properly add support for #1123. 