### PR TITLE
fix: check ptr value for visited exception chains

### DIFF
--- a/exception_test.go
+++ b/exception_test.go
@@ -395,3 +395,22 @@ func TestConvertErrorToExceptions_UnhashableError_NoPanic(t *testing.T) {
 	err := unhashableSliceError{"a", "b"}
 	_ = convertErrorToExceptions(err, -1)
 }
+
+type wrapper struct {
+	V any
+}
+
+func (w wrapper) Error() string {
+	return ""
+}
+
+func TestConvertErrorToExceptions_UnhashableWrapper_NoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("convertErrorToExceptions panicked for unhashable error: %v", r)
+		}
+	}()
+
+	var err error = wrapper{unhashableSliceError{"a", "b"}}
+	_ = convertErrorToExceptions(err, -1)
+}


### PR DESCRIPTION
### Description

Changing the implementation of tracking visited errors in the chain when parsing to exception groups, to use the pointer of the error if applicable, rather than trying to hash the error itself, to avoid cases where the error itself is unhashable.

#### Issues

* resolves: #1131
* resolves: GO-97
