### PR TITLE
fix: provide init ctx to eventHandler

### DIFF
--- a/slog/sentryslog.go
+++ b/slog/sentryslog.go
@@ -203,6 +203,7 @@ func (h *eventHandler) WithAttrs(attrs []slog.Attr) *eventHandler {
 	copy(groupsCopy, h.groups)
 
 	return &eventHandler{
+		ctx:    h.ctx,
 		option: h.option,
 		attrs:  appendAttrsToGroup(h.groups, h.attrs, attrs...),
 		groups: groupsCopy,
@@ -220,6 +221,7 @@ func (h *eventHandler) WithGroup(name string) *eventHandler {
 	newGroups = append(newGroups, name)
 
 	return &eventHandler{
+		ctx:    h.ctx,
 		option: h.option,
 		attrs:  h.attrs,
 		groups: newGroups,


### PR DESCRIPTION
### Description

Following up to #1118, we also need to fix the context propagation for the slog eventHandler, in cases that slog is used without context.

#### Issues

* resolves: #1129 
* resolves: GO-96
