### PR TITLE
feat: drop rate-limited events

### DIFF
--- a/internal/telemetry/scheduler.go
+++ b/internal/telemetry/scheduler.go
@@ -209,7 +209,7 @@ func (s *Scheduler) processItems(buffer Storage[protocol.EnvelopeItemConvertible
 		items = buffer.PollIfReady()
 	}
 
-	// drop the current batch if rate-limited
+	// drop the current batch if rate-limited or if transport is full
 	if len(items) == 0 || s.isRateLimited(category) || !s.transport.HasCapacity() {
 		return
 	}


### PR DESCRIPTION
### Description

To avoid filling up the buffer queues when rate-limited, we should be dropping events that got selected for processing. This is a behavioral change, since both the new and old transports/scheduler were just skipping the event without dropping.