### PR TITLE
fix: scheduler should check for ready to flush buffers

### DIFF
--- a/internal/telemetry/scheduler.go
+++ b/internal/telemetry/scheduler.go
@@ -170,7 +170,7 @@ func (s *Scheduler) run() {
 
 func (s *Scheduler) hasWork() bool {
 	for _, buffer := range s.buffers {
-		if !buffer.IsEmpty() {
+		if buffer.IsReadyToFlush() {
 			return true
 		}
 	}


### PR DESCRIPTION
### Description

This fixes a CPU spike reported issue. The scheduler should idle on cases where there is no work available, but in the previous implementation the check for having work was checking for non empty buffers.

In the case where logs where appended, the scheduler would constantly check for non ready buffers, consuming resources and causing the CPU to spike.