### PR TITLE
fix: pre-serialize before adding to buffers

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1052,7 +1052,12 @@ func TestClient_SetupTelemetryBuffer_WithDSN(t *testing.T) {
 		t.Fatalf("expected internalAsyncTransportAdapter, got %T", client.Transport)
 	}
 
-	if !client.telemetryBuffer.Add(NewEvent()) {
+	ev := NewEvent()
+	item, err := ev.ToEnvelopeItem()
+	if err != nil || item == nil {
+		t.Fatalf("unexpected serialization error: %v", err)
+	}
+	if !client.telemetryBuffer.Add(*item) {
 		t.Fatal("expected Add to succeed with default buffers")
 	}
 }

--- a/internal/telemetry/buffer_wrapper.go
+++ b/internal/telemetry/buffer_wrapper.go
@@ -15,7 +15,7 @@ type Buffer struct {
 
 // NewBuffer creates a new Buffer with the given configuration.
 func NewBuffer(
-	storage map[ratelimit.Category]Storage[protocol.EnvelopeItemConvertible],
+	storage map[ratelimit.Category]Storage[protocol.EnvelopeItem],
 	transport protocol.TelemetryTransport,
 	dsn *protocol.Dsn,
 	sdkInfo *protocol.SdkInfo,
@@ -28,8 +28,8 @@ func NewBuffer(
 	}
 }
 
-// Add adds an EnvelopeItemConvertible to the appropriate buffer based on its category.
-func (b *Buffer) Add(item protocol.EnvelopeItemConvertible) bool {
+// Add adds an EnvelopeItem to the appropriate buffer based on its category.
+func (b *Buffer) Add(item protocol.EnvelopeItem) bool {
 	return b.scheduler.Add(item)
 }
 

--- a/log.go
+++ b/log.go
@@ -192,8 +192,12 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 
 	if log != nil {
 		if l.client.telemetryBuffer != nil {
-			if !l.client.telemetryBuffer.Add(log) {
-				debuglog.Print("Dropping event: log buffer full or category missing")
+			if item, err := log.ToEnvelopeItem(); err == nil && item != nil {
+				if !l.client.telemetryBuffer.Add(*item) {
+					debuglog.Print("Dropping event: log buffer full or category missing")
+				}
+			} else {
+				debuglog.Printf("Failed to serialize log: %v", err)
 			}
 		} else if l.client.batchLogger != nil {
 			l.client.batchLogger.logCh <- *log


### PR DESCRIPTION
### Description

Serialize the event immediately when capturing and add the serialized envelope to the buffer. This change is happening for avoiding panics, when serializing on the scheduler's background worker, where event.Data, event.Context or event.Extra could have been mutated. 