### PR TITLE
feat: TLS config option availability using the client options

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -229,6 +230,8 @@ type ClientOptions struct {
 	// This will default to the HTTPS_PROXY environment variable.
 	// HTTPS_PROXY takes precedence over HTTP_PROXY for https requests.
 	HTTPSProxy string
+	// An optional tls config.
+	TlsConfig *tls.Config
 	// An optional set of SSL certificates to use.
 	CaCerts *x509.CertPool
 	// MaxErrorDepth is the maximum number of errors reported in a chain of errors.

--- a/client.go
+++ b/client.go
@@ -231,7 +231,7 @@ type ClientOptions struct {
 	// HTTPS_PROXY takes precedence over HTTP_PROXY for https requests.
 	HTTPSProxy string
 	// An optional tls config.
-	TlsConfig *tls.Config
+	TLSConfig *tls.Config
 	// An optional set of SSL certificates to use.
 	CaCerts *x509.CertPool
 	// MaxErrorDepth is the maximum number of errors reported in a chain of errors.

--- a/transport.go
+++ b/transport.go
@@ -62,6 +62,10 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 
 func getTLSConfig(options ClientOptions) *tls.Config {
 	if options.TlsConfig != nil {
+		if options.TlsConfig.RootCAs == nil && options.CaCerts != nil {
+			options.TlsConfig.RootCAs = options.CaCerts
+		}
+
 		return options.TlsConfig
 	} else if options.CaCerts != nil {
 		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,

--- a/transport.go
+++ b/transport.go
@@ -61,20 +61,20 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 }
 
 func getTLSConfig(options ClientOptions) *tls.Config {
-	if options.TlsConfig == nil && options.CaCerts == nil {
+	if options.TLSConfig == nil && options.CaCerts == nil {
 		return nil
 	}
 
 	var tlsConfig *tls.Config
-	if options.TlsConfig != nil {
-		tlsConfig = options.TlsConfig.Clone()
+	if options.TLSConfig != nil {
+		tlsConfig = options.TLSConfig.Clone()
 	} else {
+		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
+		// 				 but we don't want to break peoples code without the major bump.
 		tlsConfig = &tls.Config{}
 	}
 
 	if tlsConfig.RootCAs == nil && options.CaCerts != nil {
-		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
-		// 				 but we don't want to break peoples code without the major bump.
 		tlsConfig.RootCAs = options.CaCerts
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -61,22 +61,24 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 }
 
 func getTLSConfig(options ClientOptions) *tls.Config {
-	if options.TlsConfig != nil {
-		tlsConfig := options.TlsConfig
-		if tlsConfig.RootCAs == nil && options.CaCerts != nil {
-			tlsConfig.RootCAs = options.CaCerts
-		}
-
-		return tlsConfig
-	} else if options.CaCerts != nil {
-		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
-		// 				 but we don't want to break peoples code without the major bump.
-		return &tls.Config{
-			RootCAs: options.CaCerts,
-		}
+	if options.TlsConfig == nil && options.CaCerts == nil {
+		return nil
 	}
 
-	return nil
+	var tlsConfig *tls.Config
+	if options.TlsConfig != nil {
+		tlsConfig = options.TlsConfig.Clone()
+	} else {
+		tlsConfig = &tls.Config{}
+	}
+
+	if tlsConfig.RootCAs == nil && options.CaCerts != nil {
+		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
+		// 				 but we don't want to break peoples code without the major bump.
+		tlsConfig.RootCAs = options.CaCerts
+	}
+
+	return tlsConfig
 }
 
 func getRequestBodyFromEvent(event *Event) []byte {

--- a/transport.go
+++ b/transport.go
@@ -62,11 +62,12 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 
 func getTLSConfig(options ClientOptions) *tls.Config {
 	if options.TlsConfig != nil {
-		if options.TlsConfig.RootCAs == nil && options.CaCerts != nil {
-			options.TlsConfig.RootCAs = options.CaCerts
+		tlsConfig := options.TlsConfig
+		if tlsConfig.RootCAs == nil && options.CaCerts != nil {
+			tlsConfig.RootCAs = options.CaCerts
 		}
 
-		return options.TlsConfig
+		return tlsConfig
 	} else if options.CaCerts != nil {
 		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
 		// 				 but we don't want to break peoples code without the major bump.

--- a/transport.go
+++ b/transport.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,27 +57,6 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 	}
 
 	return http.ProxyFromEnvironment
-}
-
-func getTLSConfig(options ClientOptions) *tls.Config {
-	if options.TLSConfig == nil && options.CaCerts == nil {
-		return nil
-	}
-
-	var tlsConfig *tls.Config
-	if options.TLSConfig != nil {
-		tlsConfig = options.TLSConfig.Clone()
-	} else {
-		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
-		// 				 but we don't want to break peoples code without the major bump.
-		tlsConfig = &tls.Config{}
-	}
-
-	if tlsConfig.RootCAs == nil && options.CaCerts != nil {
-		tlsConfig.RootCAs = options.CaCerts
-	}
-
-	return tlsConfig
 }
 
 func getRequestBodyFromEvent(event *Event) []byte {

--- a/transport.go
+++ b/transport.go
@@ -61,7 +61,9 @@ func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error)
 }
 
 func getTLSConfig(options ClientOptions) *tls.Config {
-	if options.CaCerts != nil {
+	if options.TlsConfig != nil {
+		return options.TlsConfig
+	} else if options.CaCerts != nil {
 		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
 		// 				 but we don't want to break peoples code without the major bump.
 		return &tls.Config{

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -108,4 +109,25 @@ func revisionFromBuildInfo(info *debug.BuildInfo) string {
 
 func Pointer[T any](v T) *T {
 	return &v
+}
+
+func getTLSConfig(options ClientOptions) *tls.Config {
+	if options.TLSConfig == nil && options.CaCerts == nil {
+		return nil
+	}
+
+	var tlsConfig *tls.Config
+	if options.TLSConfig != nil {
+		tlsConfig = options.TLSConfig.Clone()
+	} else {
+		// #nosec G402 -- We should be using `MinVersion: tls.VersionTLS12`,
+		// 				 but we don't want to break peoples code without the major bump.
+		tlsConfig = &tls.Config{}
+	}
+
+	if tlsConfig.RootCAs == nil && options.CaCerts != nil {
+		tlsConfig.RootCAs = options.CaCerts
+	}
+
+	return tlsConfig
 }


### PR DESCRIPTION
### Description
This PR allows developers to provide the TLS config during the client creation via the client options.

#### Issues
* extends: #2 