### PR TITLE
feat: log specific message for RequestEntityTooLarge

### DIFF
--- a/internal/http/transport_test.go
+++ b/internal/http/transport_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getsentry/sentry-go/internal/protocol"
 	"github.com/getsentry/sentry-go/internal/ratelimit"
 	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/getsentry/sentry-go/internal/util"
 	"go.uber.org/goleak"
 )
 
@@ -469,7 +470,7 @@ func TestKeepAlive(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				fmt.Fprintln(w, `{"id":"ec71d87189164e79ab1e61030c183af0"}`)
 				if largeResponse {
-					fmt.Fprintln(w, strings.Repeat(" ", maxDrainResponseBytes))
+					fmt.Fprintln(w, strings.Repeat(" ", util.MaxDrainResponseBytes))
 				}
 			}))
 			defer server.Close()

--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -70,7 +70,7 @@ type EnvelopeItemHeader struct {
 	ItemCount *int `json:"item_count,omitempty"`
 }
 
-// EnvelopeItem represents a single item within an envelope.
+// EnvelopeItem represents a single item or batch within an envelope.
 type EnvelopeItem struct {
 	Header  *EnvelopeItemHeader `json:"-"`
 	Payload []byte              `json:"-"`

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
+	"github.com/getsentry/sentry-go/internal/protocol"
+)
+
+// MaxDrainResponseBytes is the maximum number of bytes that transport
+// implementations will read from response bodies when draining them.
+const MaxDrainResponseBytes = 16 << 10
+
+// HandleHTTPResponse is a helper method that reads the HTTP response and handles debug output.
+func HandleHTTPResponse(response *http.Response, identifier string) bool {
+	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		return true
+	}
+
+	if response.StatusCode >= 400 && response.StatusCode <= 599 {
+		body, err := io.ReadAll(io.LimitReader(response.Body, MaxDrainResponseBytes))
+		if err != nil {
+			debuglog.Printf("Error while reading response body: %v", err)
+			return false
+		}
+
+		switch {
+		case response.StatusCode == http.StatusRequestEntityTooLarge:
+			debuglog.Printf("Sending %s failed because the request was too large: %s", identifier, string(body))
+		case response.StatusCode >= 500:
+			debuglog.Printf("Sending %s failed with server error %d: %s", identifier, response.StatusCode, string(body))
+		default:
+			debuglog.Printf("Sending %s failed with client error %d: %s", identifier, response.StatusCode, string(body))
+		}
+		return false
+	}
+
+	debuglog.Printf("Unexpected status code %d for event %s", response.StatusCode, identifier)
+	return false
+}
+
+// EnvelopeIdentifier returns a human-readable identifier for the event to be used in log messages.
+// Format: "<description> [<event-id>]".
+func EnvelopeIdentifier(envelope *protocol.Envelope) string {
+	if envelope == nil || len(envelope.Items) == 0 {
+		return "empty envelope"
+	}
+
+	var description string
+	// we don't currently support mixed envelope types, so all event types would have the same type.
+	itemType := envelope.Items[0].Header.Type
+
+	switch itemType {
+	case protocol.EnvelopeItemTypeEvent:
+		description = "error"
+	case protocol.EnvelopeItemTypeTransaction:
+		description = "transaction"
+	case protocol.EnvelopeItemTypeCheckIn:
+		description = "check-in"
+	case protocol.EnvelopeItemTypeLog:
+		logCount := 0
+		for _, item := range envelope.Items {
+			if item != nil && item.Header != nil && item.Header.Type == protocol.EnvelopeItemTypeLog && item.Header.ItemCount != nil {
+				logCount += *item.Header.ItemCount
+			}
+		}
+		description = fmt.Sprintf("%d log events", logCount)
+	case protocol.EnvelopeItemTypeTraceMetric:
+		metricCount := 0
+		for _, item := range envelope.Items {
+			if item != nil && item.Header != nil && item.Header.Type == protocol.EnvelopeItemTypeTraceMetric && item.Header.ItemCount != nil {
+				metricCount += *item.Header.ItemCount
+			}
+		}
+		description = fmt.Sprintf("%d metric events", metricCount)
+	default:
+		description = fmt.Sprintf("%s event", itemType)
+	}
+
+	return fmt.Sprintf("%s [%s]", description, envelope.Header.EventID)
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/getsentry/sentry-go/internal/util"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/goleak"
 )
@@ -639,7 +640,7 @@ func testKeepAlive(t *testing.T, tr Transport) {
 		// it doesn't matter for this test.
 		fmt.Fprintln(w, `{"id":"ec71d87189164e79ab1e61030c183af0"}`)
 		if largeResponse {
-			fmt.Fprintln(w, strings.Repeat(" ", maxDrainResponseBytes))
+			fmt.Fprintln(w, strings.Repeat(" ", util.MaxDrainResponseBytes))
 		}
 	}))
 	defer srv.Close()

--- a/util.go
+++ b/util.go
@@ -109,3 +109,24 @@ func revisionFromBuildInfo(info *debug.BuildInfo) string {
 func Pointer[T any](v T) *T {
 	return &v
 }
+
+// eventIdentifier returns a human-readable identifier for the event to be used in log messages.
+// Format: "<description> [<event-id>]".
+func eventIdentifier(event *Event) string {
+	var description string
+	switch event.Type {
+	case errorType:
+		description = "error"
+	case transactionType:
+		description = "transaction"
+	case checkInType:
+		description = "check-in"
+	case logEvent.Type:
+		description = fmt.Sprintf("%d log events", len(event.Logs))
+	case traceMetricEvent.Type:
+		description = fmt.Sprintf("%d metric events", len(event.Metrics))
+	default:
+		description = fmt.Sprintf("%s event", event.Type)
+	}
+	return fmt.Sprintf("%s [%s]", description, event.EventID)
+}


### PR DESCRIPTION
### Description
Handle the RequestEntityTooLarge (413) response from relay and log a debug message so that users can understand envelope size rejections.

Extracting the httpResponse handling as an extra method for reuse.

### Issues
* resolves: #1179
* resolves: GO-115


<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
