### PR TITLE
fix: ensure correct signal delivery on multi-client setups

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -523,21 +523,32 @@ func (scope *Scope) populateAttrs(attrs map[string]Attribute) {
 	// }
 }
 
-// resolveScopeAndTrace resolves scope, trace ID, and span ID from the given contexts.
+// hubFromContexts is a helper to return the first hub found in the given contexts.
+func hubFromContexts(ctxs ...context.Context) *Hub {
+	for _, ctx := range ctxs {
+		if ctx == nil {
+			continue
+		}
+		if hub := GetHubFromContext(ctx); hub != nil {
+			return hub
+		}
+	}
+	return nil
+}
+
+// resolveTrace resolves trace ID and span ID from the given scope and contexts.
 //
 // The resolution order follows a most-specific-to-least-specific pattern:
 //  1. Check for span directly in contexts (SpanFromContext) - this is the most specific
 //     source as it represents a span explicitly attached to the current operation's context
-//  2. Check for hub in contexts (GetHubFromContext) - provides access to scope which may
-//     contain a span, but this is less specific than a directly attached span
-//  3. Fall back to CurrentHub() - the global hub as a last resort
+//  2. Check scope's span - provides access to span set on the hub's scope
+//  3. Fall back to scope's propagation context trace ID
 //
 // This ordering ensures we always use the most contextually relevant tracing information.
 // For example, if a specific span is active for an operation, we use that span's trace/span IDs
 // rather than accidentally using a different span that might be set on the hub's scope.
-func resolveScopeAndTrace(ctxs ...context.Context) (scope *Scope, traceID TraceID, spanID SpanID) {
+func resolveTrace(scope *Scope, ctxs ...context.Context) (traceID TraceID, spanID SpanID) {
 	var span *Span
-	var hub *Hub
 
 	for _, ctx := range ctxs {
 		if ctx == nil {
@@ -548,19 +559,6 @@ func resolveScopeAndTrace(ctxs ...context.Context) (scope *Scope, traceID TraceI
 		}
 	}
 
-	for _, ctx := range ctxs {
-		if ctx == nil {
-			continue
-		}
-		if hub = GetHubFromContext(ctx); hub != nil {
-			break
-		}
-	}
-	if hub == nil {
-		hub = CurrentHub()
-	}
-
-	scope = hub.Scope()
 	if scope != nil {
 		scope.mu.RLock()
 		if span == nil {
@@ -575,5 +573,5 @@ func resolveScopeAndTrace(ctxs ...context.Context) (scope *Scope, traceID TraceI
 		scope.mu.RUnlock()
 	}
 
-	return scope, traceID, spanID
+	return traceID, spanID
 }


### PR DESCRIPTION
### Description
Previously logs and metrics were coupled with the sentry.client, this created these problems on multi client setups:
- when using `WithCtx` on multi client setups, if the passed context/hub was on a new client, the signal was captured on the old client (used on initialization)
- if `bindClient` was used on hub, the client which was set wasn't respected.
- the `resolveScopeAndTrace` was falling back to the `CurrentHub`. In multi client setups this means that the fallback hub would always be the one from the most recent client, since the `Init` method always binds the new client on the `CurrentHub`.

The  PR solves all issues by coupling logs and metrics with the `Hub` and not the `Client`. This way we always can fall back to the Hub provided on logger/metric init, rather than a client which may have been mutated with `bindClient` or the `CurrentHub` which would return the most recent client.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
