### PR TITLE
ref: Decouple propagator from span processor

### DIFF
--- a/otel/context.go
+++ b/otel/context.go
@@ -1,7 +1,0 @@
-package sentryotel
-
-// Context keys to be used with context.WithValue(...) and ctx.Value(...)
-type dynamicSamplingContextKey struct{}
-type sentryTraceHeaderContextKey struct{}
-type sentryTraceParentContextKey struct{}
-type baggageContextKey struct{}

--- a/otel/internal/common/context.go
+++ b/otel/internal/common/context.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"context"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
+)
+
+// Context key types for propagating Sentry trace data through context.
+type dynamicSamplingContextKey struct{}
+type sentryTraceHeaderContextKey struct{}
+type sentryTraceParentContextKey struct{}
+type baggageContextKey struct{}
+
+func DynamicSamplingContextFromContext(ctx context.Context) sentry.DynamicSamplingContext {
+	if dsc, ok := ctx.Value(dynamicSamplingContextKey{}).(sentry.DynamicSamplingContext); ok {
+		return dsc
+	}
+	return sentry.DynamicSamplingContext{}
+}
+
+func WithDynamicSamplingContext(ctx context.Context, dsc sentry.DynamicSamplingContext) context.Context {
+	return context.WithValue(ctx, dynamicSamplingContextKey{}, dsc)
+}
+
+func TraceHeaderFromContext(ctx context.Context) string {
+	if header, ok := ctx.Value(sentryTraceHeaderContextKey{}).(string); ok {
+		return header
+	}
+	return ""
+}
+
+func WithSentryTraceHeader(ctx context.Context, header string) context.Context {
+	return context.WithValue(ctx, sentryTraceHeaderContextKey{}, header)
+}
+
+func TraceParentContextFromContext(ctx context.Context) sentry.TraceParentContext {
+	if tpc, ok := ctx.Value(sentryTraceParentContextKey{}).(sentry.TraceParentContext); ok {
+		return tpc
+	}
+	return sentry.TraceParentContext{Sampled: sentry.SampledUndefined}
+}
+
+func WithTraceParentContext(ctx context.Context, tpc sentry.TraceParentContext) context.Context {
+	return context.WithValue(ctx, sentryTraceParentContextKey{}, tpc)
+}
+
+func BaggageFromContext(ctx context.Context) baggage.Baggage {
+	if b, ok := ctx.Value(baggageContextKey{}).(baggage.Baggage); ok {
+		return b
+	}
+	return baggage.Baggage{}
+}
+
+func WithBaggage(ctx context.Context, b baggage.Baggage) context.Context {
+	return context.WithValue(ctx, baggageContextKey{}, b)
+}

--- a/otel/internal/common/context_test.go
+++ b/otel/internal/common/context_test.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
+	"github.com/getsentry/sentry-go/internal/testutils"
+)
+
+var assertEqual = testutils.AssertEqual
+
+func TestDynamicSamplingContextFromContext(t *testing.T) {
+	t.Run("returns zero value when not set", func(t *testing.T) {
+		dsc := DynamicSamplingContextFromContext(context.Background())
+		assertEqual(t, dsc.HasEntries(), false)
+	})
+
+	t.Run("round-trips correctly", func(t *testing.T) {
+		dsc := sentry.DynamicSamplingContext{
+			Entries: map[string]string{"trace_id": "abc123", "public_key": "key"},
+			Frozen:  true,
+		}
+		ctx := WithDynamicSamplingContext(context.Background(), dsc)
+		got := DynamicSamplingContextFromContext(ctx)
+		assertEqual(t, got, dsc)
+	})
+}
+
+func TestSentryTraceHeaderFromContext(t *testing.T) {
+	t.Run("returns empty string when not set", func(t *testing.T) {
+		header := TraceHeaderFromContext(context.Background())
+		assertEqual(t, header, "")
+	})
+
+	t.Run("round-trips correctly", func(t *testing.T) {
+		ctx := WithSentryTraceHeader(context.Background(), "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1")
+		got := TraceHeaderFromContext(ctx)
+		assertEqual(t, got, "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1")
+	})
+}
+
+func TestTraceParentContextFromContext(t *testing.T) {
+	t.Run("returns undefined sampled when not set", func(t *testing.T) {
+		tpc := TraceParentContextFromContext(context.Background())
+		assertEqual(t, tpc.Sampled, sentry.SampledUndefined)
+	})
+
+	t.Run("round-trips correctly", func(t *testing.T) {
+		tpc := sentry.TraceParentContext{Sampled: sentry.SampledTrue}
+		ctx := WithTraceParentContext(context.Background(), tpc)
+		got := TraceParentContextFromContext(ctx)
+		assertEqual(t, got.Sampled, sentry.SampledTrue)
+	})
+}
+
+func TestBaggageFromContext(t *testing.T) {
+	t.Run("returns empty baggage when not set", func(t *testing.T) {
+		b := BaggageFromContext(context.Background())
+		assertEqual(t, b.Len(), 0)
+	})
+
+	t.Run("round-trips correctly", func(t *testing.T) {
+		b, _ := baggage.Parse("key1=value1,key2=value2")
+		ctx := WithBaggage(context.Background(), b)
+		got := BaggageFromContext(ctx)
+		assertEqual(t, got.Len(), 2)
+	})
+}

--- a/otel/internal/common/dsc_source.go
+++ b/otel/internal/common/dsc_source.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"github.com/getsentry/sentry-go"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type DSCSource interface {
+	GetDSC(trace.TraceID, trace.SpanID) (sentry.DynamicSamplingContext, bool)
+}
+
+type noopDSCSource struct{}
+
+func (n *noopDSCSource) GetDSC(trace trace.TraceID, span trace.SpanID) (sentry.DynamicSamplingContext, bool) {
+	return sentry.DynamicSamplingContext{}, false
+}

--- a/otel/internal/common/propagator.go
+++ b/otel/internal/common/propagator.go
@@ -1,4 +1,4 @@
-package sentryotel
+package common
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/internal/otel/baggage"
-	"github.com/getsentry/sentry-go/otel/internal/common"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -22,14 +21,14 @@ type Option func(*sentryPropagator)
 // This is used for configuring the propagator to work with either OTLP or the span processor.
 //
 // The propagator fallbacks to a noop implementation if not provided.
-func WithDSCSource(src common.DSCSource) Option {
+func WithDSCSource(src DSCSource) Option {
 	return func(p *sentryPropagator) {
 		p.dscSource = src
 	}
 }
 
 type sentryPropagator struct {
-	dscSource common.DSCSource
+	dscSource DSCSource
 }
 
 // NewSentryPropagator creates a new Sentry propagator.
@@ -41,7 +40,7 @@ type sentryPropagator struct {
 // With WithDSCSource, it also emits baggage at the trace origin by looking up
 // DSC from the provided source (e.g. the bridge span map).
 func NewSentryPropagator(opts ...Option) propagation.TextMapPropagator {
-	p := &sentryPropagator{dscSource: &sentrySpanMap}
+	p := &sentryPropagator{dscSource: &noopDSCSource{}}
 	for _, o := range opts {
 		o(p)
 	}
@@ -55,10 +54,10 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	spanContext := trace.SpanContextFromContext(ctx)
 	sampled := spanContext.IsSampled()
 	if !spanContext.IsValid() {
-		if h := common.TraceHeaderFromContext(ctx); h != "" {
+		if h := TraceHeaderFromContext(ctx); h != "" {
 			carrier.Set(sentry.SentryTraceHeader, h)
 		}
-		if b := common.BaggageFromContext(ctx); b.Len() > 0 {
+		if b := BaggageFromContext(ctx); b.Len() > 0 {
 			carrier.Set(sentry.SentryBaggageHeader, b.String())
 		}
 		return
@@ -72,7 +71,7 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	// 3. no trace to propagate - skip baggage
 	dsc, _ := p.dscSource.GetDSC(spanContext.TraceID(), spanContext.SpanID())
 	if !dsc.HasEntries() {
-		dsc = common.DynamicSamplingContextFromContext(ctx)
+		dsc = DynamicSamplingContextFromContext(ctx)
 	}
 	// try and ovewrite the sampling decision from the dsc before setting the trace
 	if s, err := strconv.ParseBool(dsc.Entries["sampled"]); err == nil {
@@ -83,7 +82,7 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	if !dsc.HasEntries() {
 		return
 	}
-	b := mergeDSCToBaggage(dsc, common.BaggageFromContext(ctx))
+	b := mergeDSCToBaggage(dsc, BaggageFromContext(ctx))
 	if b.Len() > 0 {
 		carrier.Set(sentry.SentryBaggageHeader, b.String())
 	}
@@ -95,11 +94,11 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
 	sentryTraceHeader := carrier.Get(sentry.SentryTraceHeader)
 	if sentryTraceHeader != "" {
-		ctx = common.WithSentryTraceHeader(ctx, sentryTraceHeader)
+		ctx = WithSentryTraceHeader(ctx, sentryTraceHeader)
 		if traceParentContext, valid := sentry.ParseTraceParentContext([]byte(sentryTraceHeader)); valid {
 			// Save traceParentContext because we'll at least need to know the original "sampled"
 			// value in the span processor.
-			ctx = common.WithTraceParentContext(ctx, traceParentContext)
+			ctx = WithTraceParentContext(ctx, traceParentContext)
 
 			spanContextConfig := trace.SpanContextConfig{
 				TraceID:    trace.TraceID(traceParentContext.TraceID),
@@ -116,7 +115,7 @@ func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextM
 		// Preserve the original baggage
 		parsedBaggage, err := baggage.Parse(baggageHeader)
 		if err == nil {
-			ctx = common.WithBaggage(ctx, parsedBaggage)
+			ctx = WithBaggage(ctx, parsedBaggage)
 		}
 	}
 
@@ -131,7 +130,7 @@ func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextM
 		dynamicSamplingContext = sentry.DynamicSamplingContext{Frozen: false}
 	}
 
-	return common.WithDynamicSamplingContext(ctx, dynamicSamplingContext)
+	return WithDynamicSamplingContext(ctx, dynamicSamplingContext)
 }
 
 // Fields returns a list of fields that will be used by the propagator.

--- a/otel/internal/common/propagator_test.go
+++ b/otel/internal/common/propagator_test.go
@@ -1,0 +1,302 @@
+package common
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/otel/baggage"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestInject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		dscSource   DSCSource
+		spanContext *trace.SpanContext
+		ctxDSC      *sentry.DynamicSamplingContext
+		ctxBaggage  string
+		ctxTrace    string
+		wantTrace   string
+		wantBaggage map[string]string
+	}{
+		{
+			name:      "no valid span and nothing on context emits nothing",
+			wantTrace: "",
+		},
+		{
+			name:       "no valid span passes through incoming sentry-trace and baggage",
+			ctxTrace:   "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1",
+			ctxBaggage: "sentry-trace_id=abc,othervendor=val",
+			wantTrace:  "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1",
+			wantBaggage: map[string]string{
+				"sentry-trace_id": "abc",
+				"othervendor":     "val",
+			},
+		},
+		{
+			name:        "OTLP origin sampled emits only sentry-trace",
+			spanContext: sentry.Pointer(makeSpanContext(true)),
+			wantTrace:   "0102030405060708090a0b0c0d0e0f10-0102030405060708-1",
+		},
+		{
+			name:        "OTLP origin not sampled emits sentry-trace with 0",
+			spanContext: sentry.Pointer(makeSpanContext(false)),
+			wantTrace:   "0102030405060708090a0b0c0d0e0f10-0102030405060708-0",
+		},
+		{
+			name:        "downstream context DSC is forwarded as baggage",
+			spanContext: sentry.Pointer(makeSpanContext(true)),
+			ctxDSC: &sentry.DynamicSamplingContext{
+				Entries: map[string]string{
+					"trace_id":   "d4cda95b652f4a1592b449d5929fda1b",
+					"public_key": "abc",
+					"release":    "1.0",
+					"sampled":    "true",
+				},
+				Frozen: true,
+			},
+			wantTrace: "0102030405060708090a0b0c0d0e0f10-0102030405060708-1",
+			wantBaggage: map[string]string{
+				"sentry-trace_id":   "d4cda95b652f4a1592b449d5929fda1b",
+				"sentry-public_key": "abc",
+				"sentry-release":    "1.0",
+				"sentry-sampled":    "true",
+			},
+		},
+		{
+			name:        "DSC source takes priority over context DSC",
+			spanContext: sentry.Pointer(makeSpanContext(true)),
+			dscSource: &mockDSCSource{
+				traceID: testTraceID,
+				spanID:  testSpanID,
+				dsc: sentry.DynamicSamplingContext{
+					Entries: map[string]string{"trace_id": "fromspanmap", "sample_rate": "0.5", "sampled": "true"},
+					Frozen:  true,
+				},
+			},
+			ctxDSC: &sentry.DynamicSamplingContext{
+				Entries: map[string]string{"trace_id": "fromcontext"},
+				Frozen:  true,
+			},
+			wantTrace: "0102030405060708090a0b0c0d0e0f10-0102030405060708-1",
+			wantBaggage: map[string]string{
+				"sentry-trace_id":    "fromspanmap",
+				"sentry-sample_rate": "0.5",
+				"sentry-sampled":     "true",
+			},
+		},
+		{
+			name:        "DSC sampled=false overrides OTel sampled flag in sentry-trace",
+			spanContext: sentry.Pointer(makeSpanContext(true)),
+			dscSource: &mockDSCSource{
+				traceID: testTraceID,
+				spanID:  testSpanID,
+				dsc: sentry.DynamicSamplingContext{
+					Entries: map[string]string{"sampled": "false", "trace_id": "abc"},
+					Frozen:  true,
+				},
+			},
+			wantTrace: "0102030405060708090a0b0c0d0e0f10-0102030405060708-0",
+			wantBaggage: map[string]string{
+				"sentry-sampled":  "false",
+				"sentry-trace_id": "abc",
+			},
+		},
+		{
+			name:        "DSC source miss falls back to context DSC",
+			spanContext: sentry.Pointer(makeSpanContext(true)),
+			dscSource: &mockDSCSource{
+				traceID: trace.TraceID{0xFF},
+				spanID:  trace.SpanID{0xFF},
+			},
+			ctxDSC: &sentry.DynamicSamplingContext{
+				Entries: map[string]string{"trace_id": "fromcontext", "release": "2.0"},
+				Frozen:  true,
+			},
+			wantTrace: "0102030405060708090a0b0c0d0e0f10-0102030405060708-1",
+			wantBaggage: map[string]string{
+				"sentry-trace_id": "fromcontext",
+				"sentry-release":  "2.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts []Option
+			if tt.dscSource != nil {
+				opts = append(opts, WithDSCSource(tt.dscSource))
+			}
+			prop := NewSentryPropagator(opts...)
+
+			ctx := context.Background()
+			if tt.spanContext != nil {
+				ctx = trace.ContextWithSpanContext(ctx, *tt.spanContext)
+			}
+			if tt.ctxTrace != "" {
+				ctx = WithSentryTraceHeader(ctx, tt.ctxTrace)
+			}
+			if tt.ctxBaggage != "" {
+				parsed, _ := baggage.Parse(tt.ctxBaggage)
+				ctx = WithBaggage(ctx, parsed)
+			}
+			if tt.ctxDSC != nil {
+				ctx = WithDynamicSamplingContext(ctx, *tt.ctxDSC)
+			}
+
+			carrier := propagation.MapCarrier{}
+			prop.Inject(ctx, carrier)
+
+			assertEqual(t, carrier.Get(sentry.SentryTraceHeader), tt.wantTrace)
+			gotBaggage := parseBaggageToMap(carrier.Get(sentry.SentryBaggageHeader))
+			if diff := cmp.Diff(tt.wantBaggage, gotBaggage, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("baggage mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		sentryTrace    string
+		baggageHeader  string
+		wantRemote     bool
+		wantTraceID    string
+		wantSpanID     string
+		wantDSCFrozen  bool
+		wantDSCEntries map[string]string
+		wantBaggageLen int
+	}{
+		{
+			name:           "empty headers set nothing",
+			wantDSCFrozen:  false,
+			wantDSCEntries: nil,
+		},
+		{
+			name:          "valid sentry-trace and baggage",
+			sentryTrace:   "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1",
+			baggageHeader: "sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-public_key=abc,sentry-release=1.0,othervendor=bla",
+			wantRemote:    true,
+			wantTraceID:   "d4cda95b652f4a1592b449d5929fda1b",
+			wantSpanID:    "6e0c63257de34c92",
+			wantDSCFrozen: true,
+			wantDSCEntries: map[string]string{
+				"trace_id":   "d4cda95b652f4a1592b449d5929fda1b",
+				"public_key": "abc",
+				"release":    "1.0",
+			},
+			wantBaggageLen: 4,
+		},
+		{
+			name:           "only sentry-trace without baggage creates unfrozen DSC",
+			sentryTrace:    "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-0",
+			wantRemote:     true,
+			wantTraceID:    "d4cda95b652f4a1592b449d5929fda1b",
+			wantSpanID:     "6e0c63257de34c92",
+			wantDSCFrozen:  false,
+			wantDSCEntries: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prop := NewSentryPropagator()
+			carrier := propagation.MapCarrier{}
+			if tt.sentryTrace != "" {
+				carrier.Set(sentry.SentryTraceHeader, tt.sentryTrace)
+			}
+			if tt.baggageHeader != "" {
+				carrier.Set(sentry.SentryBaggageHeader, tt.baggageHeader)
+			}
+
+			ctx := prop.Extract(context.Background(), carrier)
+
+			assertEqual(t, TraceHeaderFromContext(ctx), tt.sentryTrace)
+
+			sc := trace.SpanContextFromContext(ctx)
+			if tt.wantRemote {
+				assertEqual(t, sc.IsRemote(), true)
+				assertEqual(t, sc.TraceID().String(), tt.wantTraceID)
+				assertEqual(t, sc.SpanID().String(), tt.wantSpanID)
+			} else {
+				assertEqual(t, sc.IsValid(), false)
+			}
+
+			dsc := DynamicSamplingContextFromContext(ctx)
+			assertEqual(t, dsc.Frozen, tt.wantDSCFrozen)
+			if diff := cmp.Diff(tt.wantDSCEntries, dsc.Entries, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("DSC entries mismatch (-want +got):\n%s", diff)
+			}
+
+			b := BaggageFromContext(ctx)
+			assertEqual(t, b.Len(), tt.wantBaggageLen)
+		})
+	}
+}
+
+func TestFields(t *testing.T) {
+	t.Parallel()
+
+	fields := NewSentryPropagator().Fields()
+	assertEqual(t, len(fields), 2)
+	assertEqual(t, fields[0], sentry.SentryTraceHeader)
+	assertEqual(t, fields[1], sentry.SentryBaggageHeader)
+}
+
+// mockDSCSource returns a fixed DSC for a matching trace/span pair.
+type mockDSCSource struct {
+	traceID trace.TraceID
+	spanID  trace.SpanID
+	dsc     sentry.DynamicSamplingContext
+}
+
+func (f *mockDSCSource) GetDSC(t trace.TraceID, s trace.SpanID) (sentry.DynamicSamplingContext, bool) {
+	if f != nil && t == f.traceID && s == f.spanID {
+		return f.dsc, true
+	}
+	return sentry.DynamicSamplingContext{}, false
+}
+
+var (
+	testTraceID = trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	testSpanID  = trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+)
+
+func makeSpanContext(sampled bool) trace.SpanContext {
+	flags := trace.TraceFlags(0)
+	if sampled {
+		flags = trace.FlagsSampled
+	}
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    testTraceID,
+		SpanID:     testSpanID,
+		TraceFlags: flags,
+	})
+}
+
+func parseBaggageToMap(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+	m := make(map[string]string)
+	for part := range strings.SplitSeq(raw, ",") {
+		if k, v, ok := strings.Cut(part, "="); ok {
+			m[k] = v
+		}
+	}
+	return m
+}

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -2,17 +2,50 @@ package sentryotel
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/internal/otel/baggage"
+	"github.com/getsentry/sentry-go/otel/internal/common"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
-type sentryPropagator struct{}
+const sentryPrefix = "sentry-"
 
-func NewSentryPropagator() propagation.TextMapPropagator {
-	return &sentryPropagator{}
+// Option applies configuration to the propagator.
+type Option func(*sentryPropagator)
+
+// WithDSCSource configures the propagator to look up the DSC from the given source.
+// This is used for configuring the propagator to work with either OTLP or the span processor.
+//
+// The propagator fallbacks to a noop implementation if not provided.
+func WithDSCSource(src common.DSCSource) Option {
+	return func(p *sentryPropagator) {
+		p.dscSource = src
+	}
+}
+
+type sentryPropagator struct {
+	dscSource common.DSCSource
+}
+
+// NewSentryPropagator creates a new Sentry propagator.
+//
+// Without options, it behaves as a lightweight propagator suitable for OTLP:
+// it generates sentry-trace from the OTel SpanContext and only forwards
+// baggage that was received from upstream (Extract).
+//
+// With WithDSCSource, it also emits baggage at the trace origin by looking up
+// DSC from the provided source (e.g. the bridge span map).
+func NewSentryPropagator(opts ...Option) propagation.TextMapPropagator {
+	p := &sentryPropagator{dscSource: &sentrySpanMap}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
 }
 
 // Inject sets Sentry-related values from the Context into the carrier.
@@ -20,52 +53,39 @@ func NewSentryPropagator() propagation.TextMapPropagator {
 // https://opentelemetry.io/docs/reference/specification/context/api-propagators/#inject
 func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
 	spanContext := trace.SpanContextFromContext(ctx)
-
-	var sentrySpan *sentry.Span
-
-	if spanContext.IsValid() {
-		sentrySpan, _ = sentrySpanMap.Get(spanContext.TraceID(), spanContext.SpanID())
-	} else {
-		sentrySpan = nil
-	}
-
-	// Propagate sentry-trace header
-	if sentrySpan == nil {
-		// No span => propagate the incoming sentry-trace header, if exists
-		sentryTraceHeader, _ := ctx.Value(sentryTraceHeaderContextKey{}).(string)
-		if sentryTraceHeader != "" {
-			carrier.Set(sentry.SentryTraceHeader, sentryTraceHeader)
+	sampled := spanContext.IsSampled()
+	if !spanContext.IsValid() {
+		if h := common.TraceHeaderFromContext(ctx); h != "" {
+			carrier.Set(sentry.SentryTraceHeader, h)
 		}
-	} else {
-		// Sentry span exists => generate "sentry-trace" from it
-		carrier.Set(sentry.SentryTraceHeader, sentrySpan.ToSentryTrace())
-	}
-
-	// Propagate baggage header
-	sentryBaggageStr := ""
-	if sentrySpan != nil {
-		sentryBaggageStr = sentrySpan.GetTransaction().ToBaggage()
-	}
-	// FIXME(anton): We're basically reparsing the header again, because in sentry-go
-	// we currently don't expose a method to get only DSC or its baggage (only a string).
-	// This is not optimal and we should consider other approaches.
-	sentryBaggage, _ := baggage.Parse(sentryBaggageStr)
-
-	// Merge the baggage values
-	finalBaggage, baggageOk := ctx.Value(baggageContextKey{}).(baggage.Baggage)
-	if !baggageOk {
-		finalBaggage = baggage.Baggage{}
-	}
-	for _, member := range sentryBaggage.Members() {
-		var err error
-		finalBaggage, err = finalBaggage.SetMember(member)
-		if err != nil {
-			continue
+		if b := common.BaggageFromContext(ctx); b.Len() > 0 {
+			carrier.Set(sentry.SentryBaggageHeader, b.String())
 		}
+		return
 	}
 
-	if finalBaggage.Len() > 0 {
-		carrier.Set(sentry.SentryBaggageHeader, finalBaggage.String())
+	// dscSource should have priority here. It is used for specifying a more "complete" DSC to get.
+	// when using the otel span processor, the DSC originates from the span map and includes span specific info.
+	// Then the priority should be:
+	// 1. span map (more specific)
+	// 2. upstream propagation for otlp
+	// 3. no trace to propagate - skip baggage
+	dsc, _ := p.dscSource.GetDSC(spanContext.TraceID(), spanContext.SpanID())
+	if !dsc.HasEntries() {
+		dsc = common.DynamicSamplingContextFromContext(ctx)
+	}
+	// try and ovewrite the sampling decision from the dsc before setting the trace
+	if s, err := strconv.ParseBool(dsc.Entries["sampled"]); err == nil {
+		sampled = s
+	}
+	carrier.Set(sentry.SentryTraceHeader, formatSentryTrace(spanContext.TraceID(), spanContext.SpanID(), sampled))
+
+	if !dsc.HasEntries() {
+		return
+	}
+	b := mergeDSCToBaggage(dsc, common.BaggageFromContext(ctx))
+	if b.Len() > 0 {
+		carrier.Set(sentry.SentryBaggageHeader, b.String())
 	}
 }
 
@@ -74,13 +94,12 @@ func (p sentryPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 // https://opentelemetry.io/docs/reference/specification/context/api-propagators/#extract
 func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
 	sentryTraceHeader := carrier.Get(sentry.SentryTraceHeader)
-
 	if sentryTraceHeader != "" {
-		ctx = context.WithValue(ctx, sentryTraceHeaderContextKey{}, sentryTraceHeader)
+		ctx = common.WithSentryTraceHeader(ctx, sentryTraceHeader)
 		if traceParentContext, valid := sentry.ParseTraceParentContext([]byte(sentryTraceHeader)); valid {
 			// Save traceParentContext because we'll at least need to know the original "sampled"
 			// value in the span processor.
-			ctx = context.WithValue(ctx, sentryTraceParentContextKey{}, traceParentContext)
+			ctx = common.WithTraceParentContext(ctx, traceParentContext)
 
 			spanContextConfig := trace.SpanContextConfig{
 				TraceID:    trace.TraceID(traceParentContext.TraceID),
@@ -97,7 +116,7 @@ func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextM
 		// Preserve the original baggage
 		parsedBaggage, err := baggage.Parse(baggageHeader)
 		if err == nil {
-			ctx = context.WithValue(ctx, baggageContextKey{}, parsedBaggage)
+			ctx = common.WithBaggage(ctx, parsedBaggage)
 		}
 	}
 
@@ -112,8 +131,7 @@ func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextM
 		dynamicSamplingContext = sentry.DynamicSamplingContext{Frozen: false}
 	}
 
-	ctx = context.WithValue(ctx, dynamicSamplingContextKey{}, dynamicSamplingContext)
-	return ctx
+	return common.WithDynamicSamplingContext(ctx, dynamicSamplingContext)
 }
 
 // Fields returns a list of fields that will be used by the propagator.
@@ -121,4 +139,28 @@ func (p sentryPropagator) Extract(ctx context.Context, carrier propagation.TextM
 // https://opentelemetry.io/docs/reference/specification/context/api-propagators/#fields
 func (p sentryPropagator) Fields() []string {
 	return []string{sentry.SentryTraceHeader, sentry.SentryBaggageHeader}
+}
+
+func mergeDSCToBaggage(dsc sentry.DynamicSamplingContext, base baggage.Baggage) baggage.Baggage {
+	for k, v := range dsc.Entries {
+		member, err := baggage.NewMember(sentryPrefix+k, v)
+		if err != nil {
+			continue
+		}
+		if updated, err := base.SetMember(member); err == nil {
+			base = updated
+		}
+	}
+	return base
+}
+
+func formatSentryTrace(trace trace.TraceID, span trace.SpanID, sampled bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s-%s", trace, span)
+	if sampled {
+		b.WriteString("-1")
+	} else {
+		b.WriteString("-0")
+	}
+	return b.String()
 }

--- a/otel/propagator.go
+++ b/otel/propagator.go
@@ -1,0 +1,12 @@
+package sentryotel
+
+import (
+	"github.com/getsentry/sentry-go/otel/internal/common"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func NewSentryPropagator() propagation.TextMapPropagator {
+	return common.NewSentryPropagator(
+		common.WithDSCSource(&sentrySpanMap),
+	)
+}

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -59,7 +59,7 @@ func createTransactionAndMaybeSpan(transactionContext transactionTestContext, wi
 func TestNewSentryPropagator(t *testing.T) {
 	propagator := NewSentryPropagator()
 
-	if _, valid := propagator.(*sentryPropagator); !valid {
+	if _, valid := propagator.(propagation.TextMapPropagator); !valid {
 		t.Errorf(
 			"Invalid type returned by the propagator constructor: %#v\n",
 			propagator,

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/internal/otel/baggage"
+	"github.com/getsentry/sentry-go/otel/internal/common"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -89,11 +90,7 @@ func TestInjectDoesNothingOnEmptyContext(t *testing.T) {
 
 func TestInjectUsesSentryTraceOnEmptySpan(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
-	ctx := context.WithValue(
-		context.Background(),
-		sentryTraceHeaderContextKey{},
-		"d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1",
-	)
+	ctx := common.WithSentryTraceHeader(context.Background(), "d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1")
 
 	propagator.Inject(ctx, carrier)
 
@@ -106,7 +103,7 @@ func TestInjectUsesSentryTraceOnEmptySpan(t *testing.T) {
 func TestInjectUsesBaggageOnEmptySpan(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 	bag, _ := baggage.Parse("key1=value1;value2, key2=value2")
-	ctx := context.WithValue(context.Background(), baggageContextKey{}, bag)
+	ctx := common.WithBaggage(context.Background(), bag)
 
 	propagator.Inject(ctx, carrier)
 
@@ -207,7 +204,7 @@ func TestExtractDoesNotChangeContextWithEmptyHeaders(t *testing.T) {
 	ctx := propagator.Extract(context.Background(), carrier)
 
 	assertEqual(t,
-		ctx.Value(dynamicSamplingContextKey{}),
+		common.DynamicSamplingContextFromContext(ctx),
 		sentry.DynamicSamplingContext{Entries: map[string]string{}, Frozen: false},
 	)
 }
@@ -220,7 +217,7 @@ func TestExtractSetsUndefinedDynamicSamplingContext(t *testing.T) {
 	ctx := propagator.Extract(context.Background(), carrier)
 
 	assertEqual(t,
-		ctx.Value(dynamicSamplingContextKey{}),
+		common.DynamicSamplingContextFromContext(ctx),
 		sentry.DynamicSamplingContext{Entries: map[string]string{}, Frozen: false},
 	)
 }
@@ -277,7 +274,7 @@ func TestExtractSetsDefinedDynamicSamplingContext(t *testing.T) {
 	ctx := propagator.Extract(context.Background(), carrier)
 
 	assertEqual(t,
-		ctx.Value(dynamicSamplingContextKey{}),
+		common.DynamicSamplingContextFromContext(ctx),
 		sentry.DynamicSamplingContext{
 			Entries: map[string]string{
 				"environment": "production",

--- a/otel/span_map.go
+++ b/otel/span_map.go
@@ -87,6 +87,26 @@ func (ssm *SentrySpanMap) MarkFinished(spanID otelTrace.SpanID, traceID otelTrac
 	}
 }
 
+// GetDSC looks up the transaction for the given trace and returns a frozen DSC.
+func (ssm *SentrySpanMap) GetDSC(traceID otelTrace.TraceID, spanID otelTrace.SpanID) (sentry.DynamicSamplingContext, bool) {
+	span, ok := ssm.Get(traceID, spanID)
+	if !ok {
+		return sentry.DynamicSamplingContext{}, false
+	}
+	txn := span.GetTransaction()
+	if txn == nil {
+		return sentry.DynamicSamplingContext{}, false
+	}
+	dsc := sentry.DynamicSamplingContextFromTransaction(txn)
+	if !dsc.HasEntries() {
+		return sentry.DynamicSamplingContext{}, false
+	}
+	// DynamicSamplingContextFromTransaction returns a frozen dsc, we need to separately
+	// freeze it for the transaction itself.
+	txn.SetDynamicSamplingContext(dsc)
+	return dsc, true
+}
+
 // Clear removes all spans stored on the map.
 func (ssm *SentrySpanMap) Clear() {
 	ssm.transactions.Clear()

--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/otel/internal/common"
 	"github.com/getsentry/sentry-go/otel/internal/utils"
 	"go.opentelemetry.io/otel/attribute"
 	otelSdkTrace "go.opentelemetry.io/otel/sdk/trace"
@@ -51,7 +52,7 @@ func (ssp *sentrySpanProcessor) OnStart(parent context.Context, s otelSdkTrace.R
 	transaction.TraceID = sentry.TraceID(otelTraceID)
 	transaction.ParentSpanID = sentry.SpanID(otelParentSpanID)
 	transaction.StartTime = s.StartTime()
-	if dsc, valid := parent.Value(dynamicSamplingContextKey{}).(sentry.DynamicSamplingContext); valid {
+	if dsc := common.DynamicSamplingContextFromContext(parent); dsc.HasEntries() {
 		transaction.SetDynamicSamplingContext(dsc)
 	}
 	sentrySpanMap.Set(otelSpanID, transaction, otelTraceID)
@@ -107,11 +108,7 @@ func flushSpanProcessor(ctx context.Context) error {
 }
 
 func getTraceParentContext(ctx context.Context) sentry.TraceParentContext {
-	traceParentContext, ok := ctx.Value(sentryTraceParentContextKey{}).(sentry.TraceParentContext)
-	if !ok {
-		traceParentContext.Sampled = sentry.SampledUndefined
-	}
-	return traceParentContext
+	return common.TraceParentContextFromContext(ctx)
 }
 
 func updateTransactionWithOtelData(transaction *sentry.Span, s otelSdkTrace.ReadOnlySpan) {

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/getsentry/sentry-go/otel/internal/common"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	otelSdkTrace "go.opentelemetry.io/otel/sdk/trace"
@@ -130,9 +131,8 @@ func TestOnStartWithTraceParentContext(t *testing.T) {
 	_, _, tracer := setupSpanProcessorTest()
 
 	// Sentry context
-	ctx := context.WithValue(
+	ctx := common.WithTraceParentContext(
 		emptyContextWithSentry(),
-		sentryTraceParentContextKey{},
 		sentry.TraceParentContext{
 			TraceID:      TraceIDFromHex("d4cda95b652f4a1592b449d5929fda1b"),
 			ParentSpanID: SpanIDFromHex("6e0c63257de34c92"),
@@ -143,7 +143,7 @@ func TestOnStartWithTraceParentContext(t *testing.T) {
 		Frozen:  true,
 		Entries: map[string]string{"environment": "dev"},
 	}
-	ctx = context.WithValue(ctx, dynamicSamplingContextKey{}, dsc)
+	ctx = common.WithDynamicSamplingContext(ctx, dsc)
 	// Otel span context
 	ctx = trace.ContextWithSpanContext(
 		ctx,

--- a/tracing.go
+++ b/tracing.go
@@ -310,8 +310,6 @@ func (s *Span) GetTransaction() *Span {
 // Use this function to propagate the TraceParentContext to a downstream SDK,
 // either as the value of the "sentry-trace" HTTP header, or as an html "sentry-trace" meta tag.
 func (s *Span) ToSentryTrace() string {
-	// TODO(tracing): add instrumentation for outgoing HTTP requests using
-	// ToSentryTrace.
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s-%s", s.TraceID.Hex(), s.SpanID.Hex())
 	switch s.Sampled {


### PR DESCRIPTION
### Description

This changes the current behavior of the sentry otel propagator to work without needing the span processor. The change is influenced by the otlp integration also needing a propagator, and since it doesn't make sense to couple the otlp integration with the span_map, this extracts and refines the propagator functionality to:
- receive a `WithDSCSource` to override fetching the dynamic sampling context. When using alongside span processor the propagator should inject the span map, so that it can fetch the DSC from the span itself.
- for otlp we only propagate the baggage as is in case we received it, or skip 
- the extract stays as is

The PR also moves the propagator under `otel/internal/common` so that it can be re-used by the PR that will implement the otlp integration under `otel/otlp`.

> [!NOTE]
> Tried to split the changes into first refactoring the propagator.go in-place and then move it under `common`, but the diff still shows it as a separate file. For easier review, it's probably better to have a look at the individual commits.

### Issues

* resolves: #1221 
* resolves: GO-126

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
