### PR TITLE
feat: add IsSensitiveHeader to scrub PII

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -247,39 +247,6 @@ type Request struct {
 	Env         map[string]string `json:"env,omitempty"`
 }
 
-var sensitiveHeaders = map[string]struct{}{
-	"_csrf":               {},
-	"_csrf_token":         {},
-	"_session":            {},
-	"_xsrf":               {},
-	"Api-Key":             {},
-	"Apikey":              {},
-	"Auth":                {},
-	"Authorization":       {},
-	"Cookie":              {},
-	"Credentials":         {},
-	"Csrf":                {},
-	"Csrf-Token":          {},
-	"Csrftoken":           {},
-	"Ip-Address":          {},
-	"Passwd":              {},
-	"Password":            {},
-	"Private-Key":         {},
-	"Privatekey":          {},
-	"Proxy-Authorization": {},
-	"Remote-Addr":         {},
-	"Secret":              {},
-	"Session":             {},
-	"Sessionid":           {},
-	"Token":               {},
-	"User-Session":        {},
-	"X-Api-Key":           {},
-	"X-Csrftoken":         {},
-	"X-Forwarded-For":     {},
-	"X-Real-Ip":           {},
-	"XSRF-TOKEN":          {},
-}
-
 // NewRequest returns a new Sentry Request from the given http.Request.
 //
 // NewRequest avoids operations that depend on network access. In particular, it
@@ -312,7 +279,7 @@ func NewRequest(r *http.Request) *Request {
 		}
 	} else {
 		for k, v := range r.Header {
-			if _, ok := sensitiveHeaders[k]; !ok {
+			if !IsSensitiveHeader(k) {
 				headers[k] = strings.Join(v, ",")
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -111,6 +111,45 @@ func Pointer[T any](v T) *T {
 	return &v
 }
 
+var sensitiveHeaders = map[string]struct{}{
+	"_csrf":               {},
+	"_csrf_token":         {},
+	"_session":            {},
+	"_xsrf":               {},
+	"api-key":             {},
+	"apikey":              {},
+	"auth":                {},
+	"authorization":       {},
+	"cookie":              {},
+	"credentials":         {},
+	"csrf":                {},
+	"csrf-token":          {},
+	"csrftoken":           {},
+	"ip-address":          {},
+	"passwd":              {},
+	"password":            {},
+	"private-key":         {},
+	"privatekey":          {},
+	"proxy-authorization": {},
+	"remote-addr":         {},
+	"secret":              {},
+	"session":             {},
+	"sessionid":           {},
+	"token":               {},
+	"user-session":        {},
+	"x-api-key":           {},
+	"x-csrftoken":         {},
+	"x-forwarded-for":     {},
+	"x-real-ip":           {},
+	"xsrf-token":          {},
+}
+
+// IsSensitiveHeader reports whether a header or metadata key should be treated as sensitive.
+func IsSensitiveHeader(key string) bool {
+	_, ok := sensitiveHeaders[strings.ToLower(key)]
+	return ok
+}
+
 // eventIdentifier returns a human-readable identifier for the event to be used in log messages.
 // Format: "<description> [<event-id>]".
 func eventIdentifier(event *Event) string {


### PR DESCRIPTION
### Description
This PR creates and exports the IsSensitiveHeader helper for re-use to scrub pii data in integrations. 

### Changelog Entry
- Add IsSensitiveHeader helper to easily distinguish which headers to scrub for PII.
 
### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)

-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
