### PR TITLE
test: add serialization panic reproduction

### DIFF
--- a/telemetry_processor_race_test.go
+++ b/telemetry_processor_race_test.go
@@ -1,0 +1,82 @@
+package sentry
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go/internal/protocol"
+	"github.com/getsentry/sentry-go/internal/ratelimit"
+	"github.com/getsentry/sentry-go/internal/telemetry"
+	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/getsentry/sentry-go/report"
+)
+
+// This race is between json.Marshal on the scheduler goroutine and user
+// mutations on the calling goroutine. It validates that we don't hold
+// mutable user data on the SDK.
+func TestTelemetryProcessorRace(t *testing.T) {
+	transport := &testutils.MockTelemetryTransport{}
+	dsn := &protocol.Dsn{}
+	sdkInfo := &protocol.SdkInfo{Name: "test-sdk", Version: "1.0.0"}
+
+	buffers := map[ratelimit.Category]telemetry.Buffer[protocol.TelemetryItem]{
+		ratelimit.CategoryError: telemetry.NewRingBuffer[protocol.TelemetryItem](
+			ratelimit.CategoryError, 100, telemetry.OverflowPolicyDropOldest, 1, 0, report.NoopRecorder(),
+		),
+	}
+
+	proc := telemetry.NewProcessor(buffers, transport, dsn, sdkInfo, report.NoopRecorder())
+	defer proc.Close(2 * time.Second)
+
+	const numEvents = 100
+	const numMutations = 500
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < numEvents; i++ {
+		event := NewEvent()
+		event.EventID = EventID(fmt.Sprintf("%032x", i))
+		event.Level = LevelError
+		event.Message = fmt.Sprintf("test event %d", i)
+		event.Extra = map[string]interface{}{
+			"initial_key": "initial_value",
+		}
+		event.Contexts = map[string]Context{
+			"initial_context": {"key": "value"},
+		}
+		event.Breadcrumbs = []*Breadcrumb{
+			{Message: "initial breadcrumb", Timestamp: time.Now()},
+		}
+
+		proc.Add(event)
+		// Yield to let the scheduler goroutine start processing
+		runtime.Gosched()
+
+		wg.Add(1)
+		go func(ev *Event, idx int) {
+			defer wg.Done()
+			for j := 0; j < numMutations; j++ {
+				// Map writes — "concurrent map read and map write"
+				ev.Extra[fmt.Sprintf("key-%d-%d", idx, j)] = fmt.Sprintf("value-%d", j)
+				ev.Contexts[fmt.Sprintf("ctx-%d-%d", idx, j)] = Context{
+					"dynamic": fmt.Sprintf("value-%d", j),
+				}
+
+				// Slice shrink/grow — "index out of range"
+				ev.Breadcrumbs = append(ev.Breadcrumbs, &Breadcrumb{
+					Message:   fmt.Sprintf("breadcrumb-%d-%d", idx, j),
+					Timestamp: time.Now(),
+				})
+				if j%10 == 0 && len(ev.Breadcrumbs) > 1 {
+					ev.Breadcrumbs = ev.Breadcrumbs[:1]
+				}
+			}
+		}(event, i)
+	}
+
+	wg.Wait()
+	proc.Flush(2 * time.Second)
+}

--- a/telemetry_processor_race_test.go
+++ b/telemetry_processor_race_test.go
@@ -17,7 +17,7 @@ import (
 // This race is between json.Marshal on the scheduler goroutine and user
 // mutations on the calling goroutine. It validates that we don't hold
 // mutable user data on the SDK.
-func TestTelemetryProcessorRace(t *testing.T) {
+func TestTelemetryProcessorRace(_ *testing.T) {
 	transport := &testutils.MockTelemetryTransport{}
 	dsn := &protocol.Dsn{}
 	sdkInfo := &protocol.SdkInfo{Name: "test-sdk", Version: "1.0.0"}


### PR DESCRIPTION
### Description
This PR adds a Telemetry Processor reproduction test for #1146. This validates that #1214 properly solves the race condition.

#skip-changelog 

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
