### PR TITLE
fix: race condition when getting envelope identifier

### DIFF
--- a/internal/http/transport.go
+++ b/internal/http/transport.go
@@ -400,9 +400,10 @@ func (t *AsyncTransport) SendEnvelope(envelope *protocol.Envelope) error {
 		return nil
 	}
 
+	identifier := util.EnvelopeIdentifier(envelope)
+
 	select {
 	case t.queue <- envelope:
-		identifier := util.EnvelopeIdentifier(envelope)
 		debuglog.Printf(
 			"Sending %s to %s project: %s",
 			identifier,


### PR DESCRIPTION
### Description
This PR fixes a race condition on the telemetry processor when resolving the envelope identifier. Previously the event identifier was calculated after adding the event to the queue, causing the main routine and the background worker to race on the same envelope.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
