### PR TITLE
fix(fiber): Use UserContext for transaction to enable OTel trace linking

### DIFF
--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -80,11 +80,17 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 		sentry.WithSpanOrigin(sentry.SpanOriginFiber),
 	}
 
+	savedCtx := ctx.UserContext()
+	requestCtx, cancel := context.WithCancel(savedCtx)
+	defer cancel()
+	defer func() { ctx.SetUserContext(savedCtx) }()
+
 	transaction := sentry.StartTransaction(
-		sentry.SetHubOnContext(ctx.UserContext(), hub),
+		sentry.SetHubOnContext(requestCtx, hub),
 		fmt.Sprintf("%s %s", r.Method, transactionName),
 		options...,
 	)
+	ctx.SetUserContext(transaction.Context())
 
 	defer func() {
 		status := ctx.Response().StatusCode()
@@ -94,7 +100,6 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 	}()
 
 	transaction.SetData("http.request.method", r.Method)
-	ctx.SetUserContext(transaction.Context())
 	r = r.WithContext(transaction.Context())
 
 	scope := hub.Scope()

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -110,7 +110,7 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 func (h *handler) recoverWithSentry(hub *sentry.Hub, ctx *fiber.Ctx) {
 	if err := recover(); err != nil {
 		eventID := hub.RecoverWithContext(
-			context.WithValue(context.Background(), sentry.RequestContextKey, ctx),
+			context.WithValue(ctx.UserContext(), sentry.RequestContextKey, ctx),
 			err,
 		)
 		if eventID != nil && h.waitForDelivery {

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -81,7 +81,7 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 	}
 
 	transaction := sentry.StartTransaction(
-		sentry.SetHubOnContext(ctx.Context(), hub),
+		sentry.SetHubOnContext(ctx.UserContext(), hub),
 		fmt.Sprintf("%s %s", r.Method, transactionName),
 		options...,
 	)
@@ -94,6 +94,8 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 	}()
 
 	transaction.SetData("http.request.method", r.Method)
+	ctx.SetUserContext(transaction.Context())
+	r = r.WithContext(transaction.Context())
 
 	scope := hub.Scope()
 	scope.SetRequest(r)


### PR DESCRIPTION
## Summary

- The fiber middleware was using `ctx.Context()` (raw fasthttp context) instead of `ctx.UserContext()` when starting the transaction. The raw fasthttp context does not propagate `context.WithValue` wrappers, which broke OTel trace linking since the OTel span context is stored via `context.WithValue`.
- The transaction context was not being set back on `UserContext` before calling `ctx.Next()`, so downstream handlers and panic recovery did not have access to the active span.
- The converted `*http.Request` now carries the transaction context via `r.WithContext(transaction.Context())` so that `scope.request.Context()` has trace info available for event processing (e.g., trace resolution in the OTel integration).

## Motivation

This fix is needed for the OTel integration to properly link errors, logs, and metrics to the active trace in fiber handlers. Without it, the OTel span context is lost at the point where the Sentry transaction is created, breaking the trace linkage.

## Changes

- `fiber/sentryfiber.go`: Use `ctx.UserContext()` instead of `ctx.Context()` when passing context to `sentry.StartTransaction`
- `fiber/sentryfiber.go`: Call `ctx.SetUserContext(transaction.Context())` before `ctx.Next()` so downstream handlers see the transaction span
- `fiber/sentryfiber.go`: Set `r = r.WithContext(transaction.Context())` before `scope.SetRequest(r)` so the scope request carries trace context

## Test plan

- [x] `go build ./...` passes in the fiber module
- [x] `go test -race ./...` passes in the fiber module
- [x] Verify OTel trace linking works end-to-end with a fiber app instrumented with both Sentry and OTel

🤖 Generated with [Claude Code](https://claude.com/claude-code)