### PR TITLE
fix: add missing TracesSampler fields for SamplingContext

### DIFF
--- a/traces_sampler.go
+++ b/traces_sampler.go
@@ -7,7 +7,14 @@ package sentry
 // user-provided data.
 type SamplingContext struct {
 	Span   *Span // The current span, always non-nil.
-	Parent *Span // The parent span, may be nil.
+	Parent *Span // The local parent span, non-nil only when the parent exists in the same process.
+	// ParentSampled is the sampling decision of the parent span.
+	//
+	// For a remote span, Parent is nil but ParentSampled reflects the upstream decision.
+	// For a local span, ParentSampled mirrors Parent.Sampled.
+	ParentSampled Sampled
+	// ParentSampleRate is the sample rate used by the parent transaction.
+	ParentSampleRate *float64
 }
 
 // The TracesSample type is an adapter to allow the use of ordinary

--- a/tracing.go
+++ b/tracing.go
@@ -540,9 +540,23 @@ func (s *Span) sample() Sampled {
 
 	// #3 use TracesSampler from ClientOptions.
 	sampler := clientOptions.TracesSampler
+	parentSampled := SampledUndefined
+	if s.parent != nil {
+		parentSampled = s.parent.Sampled
+	} else if s.ParentSpanID != zeroSpanID {
+		parentSampled = s.Sampled
+	}
+	var parentSampleRate *float64
+	if rateStr, ok := s.dynamicSamplingContext.Entries["sample_rate"]; ok {
+		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
+			parentSampleRate = &rate
+		}
+	}
 	samplingContext := SamplingContext{
-		Span:   s,
-		Parent: s.parent,
+		Span:             s,
+		Parent:           s.parent,
+		ParentSampled:    parentSampled,
+		ParentSampleRate: parentSampleRate,
 	}
 
 	if sampler != nil {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 )
 
 func TraceIDFromHex(s string) TraceID {
@@ -921,6 +922,72 @@ func TestSampleRatePropagation(t *testing.T) {
 			if transaction.sampleRate != tt.expectedRate {
 				t.Errorf("Expected sample rate %f, got %f", tt.expectedRate, transaction.sampleRate)
 			}
+		})
+	}
+}
+
+func TestTracesSamplerReceivesRemoteParent(t *testing.T) {
+	t.Parallel()
+
+	ptrFloat := func(f float64) *float64 { return &f }
+
+	tests := []struct {
+		name                 string
+		traceHeader          string
+		baggageHeader        string
+		wantParentSampled    Sampled
+		wantParentSampleRate *float64
+	}{
+		{
+			name:                 "remote parent sampled=true with rate",
+			traceHeader:          "423d7a0fb16128c8503f067d8447caba-d9246d56c61fc963-1",
+			baggageHeader:        "sentry-trace_id=423d7a0fb16128c8503f067d8447caba,sentry-sampled=true,sentry-sample_rate=0.8",
+			wantParentSampled:    SampledTrue,
+			wantParentSampleRate: ptrFloat(0.8),
+		},
+		{
+			name:                 "remote parent sampled=false with rate",
+			traceHeader:          "423d7a0fb16128c8503f067d8447caba-d9246d56c61fc963-0",
+			baggageHeader:        "sentry-trace_id=423d7a0fb16128c8503f067d8447caba,sentry-sampled=false,sentry-sample_rate=0.1",
+			wantParentSampled:    SampledFalse,
+			wantParentSampleRate: ptrFloat(0.1),
+		},
+		{
+			name:                 "remote parent sampled=defer no rate",
+			traceHeader:          "423d7a0fb16128c8503f067d8447caba-d9246d56c61fc963",
+			baggageHeader:        "sentry-trace_id=423d7a0fb16128c8503f067d8447caba",
+			wantParentSampled:    SampledUndefined,
+			wantParentSampleRate: nil,
+		},
+		{
+			name:                 "no remote parent",
+			traceHeader:          "",
+			baggageHeader:        "",
+			wantParentSampled:    SampledUndefined,
+			wantParentSampleRate: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotCtx SamplingContext
+			ctx := NewTestContext(ClientOptions{
+				EnableTracing: true,
+				TracesSampler: func(samplingContext SamplingContext) float64 {
+					gotCtx = samplingContext
+					return 1.0
+				},
+			})
+
+			hub := GetHubFromContext(ctx)
+			txn := StartTransaction(ctx, "test-txn", ContinueTrace(hub, tt.traceHeader, tt.baggageHeader))
+			txn.Finish()
+
+			assert.Nil(t, gotCtx.Parent, "SamplingContext.Parent should be nil for remote parent")
+			assert.Equal(t, tt.wantParentSampled, gotCtx.ParentSampled)
+			assert.Equal(t, tt.wantParentSampleRate, gotCtx.ParentSampleRate)
 		})
 	}
 }


### PR DESCRIPTION
### Description
The SDK currently was returning an incomplete SamplingContext for the TracesSampler that was diverging from the spec. The returned SamplingContext did not include ParentSampled and ParentSampleRate, thus not exposing remote parent information to the users. That also lead to confusion where users would think that the exposed `SamplingContext.Parent` actually tracked the remote parent as well.

This fixes the behavior by adding `ParentSampled` and `ParentSampleRate` to `SamplingContext`.

### Issues
* resolves: #1258 
* resolves: LIN-1234

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
