### PR TITLE
feat!: update compatibility policy and drop go 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,6 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        go: ["1.26", "1.25", "1.24"]
+        go: ["1.26", "1.25"]
         os: [ubuntu, windows, macos]
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ intended to replace the `raven-go` package.
 
 The only requirement is a Go compiler.
 
-We verify this package against the 3 most recent releases of Go. Those are the
-supported versions. The exact versions are defined in
+We follow Go's [official release policy](https://go.dev/doc/devel/release#policy),
+supporting the two most recent Go releases. Each major Go release is supported
+until there are two newer major releases. The exact versions are defined in
 [`GitHub workflow`](.github/workflows/test.yml).
 
 In addition, we run tests against the current master branch of the Go toolchain,

--- a/fasthttp/go.mod
+++ b/fasthttp/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/fasthttp
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/fiber/go.mod
+++ b/fiber/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/fiber
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/gin/go.mod
+++ b/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/gin
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-errors/errors v1.4.2

--- a/iris/go.mod
+++ b/iris/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/iris
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/logrus/go.mod
+++ b/logrus/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/logrus
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/negroni/go.mod
+++ b/negroni/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/negroni
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/slog/go.mod
+++ b/slog/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/slog
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/zap/go.mod
+++ b/zap/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/zap
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 

--- a/zerolog/go.mod
+++ b/zerolog/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/sentry-go/zerolog
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/getsentry/sentry-go => ../
 


### PR DESCRIPTION
### Description
This PR updates our compatibility policy to align with [Go's](https://go.dev/doc/devel/release#policy) and only support the last two majors. We also drop support for Go 1.24

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)

-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>

### Changelog Entry
- Update compatibility policy to align with Go, supporting only the last two major Go versions
- Drop support for Go 1.24