### PR TITLE
build(deps): bump golangci-lint action from 2.1.1 to 2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # pin@v8.0
         with:
-          version: v2.1.1
+          version: v2.11.4
           args: --timeout=10m
     timeout-minutes: 10

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,11 +38,11 @@ linters:
       - linters:
           - gosec
         path: _test\.go
-        text: 'G306:|G101:'
+        text: "G306:"
       - linters:
           - staticcheck
         path: _test\.go
-        text: 'SA5011'
+        text: "SA5011"
       - linters:
           - unused
         path: errors_test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,11 @@ linters:
       - linters:
           - gosec
         path: _test\.go
-        text: 'G306:'
+        text: 'G306:|G101:'
+      - linters:
+          - staticcheck
+        path: _test\.go
+        text: 'SA5011'
       - linters:
           - unused
         path: errors_test\.go

--- a/batch_processor.go
+++ b/batch_processor.go
@@ -49,7 +49,7 @@ func (p *batchProcessor[T]) Send(item T) bool {
 
 func (p *batchProcessor[T]) Start() {
 	p.startOnce.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in p.cancel and called in Stop()
+		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in p.cancel and called in Shutdown()
 		p.cancel = cancel
 		p.wg.Add(1)
 		go p.run(ctx)

--- a/batch_processor.go
+++ b/batch_processor.go
@@ -49,7 +49,7 @@ func (p *batchProcessor[T]) Send(item T) bool {
 
 func (p *batchProcessor[T]) Start() {
 	p.startOnce.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in p.cancel and called in Stop()
 		p.cancel = cancel
 		p.wg.Add(1)
 		go p.run(ctx)

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -131,12 +131,12 @@ func TestIntegration(t *testing.T) {
 				Status:      sentry.SpanStatusInvalidArgument,
 			},
 		},
-		{
+		{ //nolint:gosec // G101: not real credentials
 			RequestMethod:      "POST",
 			RequestURL:         "https://john:verysecurepassword@example.com:4321/secret",
 			WantStatus:         200,
 			WantResponseLength: 1024,
-			WantSpan: &sentry.Span{
+			WantSpan: &sentry.Span{ //nolint:gosec // G101: not real credentials
 				Data: map[string]interface{}{
 					"http.fragment":                string(""),
 					"http.query":                   string(""),

--- a/internal/protocol/dsn_test.go
+++ b/internal/protocol/dsn_test.go
@@ -18,7 +18,7 @@ type DsnTest struct {
 }
 
 var dsnTests = map[string]DsnTest{
-	"AllFields": {
+	"AllFields": { //nolint:gosec // G101: not real credentials
 		in: "https://public:secret@domain:8888/foo/bar/42",
 		dsn: &Dsn{
 			scheme:    SchemeHTTPS,
@@ -119,7 +119,7 @@ func TestNewDsnInvalidInput(t *testing.T) {
 }
 
 func TestDsnSerializeDeserialize(t *testing.T) {
-	url := "https://public:secret@domain:8888/foo/bar/42"
+	url := "https://public:secret@domain:8888/foo/bar/42" //nolint:gosec // G101: not real credentials
 	dsn, dsnErr := NewDsn(url)
 	serialized, _ := json.Marshal(dsn)
 	var deserialized Dsn
@@ -131,7 +131,7 @@ func TestDsnSerializeDeserialize(t *testing.T) {
 	if dsnErr != nil {
 		t.Error("expected NewDsn to not return error")
 	}
-	expected := `"https://public:secret@domain:8888/foo/bar/42"`
+	expected := `"https://public:secret@domain:8888/foo/bar/42"` //nolint:gosec // G101: not real credentials
 	if string(serialized) != expected {
 		t.Errorf("Expected %s, got %s", expected, string(serialized))
 	}
@@ -176,7 +176,7 @@ func TestRequestHeadersWithoutSecretKey(t *testing.T) {
 }
 
 func TestRequestHeadersWithSecretKey(t *testing.T) {
-	url := "https://public:secret@domain/42"
+	url := "https://public:secret@domain/42" //nolint:gosec // G101: not real credentials
 	dsn, err := NewDsn(url)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/protocol/dsn_test.go
+++ b/internal/protocol/dsn_test.go
@@ -58,7 +58,6 @@ var dsnTests = map[string]DsnTest{
 	},
 }
 
-// nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
 func TestNewDsn(t *testing.T) {
 	for name, tt := range dsnTests {
 		t.Run(name, func(t *testing.T) {
@@ -99,7 +98,6 @@ var invalidDsnTests = map[string]invalidDsnTest{
 	"TrailingSlash": {"https://public:secret@domain:8888/42/", "empty project id"},
 }
 
-// nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
 func TestNewDsnInvalidInput(t *testing.T) {
 	for name, tt := range invalidDsnTests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/telemetry/scheduler.go
+++ b/internal/telemetry/scheduler.go
@@ -43,7 +43,7 @@ func NewScheduler(
 		recorder = report.NoopRecorder()
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in s.cancel and called in Shutdown()
 
 	priorityWeights := map[ratelimit.Priority]int{
 		ratelimit.PriorityCritical: 5,

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -99,7 +99,7 @@ func (r *SendResult) IsSendError() bool {
 // DoSendRequest executes an HTTP request, handles response logging, extracts rate limits, and
 // drains+closes the response body.
 func DoSendRequest(client *http.Client, request *http.Request, identifier string) (*SendResult, error) {
-	response, err := client.Do(request)
+	response, err := client.Do(request) //nolint:gosec // G704: request is constructed internally, not from user input
 	if err != nil {
 		return nil, err
 	}

--- a/stacktrace_external_test.go
+++ b/stacktrace_external_test.go
@@ -49,7 +49,6 @@ func BlueGoErrorsRanger() error {
 	return goErrors.New("this is bad from goErrors")
 }
 
-// nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
 func TestNewStacktrace(t *testing.T) {
 	tests := map[string]struct {
 		f    func() *sentry.Stacktrace
@@ -108,7 +107,6 @@ func TestNewStacktrace(t *testing.T) {
 	}
 }
 
-// nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
 func TestExtractStacktrace(t *testing.T) {
 	tests := map[string]struct {
 		f    func() error

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -25,7 +25,6 @@ func BenchmarkNewStacktrace(b *testing.B) {
 	}
 }
 
-// nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
 func TestSplitQualifiedFunctionName(t *testing.T) {
 	tests := []struct {
 		in  string
@@ -69,7 +68,6 @@ func TestSplitQualifiedFunctionName(t *testing.T) {
 	}
 }
 
-// nolint: scopelint // false positive https://github.com/kyoh86/scopelint/issues/4
 func TestCreateFrames(t *testing.T) {
 	tests := []struct {
 		in  []runtime.Frame


### PR DESCRIPTION
### Description
This PR bumps golangci-lint to the most recent version and also resolves new lint issues that came up. New rules that were added:
- exclude SA5011 (nil pointer dereference) for test files.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
