### PR TITLE
test: add sentrytest package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,17 +69,18 @@ The `internalAsyncTransportAdapter` in `transport.go` bridges old `Transport` to
 
 Test tier preference (use the highest tier that covers what you need):
 
-1. **Integration tests** (default) — `sentry.Init` with `BeforeSend` callbacks, `httptest.Server` with real framework routers, `sentry.Flush` to collect events. Prefer tests that use the public API.
-2. **Context-level tests** — `NewTestContext` with `MockTransport` for span/transaction behavior when no HTTP server is needed.
-3. **Unit tests** (sparingly) — Direct `NewClient` + `MockScope` only for self-contained logic like `BeforeSend` callbacks or sampling decisions.
+1. **Integration tests** (default) — Prefer `internal/sentrytest` with `sentrytest.Run` or `sentrytest.NewFixture`, plus real routers / `httptest` requests where needed. Prefer tests that use the public API.
+2. **Context-level tests** — Prefer `sentrytest.NewContext` or `fixture.NewContext(parent)` for tracing / context propagation tests. Prefer `sentrytest.NewFixture` for isolated client + hub setup when no HTTP server is needed.
+3. **Unit tests** (sparingly) — Direct `NewClient` + `MockScope` only for self-contained logic where `sentrytest` would add unnecessary indirection.
 
 Conventions:
 
 - Table-driven tests for multiple inputs through the same code path
 - `t.Parallel()` for tests that don't share global state
 - `cmp.Diff` with `cmpopts.IgnoreFields` for `*Event` comparison — ignore `EventID`, `Timestamp`, `Sdk`, `sdkMetaData`
-- `testutils.FlushTimeout()` when calling `sentry.Flush` (longer timeout in CI)
-- `testify` for assertions, `internal/testutils/` for mocks
+- Prefer `fixture.Flush()` over direct `sentry.Flush(...)` in tests built on `internal/sentrytest`
+- Prefer `fixture.Events()` as the captured event stream; inspect `event.Type` in assertions instead of relying on separate fixture streams
+- `testify` for assertions, `internal/testutils/` for non-assert test helpers like mocks and flush timing
 - All tests must pass `make test-race`
 
 What to test:

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -198,6 +198,7 @@ func (f *Fixture) Events() []*sentry.Event {
 
 // AssertEventCount flushes and asserts the number of captured events.
 func (f *Fixture) AssertEventCount(want int) {
+	f.T.Helper()
 	f.assertCount("event", want)
 }
 
@@ -213,6 +214,7 @@ func (f *Fixture) assertCount(kind string, want int) {
 // against want. Uses [DefaultEventCmpOpts] merged with any additional opts.
 // Returns "" when events match.
 func (f *Fixture) DiffEvents(want []*sentry.Event, opts ...cmp.Option) string {
+	f.T.Helper()
 	f.Flush()
 	combined := make(cmp.Options, 0, len(DefaultEventCmpOpts)+len(opts))
 	combined = append(combined, DefaultEventCmpOpts...)

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -113,7 +113,7 @@ func NewFixture(t testing.TB, opts ...Option) *Fixture {
 
 // NewContext creates a context backed by a new [Fixture] without a synctest
 // bubble. If parent is nil, [context.Background] is used.
-func NewContext(t testing.TB, parent context.Context, opts ...Option) context.Context {
+func NewContext(parent context.Context, t testing.TB, opts ...Option) context.Context {
 	t.Helper()
 	return NewFixture(t, opts...).NewContext(parent)
 }

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -1,0 +1,253 @@
+// Package sentrytest provides test fixtures for the Sentry Go SDK.
+//
+// Fixture bundles a Hub, Client, and MockTransport with assertion helpers,
+// eliminating boilerplate across integration and unit tests.
+//
+// Isolated mode (default) creates a cloned hub safe for parallel tests.
+// Global mode (WithGlobal) calls sentry.Init for middleware tests that read
+// from sentry.CurrentHub.
+package sentrytest
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+const testDsn = "https://whatever@sentry.io/1337"
+
+// DefaultEventCmpOpts are [cmp.Options] for comparing [sentry.Event] values.
+// They ignore fields that vary between runs (IDs, timestamps, server metadata)
+// and all unexported fields.
+var DefaultEventCmpOpts = cmp.Options{
+	cmpopts.IgnoreFields(sentry.Event{},
+		"Contexts",
+		"EventID",
+		"Extra",
+		"Modules",
+		"Platform",
+		"Release",
+		"Sdk",
+		"ServerName",
+		"Timestamp",
+	),
+	cmpopts.IgnoreFields(sentry.Request{}, "Env"),
+	cmpopts.IgnoreUnexported(sentry.Event{}),
+	cmpopts.EquateEmpty(),
+}
+
+// Option configures a [Fixture].
+type Option func(*config)
+
+type config struct {
+	opts   sentry.ClientOptions
+	global bool
+}
+
+// WithGlobal makes the fixture call [sentry.Init] to set the global hub
+// instead of creating an isolated hub. Use this for middleware tests where
+// the middleware reads from [sentry.CurrentHub].
+//
+// Tests using global mode must not run in parallel.
+func WithGlobal() Option {
+	return func(c *config) {
+		c.global = true
+	}
+}
+
+// WithClientOptions sets the [sentry.ClientOptions] for the fixture.
+// Transport is always overridden to use the fixture's mock transport. If Dsn is
+// empty, the fixture sets a placeholder test DSN.
+func WithClientOptions(opts sentry.ClientOptions) Option {
+	return func(c *config) {
+		c.opts = opts
+	}
+}
+
+// Fixture provides an isolated Sentry environment for testing.
+// It bundles a Hub, Client, and MockTransport with assertion helpers.
+type Fixture struct {
+	// T is the test context.
+	T testing.TB
+
+	// Hub is the fixture's hub. In global mode this is [sentry.CurrentHub].
+	// In isolated mode this is a clone with its own client.
+	Hub *sentry.Hub
+
+	// Client is the fixture's client, configured with the MockTransport.
+	Client *sentry.Client
+
+	// Transport captures all events sent through the client.
+	Transport *sentry.MockTransport
+
+	// useSynctest indicates the fixture is running inside a synctest bubble.
+	useSynctest bool
+}
+
+// Run creates a [Fixture] inside a [synctest.Test] bubble and calls fn
+// with it. All background goroutines (batch processors) use fake time, so
+// [Fixture.Flush] completes instantly. This is the preferred way to
+// create fixtures.
+//
+// For the rare case where synctest is incompatible (e.g. third-party code that
+// leaks goroutines), use [NewFixture] directly.
+func Run(t *testing.T, fn func(t *testing.T, f *Fixture), opts ...Option) {
+	t.Helper()
+	synctest.Test(t, func(t *testing.T) {
+		f := newFixture(t, true, opts...)
+		fn(t, f)
+	})
+}
+
+// NewFixture creates a new test fixture without a synctest bubble.
+// Prefer [Run] for most tests; use this only when synctest is incompatible.
+func NewFixture(t testing.TB, opts ...Option) *Fixture {
+	t.Helper()
+	return newFixture(t, false, opts...)
+}
+
+// NewContext creates a context backed by a new [Fixture] without a synctest
+// bubble. If parent is nil, [context.Background] is used.
+func NewContext(t testing.TB, parent context.Context, opts ...Option) context.Context {
+	t.Helper()
+	return NewFixture(t, opts...).NewContext(parent)
+}
+
+func newFixture(t testing.TB, useSynctest bool, opts ...Option) *Fixture {
+	t.Helper()
+
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	transport := &sentry.MockTransport{}
+	cfg.opts.Transport = transport
+
+	if cfg.opts.Dsn == "" {
+		cfg.opts.Dsn = testDsn
+	}
+
+	f := &Fixture{
+		T:           t,
+		Transport:   transport,
+		useSynctest: useSynctest,
+	}
+
+	if cfg.global {
+		if err := sentry.Init(cfg.opts); err != nil {
+			t.Fatal(err)
+		}
+		f.Hub = sentry.CurrentHub()
+		f.Client = f.Hub.Client()
+	} else {
+		client, err := sentry.NewClient(cfg.opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hub := sentry.CurrentHub().Clone()
+		hub.BindClient(client)
+		f.Hub = hub
+		f.Client = client
+	}
+
+	// Ensure background goroutines (batch processors) are stopped when the test finishes.
+	// This is required for synctest bubbles which will panic if blocked goroutines remain
+	// after the bubble's root goroutine exits.
+	t.Cleanup(func() { f.Client.Close() })
+
+	return f
+}
+
+// Flush flushes the fixture's client.
+//
+// Inside a [Run] bubble it calls [synctest.Wait] first to let all background
+// goroutines settle, then flushes under fake time (completing instantly).
+// Outside a bubble it awaits for a real Flush.
+func (f *Fixture) Flush() {
+	f.T.Helper()
+	if f.useSynctest {
+		synctest.Wait()
+	}
+	if ok := f.Client.Flush(testutils.FlushTimeout()); !ok {
+		f.T.Error("Fixture: client flush timed out")
+	}
+}
+
+// NewContext returns parent with the fixture's hub attached. If parent is nil,
+// [context.Background] is used.
+func (f *Fixture) NewContext(parent context.Context) context.Context {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return sentry.SetHubOnContext(parent, f.Hub)
+}
+
+// Events returns all captured events, including transactions.
+//
+// TODO: Add typed helper views (errors, transactions, logs, metrics,
+// check-ins) when the telemetry processor path is enabled in tests.
+func (f *Fixture) Events() []*sentry.Event {
+	return f.Transport.Events()
+}
+
+// AssertEventCount flushes and asserts the number of captured events.
+func (f *Fixture) AssertEventCount(want int) {
+	f.assertCount("event", want)
+}
+
+func (f *Fixture) assertCount(kind string, want int) {
+	f.T.Helper()
+	f.Flush()
+	if got := len(f.Events()); got != want {
+		f.T.Errorf("%s count: got %d, want %d", kind, got, want)
+	}
+}
+
+// DiffEvents flushes and returns a [cmp.Diff] of captured events
+// against want. Uses [DefaultEventCmpOpts] merged with any additional opts.
+// Returns "" when events match.
+func (f *Fixture) DiffEvents(want []*sentry.Event, opts ...cmp.Option) string {
+	f.Flush()
+	combined := make(cmp.Options, 0, len(DefaultEventCmpOpts)+len(opts))
+	combined = append(combined, DefaultEventCmpOpts...)
+	for _, o := range opts {
+		combined = append(combined, o)
+	}
+	return cmp.Diff(want, f.Events(), combined...)
+}
+
+// AssertHubIsolation verifies that requestHub is a distinct clone from the
+// fixture's hub, confirming the middleware properly cloned the hub per request.
+func (f *Fixture) AssertHubIsolation(requestHub *sentry.Hub) {
+	f.T.Helper()
+
+	if requestHub == nil {
+		f.T.Error("request hub is nil")
+		return
+	}
+	if requestHub == f.Hub {
+		f.T.Error("request hub is the same instance as the fixture hub")
+		return
+	}
+
+	const sentinel = "_sentrytest_isolation_probe"
+	f.Hub.Scope().SetTag(sentinel, "leaked")
+	defer f.Hub.Scope().RemoveTag(sentinel)
+
+	// Apply the request scope to a probe event to read its tags.
+	probe := &sentry.Event{}
+	applied := requestHub.Scope().ApplyToEvent(probe, nil, nil)
+	if applied == nil {
+		f.T.Error("event dropped by event processor")
+		return
+	}
+	if _, ok := applied.Tags[sentinel]; ok {
+		f.T.Error("scope mutation leaked into request hub; scopes are not independent")
+	}
+}

--- a/internal/sentrytest/fixture_test.go
+++ b/internal/sentrytest/fixture_test.go
@@ -1,0 +1,245 @@
+package sentrytest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+)
+
+type contextKey struct{}
+
+func TestNewSentryFixture_Isolated(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t)
+
+	assert.NotNil(t, f.Hub, "hub should not be nil")
+	assert.NotNil(t, f.Client, "client should not be nil")
+	assert.NotNil(t, f.Transport, "transport should not be nil")
+	assert.NotSame(t, sentry.CurrentHub(), f.Hub, "isolated fixture hub should not be the global hub")
+}
+
+func TestNewSentryFixture_Global(t *testing.T) {
+	f := NewFixture(t, WithGlobal())
+
+	assert.Same(t, sentry.CurrentHub(), f.Hub, "global fixture hub should be the current hub")
+	assert.NotNil(t, f.Client, "client should not be nil")
+}
+
+func TestNewSentryFixture_WithClientOptions_Tracing(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t, WithClientOptions(sentry.ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+	}))
+
+	span := sentry.StartTransaction(
+		sentry.SetHubOnContext(t.Context(), f.Hub),
+		"test-transaction",
+	)
+	span.Finish()
+	f.Flush()
+
+	events := f.Events()
+	assert.Len(t, events, 1, "event count")
+	assert.Equal(t, "transaction", events[0].Type, "event type")
+}
+
+func TestNewSentryFixture_WithClientOptions(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t,
+		WithClientOptions(sentry.ClientOptions{
+			Environment: "test-env",
+		}),
+	)
+
+	f.Hub.CaptureMessage("hello")
+	f.Flush()
+
+	events := f.Events()
+	assert.Len(t, events, 1, "event count")
+	assert.Equal(t, "test-env", events[0].Environment, "environment")
+}
+
+func TestFixture_NewContext(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t)
+	parent := context.WithValue(context.Background(), contextKey{}, "value")
+
+	ctx := f.NewContext(parent)
+
+	assert.Equal(t, "value", ctx.Value(contextKey{}), "context value")
+	assert.Same(t, f.Hub, sentry.GetHubFromContext(ctx), "context hub")
+}
+
+func TestNewContext(t *testing.T) {
+	t.Parallel()
+
+	parent := context.WithValue(context.Background(), contextKey{}, "value")
+	ctx := NewContext(t, parent)
+
+	assert.Equal(t, "value", ctx.Value(contextKey{}), "context value")
+	assert.NotNil(t, sentry.GetHubFromContext(ctx), "context hub")
+}
+
+func TestNewContext_NilParent(t *testing.T) {
+	t.Parallel()
+
+	ctx := NewContext(t, nil)
+
+	assert.NotNil(t, sentry.GetHubFromContext(ctx), "context hub")
+	assert.Nil(t, ctx.Value(contextKey{}), "context value")
+}
+
+func TestSentryFixture_Events_IncludesTransactions(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t, WithClientOptions(sentry.ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+	}))
+	ctx := sentry.SetHubOnContext(t.Context(), f.Hub)
+	f.Hub.CaptureMessage("error event")
+	span := sentry.StartTransaction(ctx, "test-tx")
+	span.Finish()
+
+	f.Flush()
+
+	events := f.Events()
+	assert.Len(t, events, 2, "event count")
+	assert.Equal(t, "error event", events[0].Message, "event message")
+	assert.Equal(t, "transaction", events[1].Type, "event type")
+}
+
+func TestSentryFixture_AssertEventCount(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t)
+	f.Hub.CaptureMessage("one")
+	f.Hub.CaptureMessage("two")
+
+	f.AssertEventCount(2)
+}
+
+func TestSentryFixture_DiffEvents(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t)
+	f.Hub.CaptureMessage("hello")
+
+	want := []*sentry.Event{
+		{Message: "hello", Level: sentry.LevelInfo},
+	}
+	if diff := f.DiffEvents(want); diff != "" {
+		t.Errorf("DiffEvents mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSentryFixture_DiffEvents_WithExtraOpts(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t)
+	f.Hub.CaptureMessage("hello")
+
+	want := []*sentry.Event{
+		{Message: "hello"},
+	}
+	if diff := f.DiffEvents(want, cmpopts.IgnoreFields(sentry.Event{}, "Level")); diff != "" {
+		t.Errorf("DiffEvents mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSentryFixture_AssertHubIsolation_Pass(t *testing.T) {
+	t.Parallel()
+
+	f := NewFixture(t)
+	requestHub := f.Hub.Clone()
+
+	f.AssertHubIsolation(requestHub)
+}
+
+func TestSentryFixture_AssertHubIsolation_DetectsNil(t *testing.T) {
+	t.Parallel()
+
+	mock := &testing.T{}
+	f := &Fixture{T: mock, Hub: sentry.CurrentHub().Clone()}
+	f.AssertHubIsolation(nil)
+
+	assert.True(t, mock.Failed(), "AssertHubIsolation should fail when requestHub is nil")
+}
+
+func TestSentryFixture_AssertHubIsolation_DetectsSameHub(t *testing.T) {
+	t.Parallel()
+
+	mock := &testing.T{}
+	f := &Fixture{T: mock, Hub: sentry.CurrentHub().Clone()}
+
+	f.AssertHubIsolation(f.Hub) // same pointer
+
+	assert.True(t, mock.Failed(), "AssertHubIsolation should fail when requestHub is the same pointer")
+}
+
+func TestSentryFixture_AssertHubIsolation_DetectsScopeLeakage(t *testing.T) {
+	t.Parallel()
+
+	// Create a "bad clone" that shares the scope pointer.
+	mock := &testing.T{}
+	f := &Fixture{T: mock, Hub: sentry.CurrentHub().Clone()}
+	badHub := sentry.NewHub(f.Hub.Client(), f.Hub.Scope())
+
+	f.AssertHubIsolation(badHub)
+
+	assert.True(t, mock.Failed(), "AssertHubIsolation should fail when scopes are shared (not cloned)")
+}
+
+func TestDefaultEventCmpOpts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    *sentry.Event
+		b    *sentry.Event
+	}{
+		{
+			name: "ignores variable event fields",
+			a: &sentry.Event{
+				Message: "same",
+				EventID: "aaa",
+			},
+			b: &sentry.Event{
+				Message: "same",
+				EventID: "bbb",
+			},
+		},
+		{
+			name: "ignores request env and equates empty collections",
+			a: &sentry.Event{
+				Message: "same",
+				Request: &sentry.Request{Env: map[string]string{"A": "1"}},
+				Tags:    nil,
+			},
+			b: &sentry.Event{
+				Message: "same",
+				Request: &sentry.Request{},
+				Tags:    map[string]string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if diff := cmp.Diff(tt.a, tt.b, DefaultEventCmpOpts...); diff != "" {
+				t.Errorf("DefaultEventCmpOpts mismatch (-a +b):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sentrytest/fixture_test.go
+++ b/internal/sentrytest/fixture_test.go
@@ -83,7 +83,7 @@ func TestNewContext(t *testing.T) {
 	t.Parallel()
 
 	parent := context.WithValue(context.Background(), contextKey{}, "value")
-	ctx := NewContext(t, parent)
+	ctx := NewContext(parent, t)
 
 	assert.Equal(t, "value", ctx.Value(contextKey{}), "context value")
 	assert.NotNil(t, sentry.GetHubFromContext(ctx), "context hub")
@@ -92,7 +92,7 @@ func TestNewContext(t *testing.T) {
 func TestNewContext_NilParent(t *testing.T) {
 	t.Parallel()
 
-	ctx := NewContext(t, nil)
+	ctx := NewContext(nil, t) // nolint: staticcheck // SA1012: passing nil context for the test
 
 	assert.NotNil(t, sentry.GetHubFromContext(ctx), "context hub")
 	assert.Nil(t, ctx.Value(contextKey{}), "context value")


### PR DESCRIPTION
### Description
The sentrytest package is a wrapper for writing simpler integration tests. The package simulates sentry.Init and runs in a synctest bubble to eliminate timing-related flakiness.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
