### PR TITLE
feat: add internal_sdk_error client report on serialization fail

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -463,28 +463,7 @@ func (e *Event) safeMarshal() (b []byte, err error) {
 func (e *Event) ToEnvelopeItem() (item *protocol.EnvelopeItem, err error) {
 	eventBody, err := e.safeMarshal()
 	if err != nil {
-		// Try fallback: remove problematic fields and retry.
-		// Clear both original and pre-serialized versions.
-		e.Breadcrumbs = nil
-		e.serializedBreadcrumbs = nil
-		e.Contexts = nil
-		e.serializedContexts = nil
-		e.serializedException = nil
-		e.serializedUser = nil
-		e.serializedExtra = nil
-		e.Extra = map[string]interface{}{
-			"info": fmt.Sprintf("Could not encode original event as JSON. "+
-				"Succeeded by removing Breadcrumbs, Contexts and Extra. "+
-				"Please verify the data you attach to the scope. "+
-				"Error: %s", err),
-		}
-
-		eventBody, err = json.Marshal(e)
-		if err != nil {
-			return nil, fmt.Errorf("event could not be marshaled even with fallback: %w", err)
-		}
-
-		DebugLogger.Printf("Event marshaling succeeded with fallback after removing problematic fields")
+		return nil, fmt.Errorf("could not encode event as JSON, skipping delivery: %w", err)
 	}
 
 	// TODO: all event types should be abstracted to implement EnvelopeItemConvertible and convert themselves.

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -709,61 +709,52 @@ func TestEvent_ToCategory(t *testing.T) {
 	}
 }
 
-func TestEvent_ToEnvelopeItem_FallbackOnMarshalError(t *testing.T) {
-	unmarshalableFunc := func() string { return "test" }
-
+func TestEvent_ToEnvelopeItem_ErrorOnMarshalFailure(t *testing.T) {
 	event := &Event{
-		EventID:   "12345678901234567890123456789012",
-		Message:   "test message with fallback",
-		Level:     LevelError,
-		Timestamp: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
-		Extra: map[string]interface{}{
-			"bad_data": unmarshalableFunc,
-		},
+		EventID: "12345678901234567890123456789012",
+		Exception: []Exception{{
+			Stacktrace: &Stacktrace{
+				Frames: []Frame{{
+					Vars: map[string]interface{}{
+						"bad": func() string { return "test" },
+					},
+				}},
+			},
+		}},
 	}
 
 	item, err := event.ToEnvelopeItem()
-	if err != nil {
-		t.Errorf("ToEnvelopeItem() should not error even with unmarshalable data, got: %v", err)
-		return
+	if err == nil {
+		t.Fatal("ToEnvelopeItem() expected error for unmarshalable event, got nil")
 	}
-	if item == nil {
-		t.Fatal("ToEnvelopeItem() returned nil item")
-	}
-
-	var payload map[string]interface{}
-	if err := json.Unmarshal(item.Payload, &payload); err != nil {
-		t.Fatalf("Failed to unmarshal item payload: %v", err)
-	}
-
-	extra, exists := payload["extra"].(map[string]interface{})
-	if !exists {
-		t.Fatal("Expected extra field after fallback in ToEnvelopeItem")
-	}
-
-	info, exists := extra["info"].(string)
-	if !exists || !strings.Contains(info, "Could not encode original event as JSON") {
-		t.Fatal("Expected fallback info message in extra field for ToEnvelopeItem")
+	if item != nil {
+		t.Fatal("ToEnvelopeItem() expected nil item on marshal failure")
 	}
 }
 
 func TestEvent_ToEnvelopeItem_RecoverFromPanic(t *testing.T) {
 	// Verify that safeMarshal recovers from panics and ToEnvelopeItem
-	// falls back to a stripped-down event instead of crashing.
+	// returns an error instead of crashing.
 	event := &Event{
 		EventID: "panic-test",
-		Extra: map[string]interface{}{
-			// json.Marshal will panic on a channel value.
-			"bad": make(chan int),
-		},
+		Exception: []Exception{{
+			Stacktrace: &Stacktrace{
+				Frames: []Frame{{
+					Vars: map[string]interface{}{
+						// json.Marshal will error on a channel value.
+						"bad": make(chan int),
+					},
+				}},
+			},
+		}},
 	}
 
 	item, err := event.ToEnvelopeItem()
-	if err != nil {
-		t.Fatalf("ToEnvelopeItem() should recover from panic and use fallback, got error: %v", err)
+	if err == nil {
+		t.Fatal("ToEnvelopeItem() expected error from unmarshalable data, got nil")
 	}
-	if item == nil {
-		t.Fatal("ToEnvelopeItem() returned nil item after panic recovery")
+	if item != nil {
+		t.Fatal("ToEnvelopeItem() expected nil item on marshal failure")
 	}
 }
 

--- a/internal/telemetry/scheduler.go
+++ b/internal/telemetry/scheduler.go
@@ -299,6 +299,7 @@ func (s *Scheduler) sendItem(item protocol.EnvelopeItemConvertible) {
 	envItem, err := item.ToEnvelopeItem()
 	if err != nil {
 		debuglog.Printf("error while converting to envelope item: %v", err)
+		s.recorder.RecordItem(report.ReasonInternalError, item)
 		return
 	}
 	envelope.AddItem(envItem)

--- a/transport.go
+++ b/transport.go
@@ -63,34 +63,26 @@ func getTLSConfig(options ClientOptions) *tls.Config {
 	return nil
 }
 
+// eventDebugContext returns a panic-safe summary of an event for debug logging.
+// It only touches scalar fields and len() of collections, which do not trigger
+// the runtime concurrent-map-access fatal nor invoke user-defined Stringers.
+func eventDebugContext(event *Event) string {
+	return fmt.Sprintf(
+		"event=%s type=%s level=%s "+
+			"breadcrumbs=%d exceptions=%d extra=%d tags=%d contexts=%d attachments=%d",
+		event.EventID, event.Type, event.Level,
+		len(event.Breadcrumbs), len(event.Exception), len(event.Extra),
+		len(event.Tags), len(event.Contexts), len(event.Attachments),
+	)
+}
+
 func getRequestBodyFromEvent(event *Event) []byte {
 	body, err := json.Marshal(event)
-	if err == nil {
-		return body
+	if err != nil {
+		debuglog.Printf("Could not encode event as JSON, skipping delivery. %s: %v", eventDebugContext(event), err)
+		return nil
 	}
-
-	msg := fmt.Sprintf("Could not encode original event as JSON. "+
-		"Succeeded by removing Breadcrumbs, Contexts and Extra. "+
-		"Please verify the data you attach to the scope. "+
-		"Error: %s", err)
-	// Try to serialize the event, with all the contextual data that allows for interface{} stripped.
-	event.Breadcrumbs = nil
-	event.Contexts = nil
-	event.Extra = map[string]interface{}{
-		"info": msg,
-	}
-	body, err = json.Marshal(event)
-	if err == nil {
-		debuglog.Println(msg)
-		return body
-	}
-
-	// This should _only_ happen when Event.Exception[0].Stacktrace.Frames[0].Vars is unserializable
-	// Which won't ever happen, as we don't use it now (although it's the part of public interface accepted by Sentry)
-	// Juuust in case something, somehow goes utterly wrong.
-	debuglog.Println("Event couldn't be marshaled, even with stripped contextual data. Skipping delivery. " +
-		"Please notify the SDK owners with possibly broken payload.")
-	return nil
+	return body
 }
 
 func encodeAttachment(enc *json.Encoder, b io.Writer, attachment *Attachment) error {
@@ -462,6 +454,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 	}
 	envelope, err := envelopeFromBody(event, t.dsn, time.Now(), body)
 	if err != nil {
+		debuglog.Printf("Failed to build envelope, skipping delivery. %s: %v", eventDebugContext(event), err)
 		recordForEvent(t.recorder, report.ReasonInternalError, event)
 		return
 	}
@@ -500,7 +493,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 			t.dsn.GetProjectID(),
 		)
 	default:
-		debuglog.Println("Event dropped due to transport buffer being full.")
+		debuglog.Printf("Event dropped due to transport buffer being full. %s", eventDebugContext(event))
 		recordForEvent(t.recorder, report.ReasonQueueOverflow, event)
 	}
 
@@ -799,6 +792,7 @@ func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Eve
 
 	envelope, err := envelopeFromBody(event, t.dsn, time.Now(), body)
 	if err != nil {
+		debuglog.Printf("Failed to build envelope, skipping delivery. %s: %v", eventDebugContext(event), err)
 		recordForEvent(t.recorder, report.ReasonInternalError, event)
 		return
 	}
@@ -946,7 +940,7 @@ func (a *internalAsyncTransportAdapter) SendEvent(event *Event) {
 	envelope := protocol.NewEnvelope(header)
 	item, err := event.ToEnvelopeItem()
 	if err != nil {
-		debuglog.Printf("Failed to convert event to envelope item: %v", err)
+		debuglog.Printf("Failed to convert event to envelope item, skipping delivery. %s: %v", eventDebugContext(event), err)
 		if a.recorder != nil {
 			recordForEvent(a.recorder, report.ReasonInternalError, event)
 		}

--- a/transport_test.go
+++ b/transport_test.go
@@ -28,8 +28,7 @@ type unserializableType struct {
 }
 
 const (
-	basicEvent         = `{"message":"mkey","sdk":{},"user":{}}`
-	invalidEventOutput = `{"extra":{"info":"Could not encode original event as JSON. Succeeded by removing Breadcrumbs, Contexts and Extra. Please verify the data you attach to the scope. Error: json: error calling MarshalJSON for type *sentry.Event: json: unsupported type: func()"},"message":"mkey","sdk":{},"user":{}}`
+	basicEvent = `{"message":"mkey","sdk":{},"user":{}}`
 )
 
 func TestGetRequestBodyFromEventValid(t *testing.T) {
@@ -45,81 +44,7 @@ func TestGetRequestBodyFromEventValid(t *testing.T) {
 	}
 }
 
-func TestGetRequestBodyFromEventInvalidBreadcrumbsField(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Breadcrumbs: []*Breadcrumb{{
-			Data: map[string]interface{}{
-				"wat": unserializableType{},
-			},
-		}},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventInvalidExtraField(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Extra: map[string]interface{}{
-			"wat": unserializableType{},
-		},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventInvalidContextField(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Contexts: map[string]Context{
-			"wat": {"key": unserializableType{}},
-		},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventMultipleInvalidFields(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Breadcrumbs: []*Breadcrumb{{
-			Data: map[string]interface{}{
-				"wat": unserializableType{},
-			},
-		}},
-		Extra: map[string]interface{}{
-			"wat": unserializableType{},
-		},
-		Contexts: map[string]Context{
-			"wat": {"key": unserializableType{}},
-		},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventCompletelyInvalid(t *testing.T) {
+func TestGetRequestBodyFromEventUnserializable(t *testing.T) {
 	body := getRequestBodyFromEvent(&Event{
 		Exception: []Exception{{
 			Stacktrace: &Stacktrace{
@@ -133,7 +58,7 @@ func TestGetRequestBodyFromEventCompletelyInvalid(t *testing.T) {
 	})
 
 	if body != nil {
-		t.Error("expected body to be nil")
+		t.Error("expected body to be nil when event cannot be marshaled")
 	}
 }
 


### PR DESCRIPTION
### Description
This changes the behavior of stripping the event when serialization fails and resending, with sending a client report when serialization fails

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
