### PR TITLE
feat!: remove SetExtra

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -91,7 +91,7 @@ func TestCaptureMessageEmptyString(t *testing.T) {
 	}
 	got := transport.lastEvent
 	opts := cmp.Options{
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 			return &Event{
 				Exception: e.Exception,
@@ -340,7 +340,7 @@ func TestCaptureEvent(t *testing.T) {
 		},
 	}
 	got := transport.lastEvent
-	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release"), cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser")}
+	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release"), cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser")}
 	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Errorf("Event mismatch (-want +got):\n%s", diff)
 	}
@@ -368,7 +368,7 @@ func TestCaptureEventNil(t *testing.T) {
 	}
 	got := transport.lastEvent
 	opts := cmp.Options{
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 			return &Event{
 				Exception: e.Exception,
@@ -984,7 +984,7 @@ func TestRecover(t *testing.T) {
 		}
 		got := events[0]
 		opts := cmp.Options{
-			cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+			cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 			cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 				return &Event{
 					Message:   e.Message,

--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -439,10 +439,11 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 			"sdkMetaData",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(
@@ -468,7 +469,8 @@ func TestIntegration(t *testing.T) {
 			"EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"sdkMetaData", "StartTime", "Spans",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -399,10 +399,11 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 			"sdkMetaData",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(
@@ -439,7 +440,8 @@ func TestIntegration(t *testing.T) {
 			"EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"sdkMetaData", "StartTime", "Spans",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(

--- a/fiber/sentryfiber_test.go
+++ b/fiber/sentryfiber_test.go
@@ -445,10 +445,11 @@ func TestIntegration(t *testing.T) {
 	opt := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 			"sdkMetaData",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(
@@ -479,7 +480,8 @@ func TestIntegration(t *testing.T) {
 			"EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"sdkMetaData", "StartTime", "Spans",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -428,10 +428,11 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 			"sdkMetaData",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(
@@ -457,7 +458,8 @@ func TestIntegration(t *testing.T) {
 			"EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"sdkMetaData", "StartTime", "Spans",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -359,10 +359,10 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
-		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",
@@ -387,7 +387,7 @@ func TestIntegration(t *testing.T) {
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"StartTime", "Spans",
 		),
-		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {

--- a/hub_test.go
+++ b/hub_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getsentry/sentry-go/attribute"
 	"github.com/getsentry/sentry-go/internal/protocol"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -60,15 +61,20 @@ func TestPushScopeAddsScopeOnTopOfStack(t *testing.T) {
 
 func TestPushScopeInheritsScopeData(t *testing.T) {
 	hub, _, scope := setupHubTest()
-	scope.SetExtra("foo", "bar")
+	scope.SetAttributes(attribute.String("foo", "bar"))
 	hub.PushScope()
-	scope.SetExtra("baz", "qux")
+	scope.SetAttributes(attribute.String("baz", "qux"))
 
 	if (*hub.stack)[0].scope == (*hub.stack)[1].scope {
 		t.Error("Scope shouldnt point to the same struct")
 	}
-	assertEqual(t, map[string]interface{}{"foo": "bar", "baz": "qux"}, (*hub.stack)[0].scope.extra)
-	assertEqual(t, map[string]interface{}{"foo": "bar"}, (*hub.stack)[1].scope.extra)
+	assertEqual(t, map[string]attribute.Value{
+		"foo": attribute.StringValue("bar"),
+		"baz": attribute.StringValue("qux"),
+	}, (*hub.stack)[0].scope.attributes)
+	assertEqual(t, map[string]attribute.Value{
+		"foo": attribute.StringValue("bar"),
+	}, (*hub.stack)[1].scope.attributes)
 }
 
 func TestPushScopeInheritsClient(t *testing.T) {
@@ -141,40 +147,40 @@ func TestWithScopeBindClient(t *testing.T) {
 
 func TestWithScopeDirectChanges(t *testing.T) {
 	hub, _, _ := setupHubTest()
-	hub.Scope().SetExtra("extra", "foo")
+	hub.Scope().SetAttributes(attribute.String("extra", "foo"))
 
 	hub.WithScope(func(scope *Scope) {
-		scope.SetExtra("extra", "bar")
-		assertEqual(t, map[string]interface{}{"extra": "bar"}, hub.stackTop().scope.extra)
+		scope.SetAttributes(attribute.String("extra", "bar"))
+		assertEqual(t, map[string]attribute.Value{"extra": attribute.StringValue("bar")}, hub.stackTop().scope.attributes)
 	})
 
-	assertEqual(t, map[string]interface{}{"extra": "foo"}, hub.stackTop().scope.extra)
+	assertEqual(t, map[string]attribute.Value{"extra": attribute.StringValue("foo")}, hub.stackTop().scope.attributes)
 }
 
 func TestWithScopeChangesThroughConfigureScope(t *testing.T) {
 	hub, _, _ := setupHubTest()
-	hub.Scope().SetExtra("extra", "foo")
+	hub.Scope().SetAttributes(attribute.String("extra", "foo"))
 
 	hub.WithScope(func(_ *Scope) {
 		hub.ConfigureScope(func(scope *Scope) {
-			scope.SetExtra("extra", "bar")
+			scope.SetAttributes(attribute.String("extra", "bar"))
 		})
-		assertEqual(t, map[string]interface{}{"extra": "bar"}, hub.stackTop().scope.extra)
+		assertEqual(t, map[string]attribute.Value{"extra": attribute.StringValue("bar")}, hub.stackTop().scope.attributes)
 	})
 
-	assertEqual(t, map[string]interface{}{"extra": "foo"}, hub.stackTop().scope.extra)
+	assertEqual(t, map[string]attribute.Value{"extra": attribute.StringValue("foo")}, hub.stackTop().scope.attributes)
 }
 
 func TestConfigureScope(t *testing.T) {
 	hub, _, _ := setupHubTest()
-	hub.Scope().SetExtra("extra", "foo")
+	hub.Scope().SetAttributes(attribute.String("extra", "foo"))
 
 	hub.ConfigureScope(func(scope *Scope) {
-		scope.SetExtra("extra", "bar")
-		assertEqual(t, map[string]interface{}{"extra": "bar"}, hub.stackTop().scope.extra)
+		scope.SetAttributes(attribute.String("extra", "bar"))
+		assertEqual(t, map[string]attribute.Value{"extra": attribute.StringValue("bar")}, hub.stackTop().scope.attributes)
 	})
 
-	assertEqual(t, map[string]interface{}{"extra": "bar"}, hub.stackTop().scope.extra)
+	assertEqual(t, map[string]attribute.Value{"extra": attribute.StringValue("bar")}, hub.stackTop().scope.attributes)
 }
 
 func TestLastEventID(t *testing.T) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -373,30 +373,29 @@ type Context = map[string]interface{}
 
 // Event is the fundamental data structure that is sent to Sentry.
 type Event struct {
-	Breadcrumbs []*Breadcrumb          `json:"breadcrumbs,omitempty"`
-	Contexts    map[string]Context     `json:"contexts,omitempty"`
-	Dist        string                 `json:"dist,omitempty"`
-	Environment string                 `json:"environment,omitempty"`
-	EventID     EventID                `json:"event_id,omitempty"`
-	Extra       map[string]interface{} `json:"extra,omitempty"`
-	Fingerprint []string               `json:"fingerprint,omitempty"`
-	Level       Level                  `json:"level,omitempty"`
-	Message     string                 `json:"message,omitempty"`
-	Platform    string                 `json:"platform,omitempty"`
-	Release     string                 `json:"release,omitempty"`
-	Sdk         SdkInfo                `json:"sdk,omitempty"`
-	ServerName  string                 `json:"server_name,omitempty"`
-	Threads     []Thread               `json:"threads,omitempty"`
-	Tags        map[string]string      `json:"tags,omitempty"`
-	Timestamp   time.Time              `json:"timestamp,omitzero"`
-	Transaction string                 `json:"transaction,omitempty"`
-	User        User                   `json:"user,omitempty"`
-	Logger      string                 `json:"logger,omitempty"`
-	Modules     map[string]string      `json:"modules,omitempty"`
-	Request     *Request               `json:"request,omitempty"`
-	Exception   []Exception            `json:"exception,omitempty"`
-	DebugMeta   *DebugMeta             `json:"debug_meta,omitempty"`
-	Attachments []*Attachment          `json:"-"`
+	Breadcrumbs []*Breadcrumb      `json:"breadcrumbs,omitempty"`
+	Contexts    map[string]Context `json:"contexts,omitempty"`
+	Dist        string             `json:"dist,omitempty"`
+	Environment string             `json:"environment,omitempty"`
+	EventID     EventID            `json:"event_id,omitempty"`
+	Fingerprint []string           `json:"fingerprint,omitempty"`
+	Level       Level              `json:"level,omitempty"`
+	Message     string             `json:"message,omitempty"`
+	Platform    string             `json:"platform,omitempty"`
+	Release     string             `json:"release,omitempty"`
+	Sdk         SdkInfo            `json:"sdk,omitempty"`
+	ServerName  string             `json:"server_name,omitempty"`
+	Threads     []Thread           `json:"threads,omitempty"`
+	Tags        map[string]string  `json:"tags,omitempty"`
+	Timestamp   time.Time          `json:"timestamp,omitzero"`
+	Transaction string             `json:"transaction,omitempty"`
+	User        User               `json:"user,omitempty"`
+	Logger      string             `json:"logger,omitempty"`
+	Modules     map[string]string  `json:"modules,omitempty"`
+	Request     *Request           `json:"request,omitempty"`
+	Exception   []Exception        `json:"exception,omitempty"`
+	DebugMeta   *DebugMeta         `json:"debug_meta,omitempty"`
+	Attachments []*Attachment      `json:"-"`
 
 	// The fields below are only relevant for transactions.
 
@@ -421,7 +420,7 @@ type Event struct {
 	sdkMetaData SDKMetaData
 
 	// Pre-serialized copies of mutable fields, set by MakeSerializationSafe.
-	serializedExtra       json.RawMessage
+	serializedTags        json.RawMessage
 	serializedContexts    json.RawMessage
 	serializedBreadcrumbs json.RawMessage
 	serializedException   json.RawMessage
@@ -597,7 +596,7 @@ func (e *Event) defaultMarshalJSON() ([]byte, error) {
 }
 
 func (e *Event) hasPreSerializedFields() bool {
-	return e.serializedExtra != nil ||
+	return e.serializedTags != nil ||
 		e.serializedContexts != nil ||
 		e.serializedBreadcrumbs != nil ||
 		e.serializedException != nil ||
@@ -613,7 +612,7 @@ func (e *Event) preSerializedMarshalJSON() ([]byte, error) {
 	if e.Type == transactionType {
 		type safeTransaction struct {
 			*event
-			Extra       json.RawMessage `json:"extra,omitempty"`
+			Tags        json.RawMessage `json:"tags,omitempty"`
 			Contexts    json.RawMessage `json:"contexts,omitempty"`
 			Breadcrumbs json.RawMessage `json:"breadcrumbs,omitempty"`
 			Exception   json.RawMessage `json:"exception,omitempty"`
@@ -621,7 +620,7 @@ func (e *Event) preSerializedMarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(safeTransaction{
 			event:       (*event)(e),
-			Extra:       e.serializedExtra,
+			Tags:        e.serializedTags,
 			Contexts:    e.serializedContexts,
 			Breadcrumbs: e.serializedBreadcrumbs,
 			Exception:   e.serializedException,
@@ -632,7 +631,7 @@ func (e *Event) preSerializedMarshalJSON() ([]byte, error) {
 	// Error event: also shadow transaction-only fields to exclude them.
 	type safeErrorEvent struct {
 		*event
-		Extra           json.RawMessage `json:"extra,omitempty"`
+		Tags            json.RawMessage `json:"tags,omitempty"`
 		Contexts        json.RawMessage `json:"contexts,omitempty"`
 		Breadcrumbs     json.RawMessage `json:"breadcrumbs,omitempty"`
 		Exception       json.RawMessage `json:"exception,omitempty"`
@@ -644,7 +643,7 @@ func (e *Event) preSerializedMarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(safeErrorEvent{
 		event:       (*event)(e),
-		Extra:       e.serializedExtra,
+		Tags:        e.serializedTags,
 		Contexts:    e.serializedContexts,
 		Breadcrumbs: e.serializedBreadcrumbs,
 		Exception:   e.serializedException,
@@ -698,7 +697,6 @@ func (e *Event) toCategory() ratelimit.Category {
 func NewEvent() *Event {
 	return &Event{
 		Contexts: make(map[string]Context),
-		Extra:    make(map[string]interface{}),
 		Tags:     make(map[string]string),
 		Modules:  make(map[string]string),
 	}
@@ -876,9 +874,9 @@ func (v MetricValue) MarshalJSON() ([]byte, error) {
 // MakeSerializationSafe pre-serializes all fields containing user mutable data to json.RawMessage, preventing race
 // conditions when the event is later serialized on a background goroutine.
 func (e *Event) MakeSerializationSafe() {
-	if len(e.Extra) > 0 {
-		if b, err := json.Marshal(e.Extra); err == nil {
-			e.serializedExtra = b
+	if len(e.Tags) > 0 {
+		if b, err := json.Marshal(e.Tags); err == nil {
+			e.serializedTags = b
 		}
 	}
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -463,28 +463,7 @@ func (e *Event) safeMarshal() (b []byte, err error) {
 func (e *Event) ToEnvelopeItem() (item *protocol.EnvelopeItem, err error) {
 	eventBody, err := e.safeMarshal()
 	if err != nil {
-		// Try fallback: remove problematic fields and retry.
-		// Clear both original and pre-serialized versions.
-		e.Breadcrumbs = nil
-		e.serializedBreadcrumbs = nil
-		e.Contexts = nil
-		e.serializedContexts = nil
-		e.serializedException = nil
-		e.serializedUser = nil
-		e.serializedExtra = nil
-		e.Extra = map[string]interface{}{
-			"info": fmt.Sprintf("Could not encode original event as JSON. "+
-				"Succeeded by removing Breadcrumbs, Contexts and Extra. "+
-				"Please verify the data you attach to the scope. "+
-				"Error: %s", err),
-		}
-
-		eventBody, err = json.Marshal(e)
-		if err != nil {
-			return nil, fmt.Errorf("event could not be marshaled even with fallback: %w", err)
-		}
-
-		DebugLogger.Printf("Event marshaling succeeded with fallback after removing problematic fields")
+		return nil, fmt.Errorf("could not encode event as JSON, skipping delivery: %w", err)
 	}
 
 	// TODO: all event types should be abstracted to implement EnvelopeItemConvertible and convert themselves.

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -628,9 +628,6 @@ func TestStructSnapshots(t *testing.T) {
 						"data_key": "data_val",
 					},
 				}},
-				Extra: map[string]interface{}{
-					"extra_key": "extra_val",
-				},
 				Contexts: map[string]Context{
 					"context_key": {
 						"context_key": "context_val",
@@ -929,30 +926,6 @@ func TestMetric_GetterMethods(t *testing.T) {
 }
 
 func TestMakeSerializationSafe(t *testing.T) {
-	t.Run("pre-serializes Extra", func(t *testing.T) {
-		event := &Event{
-			Extra: map[string]interface{}{
-				"key": "value",
-				"nested": map[string]interface{}{
-					"inner": "data",
-				},
-			},
-		}
-		event.MakeSerializationSafe()
-
-		if event.serializedExtra == nil {
-			t.Fatal("serializedExtra should be set")
-		}
-
-		var got map[string]interface{}
-		if err := json.Unmarshal(event.serializedExtra, &got); err != nil {
-			t.Fatalf("invalid serializedExtra JSON: %v", err)
-		}
-		if got["key"] != "value" {
-			t.Errorf("expected key=value, got %v", got["key"])
-		}
-	})
-
 	t.Run("pre-serializes Contexts", func(t *testing.T) {
 		event := &Event{
 			Contexts: map[string]Context{
@@ -1021,8 +994,7 @@ func TestMakeSerializationSafe(t *testing.T) {
 
 	t.Run("pre-serializes User when Data is empty", func(t *testing.T) {
 		event := &Event{
-			Extra: map[string]interface{}{"key": "value"},
-			User:  User{ID: "1", Email: "user@example.com"},
+			User: User{ID: "1", Email: "user@example.com"},
 		}
 		event.MakeSerializationSafe()
 
@@ -1091,9 +1063,9 @@ func TestMakeSerializationSafe(t *testing.T) {
 			EventID: "12345678901234567890123456789012",
 			Message: "test message",
 			Level:   LevelError,
-			Extra: map[string]interface{}{
+			Tags: map[string]string{
 				"string_val": "hello",
-				"number_val": float64(42),
+				"number_val": "42",
 			},
 			Contexts: map[string]Context{
 				"os": {"name": "linux", "version": "5.4"},
@@ -1116,9 +1088,9 @@ func TestMakeSerializationSafe(t *testing.T) {
 			EventID: "12345678901234567890123456789012",
 			Message: "test message",
 			Level:   LevelError,
-			Extra: map[string]interface{}{
+			Tags: map[string]string{
 				"string_val": "hello",
-				"number_val": float64(42),
+				"number_val": "42",
 			},
 			Contexts: map[string]Context{
 				"os": {"name": "linux", "version": "5.4"},
@@ -1156,17 +1128,15 @@ func TestMakeSerializationSafe(t *testing.T) {
 }
 
 func TestMakeSerializationSafe_ConcurrentAccess(t *testing.T) {
-	extra := map[string]interface{}{
-		"key1": "value1",
+	ctx := Context{
+		"info": "context_value",
 		"nested": map[string]interface{}{
 			"inner": "data",
 		},
 	}
-	ctx := Context{"info": "context_value"}
 	bcData := map[string]interface{}{"bc_key": "bc_value"}
 
 	event := &Event{
-		Extra:    extra,
 		Contexts: map[string]Context{"ctx": ctx},
 		Breadcrumbs: []*Breadcrumb{
 			{Message: "crumb", Data: bcData},
@@ -1191,9 +1161,6 @@ func TestMakeSerializationSafe_ConcurrentAccess(t *testing.T) {
 	}()
 	close(start)
 	for range 1000 {
-		extra["key1"] = "mutated"
-		extra["new_key"] = "new_value"
-		delete(extra, "new_key")
 		ctx["info"] = "mutated"
 		bcData["bc_key"] = "mutated"
 		event.User.Data["role"] = "mutated"
@@ -1272,10 +1239,6 @@ func TestProcessor_MutationAfterAdd(t *testing.T) {
 
 	proc := telemetry.NewProcessor(buffers, transport, dsn, func() *protocol.SdkInfo { return sdk }, nil)
 
-	extra := map[string]interface{}{
-		"request_id": "original-123",
-		"nested":     map[string]interface{}{"deep": "value"},
-	}
 	contexts := map[string]Context{
 		"app": {"version": "1.0"},
 	}
@@ -1283,10 +1246,13 @@ func TestProcessor_MutationAfterAdd(t *testing.T) {
 	mechData := map[string]any{"errno": float64(42)}
 
 	event := &Event{
-		EventID:  "aaaabbbbccccddddeeeeffffaaaabbbb",
-		Message:  "test event",
-		Level:    LevelError,
-		Extra:    extra,
+		EventID: "aaaabbbbccccddddeeeeffffaaaabbbb",
+		Message: "test event",
+		Level:   LevelError,
+		Tags: map[string]string{
+			"request_id": "original-123",
+			"nested":     "map[deep:value]",
+		},
 		Contexts: contexts,
 		Breadcrumbs: []*Breadcrumb{
 			{Message: "clicked", Data: bcData},
@@ -1309,9 +1275,9 @@ func TestProcessor_MutationAfterAdd(t *testing.T) {
 		t.Fatal("Add returned false")
 	}
 
-	extra["request_id"] = "MUTATED"
-	delete(extra, "nested")
-	extra["injected"] = "should-not-appear"
+	event.Tags["request_id"] = "MUTATED"
+	delete(event.Tags, "nested")
+	event.Tags["injected"] = "should-not-appear"
 	contexts["app"]["version"] = "MUTATED"
 	bcData["target"] = "MUTATED"
 	mechData["errno"] = "MUTATED"
@@ -1329,16 +1295,15 @@ func TestProcessor_MutationAfterAdd(t *testing.T) {
 		t.Fatalf("invalid JSON payload: %v", err)
 	}
 
-	gotExtra, _ := body["extra"].(map[string]interface{})
-	if gotExtra["request_id"] != "original-123" {
-		t.Errorf("extra.request_id = %v, want original-123", gotExtra["request_id"])
+	gotTags, _ := body["tags"].(map[string]interface{})
+	if gotTags["request_id"] != "original-123" {
+		t.Errorf("tags.request_id = %v, want original-123", gotTags["request_id"])
 	}
-	if _, ok := gotExtra["injected"]; ok {
-		t.Error("injected key should not appear in serialized extra")
+	if _, ok := gotTags["injected"]; ok {
+		t.Error("injected key should not appear in serialized tags")
 	}
-	nested, _ := gotExtra["nested"].(map[string]interface{})
-	if nested["deep"] != "value" {
-		t.Errorf("extra.nested.deep = %v, want value", nested["deep"])
+	if gotTags["nested"] != "map[deep:value]" {
+		t.Errorf("tags.nested = %v, want map[deep:value]", gotTags["nested"])
 	}
 	gotContexts, _ := body["contexts"].(map[string]interface{})
 	gotApp, _ := gotContexts["app"].(map[string]interface{})

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -709,61 +709,52 @@ func TestEvent_ToCategory(t *testing.T) {
 	}
 }
 
-func TestEvent_ToEnvelopeItem_FallbackOnMarshalError(t *testing.T) {
-	unmarshalableFunc := func() string { return "test" }
-
+func TestEvent_ToEnvelopeItem_ErrorOnMarshalFailure(t *testing.T) {
 	event := &Event{
-		EventID:   "12345678901234567890123456789012",
-		Message:   "test message with fallback",
-		Level:     LevelError,
-		Timestamp: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
-		Extra: map[string]interface{}{
-			"bad_data": unmarshalableFunc,
-		},
+		EventID: "12345678901234567890123456789012",
+		Exception: []Exception{{
+			Stacktrace: &Stacktrace{
+				Frames: []Frame{{
+					Vars: map[string]interface{}{
+						"bad": func() string { return "test" },
+					},
+				}},
+			},
+		}},
 	}
 
 	item, err := event.ToEnvelopeItem()
-	if err != nil {
-		t.Errorf("ToEnvelopeItem() should not error even with unmarshalable data, got: %v", err)
-		return
+	if err == nil {
+		t.Fatal("ToEnvelopeItem() expected error for unmarshalable event, got nil")
 	}
-	if item == nil {
-		t.Fatal("ToEnvelopeItem() returned nil item")
-	}
-
-	var payload map[string]interface{}
-	if err := json.Unmarshal(item.Payload, &payload); err != nil {
-		t.Fatalf("Failed to unmarshal item payload: %v", err)
-	}
-
-	extra, exists := payload["extra"].(map[string]interface{})
-	if !exists {
-		t.Fatal("Expected extra field after fallback in ToEnvelopeItem")
-	}
-
-	info, exists := extra["info"].(string)
-	if !exists || !strings.Contains(info, "Could not encode original event as JSON") {
-		t.Fatal("Expected fallback info message in extra field for ToEnvelopeItem")
+	if item != nil {
+		t.Fatal("ToEnvelopeItem() expected nil item on marshal failure")
 	}
 }
 
 func TestEvent_ToEnvelopeItem_RecoverFromPanic(t *testing.T) {
 	// Verify that safeMarshal recovers from panics and ToEnvelopeItem
-	// falls back to a stripped-down event instead of crashing.
+	// returns an error instead of crashing.
 	event := &Event{
 		EventID: "panic-test",
-		Extra: map[string]interface{}{
-			// json.Marshal will panic on a channel value.
-			"bad": make(chan int),
-		},
+		Exception: []Exception{{
+			Stacktrace: &Stacktrace{
+				Frames: []Frame{{
+					Vars: map[string]interface{}{
+						// json.Marshal will error on a channel value.
+						"bad": make(chan int),
+					},
+				}},
+			},
+		}},
 	}
 
 	item, err := event.ToEnvelopeItem()
-	if err != nil {
-		t.Fatalf("ToEnvelopeItem() should recover from panic and use fallback, got error: %v", err)
+	if err == nil {
+		t.Fatal("ToEnvelopeItem() expected error from unmarshalable data, got nil")
 	}
-	if item == nil {
-		t.Fatal("ToEnvelopeItem() returned nil item after panic recovery")
+	if item != nil {
+		t.Fatal("ToEnvelopeItem() expected nil item on marshal failure")
 	}
 }
 

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -28,7 +28,6 @@ var DefaultEventCmpOpts = cmp.Options{
 	cmpopts.IgnoreFields(sentry.Event{},
 		"Contexts",
 		"EventID",
-		"Extra",
 		"Modules",
 		"Platform",
 		"Release",

--- a/internal/telemetry/scheduler.go
+++ b/internal/telemetry/scheduler.go
@@ -299,6 +299,7 @@ func (s *Scheduler) sendItem(item protocol.EnvelopeItemConvertible) {
 	envItem, err := item.ToEnvelopeItem()
 	if err != nil {
 		debuglog.Printf("error while converting to envelope item: %v", err)
+		s.recorder.RecordItem(report.ReasonInternalError, item)
 		return
 	}
 	envelope.AddItem(envItem)

--- a/iris/sentryiris_test.go
+++ b/iris/sentryiris_test.go
@@ -427,10 +427,11 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 			"sdkMetaData",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(
@@ -456,7 +457,8 @@ func TestIntegration(t *testing.T) {
 			"EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"sdkMetaData", "StartTime", "Spans",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -164,33 +164,31 @@ func (h *eventHook) Fire(entry *logrus.Entry) error {
 }
 
 func (h *eventHook) entryToEvent(l *logrus.Entry) *sentry.Event {
-	data := make(logrus.Fields, len(l.Data))
+	extra := make(logrus.Fields, len(l.Data))
 	for k, v := range l.Data {
-		data[k] = v
+		extra[k] = v
 	}
-	s := &sentry.Event{
-		Level:     levelMap[l.Level],
-		Extra:     data,
-		Message:   l.Message,
-		Timestamp: l.Time,
-		Logger:    name,
-	}
+	s := sentry.NewEvent()
+	s.Level = levelMap[l.Level]
+	s.Message = l.Message
+	s.Timestamp = l.Time
+	s.Logger = name
 
 	key := h.key(FieldRequest)
-	switch request := s.Extra[key].(type) {
+	switch request := extra[key].(type) {
 	case *http.Request:
-		delete(s.Extra, key)
+		delete(extra, key)
 		s.Request = sentry.NewRequest(request)
 	case sentry.Request:
-		delete(s.Extra, key)
+		delete(extra, key)
 		s.Request = &request
 	case *sentry.Request:
-		delete(s.Extra, key)
+		delete(extra, key)
 		s.Request = request
 	}
 
-	if err, ok := s.Extra[logrus.ErrorKey].(error); ok {
-		delete(s.Extra, logrus.ErrorKey)
+	if err, ok := extra[logrus.ErrorKey].(error); ok {
+		delete(extra, logrus.ErrorKey)
 
 		errorDepth := maxErrorDepth
 		if hub := h.hubProvider(); hub != nil {
@@ -202,29 +200,33 @@ func (h *eventHook) entryToEvent(l *logrus.Entry) *sentry.Event {
 	}
 
 	key = h.key(FieldUser)
-	switch user := s.Extra[key].(type) {
+	switch user := extra[key].(type) {
 	case sentry.User:
-		delete(s.Extra, key)
+		delete(extra, key)
 		s.User = user
 	case *sentry.User:
-		delete(s.Extra, key)
+		delete(extra, key)
 		s.User = *user
 	}
 
 	key = h.key(FieldTransaction)
-	if txn, ok := s.Extra[key].(string); ok {
-		delete(s.Extra, key)
+	if txn, ok := extra[key].(string); ok {
+		delete(extra, key)
 		s.Transaction = txn
 	}
 
 	key = h.key(FieldFingerprint)
-	if fp, ok := s.Extra[key].([]string); ok {
-		delete(s.Extra, key)
+	if fp, ok := extra[key].([]string); ok {
+		delete(extra, key)
 		s.Fingerprint = fp
 	}
 
-	delete(s.Extra, FieldGoVersion)
-	delete(s.Extra, FieldMaxProcs)
+	delete(extra, FieldGoVersion)
+	delete(extra, FieldMaxProcs)
+
+	for key, value := range extra {
+		s.Tags[key] = fmt.Sprint(value)
+	}
 	return s
 }
 

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -228,7 +228,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			entry: &logrus.Entry{},
 			want: &sentry.Event{
 				Level:  "fatal",
-				Extra:  map[string]any{},
 				Logger: name,
 			},
 		},
@@ -241,7 +240,7 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level:  sentry.LevelFatal,
-				Extra:  map[string]any{"bar": "oink", "foo": 123.4},
+				Tags:   map[string]string{"bar": "oink", "foo": "123.4"},
 				Logger: name,
 			},
 		},
@@ -251,7 +250,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level:  sentry.LevelInfo,
-				Extra:  map[string]any{},
 				Logger: name,
 			},
 		},
@@ -261,7 +259,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level:   sentry.LevelFatal,
-				Extra:   map[string]any{},
 				Message: "the only thing we have to fear is fear itself",
 				Logger:  name,
 			},
@@ -272,7 +269,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level:     sentry.LevelFatal,
-				Extra:     map[string]any{},
 				Timestamp: time.Unix(1, 2).UTC(),
 				Logger:    name,
 			},
@@ -285,7 +281,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				Request: &sentry.Request{
 					URL:     "http://example.com/",
 					Method:  http.MethodGet,
@@ -305,7 +300,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				Request: &sentry.Request{
 					URL:    "http://example.com/",
 					Method: http.MethodGet,
@@ -324,7 +318,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				Request: &sentry.Request{
 					URL:    "http://example.com/",
 					Method: http.MethodGet,
@@ -340,7 +333,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				Exception: []sentry.Exception{
 					{Type: "*errors.errorString", Value: "things failed", Stacktrace: &sentry.Stacktrace{Frames: []sentry.Frame{}}},
 				},
@@ -354,10 +346,8 @@ func TestEventHook_entryToEvent(t *testing.T) {
 				},
 			},
 			want: &sentry.Event{
-				Level: sentry.LevelFatal,
-				Extra: map[string]any{
-					"error": "this isn't really an error",
-				},
+				Level:  sentry.LevelFatal,
+				Tags:   map[string]string{"error": "this isn't really an error"},
 				Logger: name,
 			},
 		},
@@ -369,7 +359,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				Exception: []sentry.Exception{
 					{
 						Type:       "*errors.errorString",
@@ -411,7 +400,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				User: sentry.User{
 					ID: "bob",
 				},
@@ -428,7 +416,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			},
 			want: &sentry.Event{
 				Level: sentry.LevelFatal,
-				Extra: map[string]any{},
 				User: sentry.User{
 					ID: "alice",
 				},
@@ -442,10 +429,8 @@ func TestEventHook_entryToEvent(t *testing.T) {
 				},
 			},
 			want: &sentry.Event{
-				Level: sentry.LevelFatal,
-				Extra: map[string]any{
-					"user": "just say no to drugs",
-				},
+				Level:  sentry.LevelFatal,
+				Tags:   map[string]string{"user": "just say no to drugs"},
 				Logger: name,
 			},
 		},
@@ -458,7 +443,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			want: &sentry.Event{
 				Level:       sentry.LevelError,
 				Message:     "transaction error",
-				Extra:       map[string]any{},
 				Transaction: "payment_process",
 				Logger:      name,
 			},
@@ -472,7 +456,6 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			want: &sentry.Event{
 				Level:       sentry.LevelError,
 				Message:     "fingerprinted error",
-				Extra:       map[string]any{},
 				Fingerprint: []string{"{{ default }}", "custom-fingerprint"},
 				Logger:      name,
 			},
@@ -498,8 +481,9 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			got := hook.entryToEvent(tt.entry)
 			opts := cmp.Options{
 				cmpopts.IgnoreFields(sentry.Event{}, "Contexts", "EventID", "Platform", "Release", "ServerName", "Modules", "Sdk", "Timestamp"),
-				cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+				cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 				cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
+				cmpopts.EquateEmpty(),
 			}
 			if d := cmp.Diff(tt.want, got, opts); d != "" {
 				t.Errorf("entryToEvent mismatch (-want +got):\n%s", d)

--- a/negroni/sentrynegroni_test.go
+++ b/negroni/sentrynegroni_test.go
@@ -361,10 +361,11 @@ func TestIntegration(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(
 			sentry.Event{},
-			"Contexts", "EventID", "Extra", "Platform", "Modules",
+			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 			"sdkMetaData",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(
@@ -390,7 +391,8 @@ func TestIntegration(t *testing.T) {
 			"EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"sdkMetaData", "StartTime", "Spans",
-			"serializedExtra", "serializedContexts", "serializedBreadcrumbs",
+			"serializedTags",
+			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser",
 		),
 		cmpopts.IgnoreFields(

--- a/scope.go
+++ b/scope.go
@@ -37,7 +37,6 @@ type Scope struct {
 	user        User
 	tags        map[string]string
 	contexts    map[string]Context
-	extra       map[string]interface{}
 	fingerprint []string
 	level       Level
 	request     *http.Request
@@ -64,7 +63,6 @@ func NewScope() *Scope {
 		attachments:        make([]*Attachment, 0),
 		tags:               make(map[string]string),
 		contexts:           make(map[string]Context),
-		extra:              make(map[string]interface{}),
 		fingerprint:        make([]string, 0),
 		propagationContext: NewPropagationContext(),
 	}
@@ -282,44 +280,6 @@ func (scope *Scope) RemoveContext(key string) {
 	delete(scope.contexts, key)
 }
 
-// SetExtra adds an extra to the current scope.
-//
-// Deprecated: Use [Scope.SetAttributes] instead, which attaches typed key-value
-// pairs to logs and metrics. Note that attributes do not attach to error events;
-// if you only capture errors, use [Scope.SetTag] or [Scope.SetContext] to enrich them.
-func (scope *Scope) SetExtra(key string, value interface{}) {
-	scope.mu.Lock()
-	defer scope.mu.Unlock()
-
-	scope.extra[key] = value
-}
-
-// SetExtras assigns multiple extras to the current scope.
-//
-// Deprecated: Use [Scope.SetAttributes] instead, which attaches typed key-value
-// pairs to logs and metrics. Note that attributes do not attach to error events;
-// if you only capture errors, use [Scope.SetTag] or [Scope.SetContext] to enrich them.
-func (scope *Scope) SetExtras(extra map[string]interface{}) {
-	scope.mu.Lock()
-	defer scope.mu.Unlock()
-
-	for k, v := range extra {
-		scope.extra[k] = v
-	}
-}
-
-// RemoveExtra removes a extra from the current scope.
-//
-// Deprecated: Use [Scope.RemoveAttribute] instead. Note that attributes only
-// attach to logs and metrics, not error events. If you only capture errors,
-// use [Scope.RemoveTag] or [Scope.RemoveContext] instead.
-func (scope *Scope) RemoveExtra(key string) {
-	scope.mu.Lock()
-	defer scope.mu.Unlock()
-
-	delete(scope.extra, key)
-}
-
 // SetFingerprint sets new fingerprint for the current scope.
 func (scope *Scope) SetFingerprint(fingerprint []string) {
 	scope.mu.Lock()
@@ -374,7 +334,6 @@ func (scope *Scope) Clone() *Scope {
 	clone.attributes = maps.Clone(scope.attributes)
 	clone.contexts = maps.Clone(scope.contexts)
 	clone.tags = maps.Clone(scope.tags)
-	clone.extra = maps.Clone(scope.extra)
 	clone.fingerprint = make([]string, len(scope.fingerprint))
 	copy(clone.fingerprint, scope.fingerprint)
 	clone.level = scope.level
@@ -484,16 +443,6 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		}
 	}
 
-	if len(scope.extra) > 0 {
-		if event.Extra == nil {
-			event.Extra = make(map[string]interface{}, len(scope.extra))
-		}
-
-		for key, value := range scope.extra {
-			event.Extra[key] = value
-		}
-	}
-
 	if event.User.IsEmpty() {
 		event.User = scope.user
 	}
@@ -516,7 +465,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		// invalid payloads that are more prone to leaking PII data.
 		//
 		// Users can still send more data along their events if they want to,
-		// for example using Event.Extra.
+		// for example using Event.Contexts.
 		if scope.requestBody != nil && !scope.requestBody.Overflow() {
 			event.Request.Data = string(scope.requestBody.Bytes())
 		}

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -51,7 +51,6 @@ func TestConcurrentScopeUsage(_ *testing.T) {
 func touchScope(scope *sentry.Scope, x int) {
 	scope.SetTag("foo", "bar")
 	scope.SetContext("foo", sentry.Context{"foo": "bar"})
-	scope.SetExtra("foo", "bar")
 	scope.SetAttributes(attribute.String("foo", "bar"))
 	scope.RemoveAttribute("foo")
 	scope.SetLevel(sentry.LevelDebug)

--- a/scope_test.go
+++ b/scope_test.go
@@ -27,7 +27,7 @@ func fillScopeWithData(scope *Scope) *Scope {
 		"scopeContextsKey": {"scopeContextKey": "scopeContextValue"},
 		sharedContextsKey:  {"scopeContextKey": "scopeContextValue"},
 	}
-	scope.extra = map[string]interface{}{"scopeExtraKey": "scopeExtraValue"}
+	scope.attributes = map[string]attribute.Value{"scopeAttributeKey": attribute.StringValue("scopeAttributeValue")}
 	scope.fingerprint = []string{"scopeFingerprintOne", "scopeFingerprintTwo"}
 	scope.level = LevelDebug
 	scope.request = httptest.NewRequest("GET", "/wat", nil)
@@ -49,7 +49,6 @@ func fillEventWithData(event *Event) *Event {
 		"eventContextsKey": {"eventContextKey": "eventContextValue"},
 		sharedContextsKey:  {"eventContextKey": "eventContextKey"},
 	}
-	event.Extra = map[string]interface{}{"eventExtraKey": "eventExtraValue"}
 	event.Fingerprint = []string{"eventFingerprintOne", "eventFingerprintTwo"}
 	event.Level = LevelInfo
 	event.Transaction = "aye"
@@ -267,76 +266,6 @@ func TestScopeRemoveContextOnEmptyScope(t *testing.T) {
 	assertEqual(t, make(map[string]Context), scope.contexts)
 }
 
-func TestScopeSetExtra(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtra("a", 1)
-
-	assertEqual(t, map[string]interface{}{"a": 1}, scope.extra)
-}
-
-func TestScopeSetExtraMerges(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtra("a", "foo")
-	scope.SetExtra("b", 2)
-
-	assertEqual(t, map[string]interface{}{"a": "foo", "b": 2}, scope.extra)
-}
-
-func TestScopeSetExtraOverrides(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtra("a", "foo")
-	scope.SetExtra("a", 2)
-
-	assertEqual(t, map[string]interface{}{"a": 2}, scope.extra)
-}
-
-func TestScopeSetExtras(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtras(map[string]interface{}{"a": 1})
-
-	assertEqual(t, map[string]interface{}{"a": 1}, scope.extra)
-}
-
-func TestScopeSetExtrasMerges(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtras(map[string]interface{}{"a": "foo"})
-	scope.SetExtras(map[string]interface{}{"b": 2, "c": 3})
-
-	assertEqual(t, map[string]interface{}{"a": "foo", "b": 2, "c": 3}, scope.extra)
-}
-
-func TestScopeSetExtrasOverrides(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtras(map[string]interface{}{"a": "foo"})
-	scope.SetExtras(map[string]interface{}{"a": 2, "b": 3})
-
-	assertEqual(t, map[string]interface{}{"a": 2, "b": 3}, scope.extra)
-}
-
-func TestScopeRemoveExtra(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtra("a", "foo")
-	scope.SetExtra("b", "bar")
-	scope.RemoveExtra("b")
-
-	assertEqual(t, map[string]interface{}{"a": "foo"}, scope.extra)
-}
-
-func TestScopeRemoveExtraSkipsEmptyValues(t *testing.T) {
-	scope := NewScope()
-	scope.SetExtra("a", "foo")
-	scope.RemoveExtra("b")
-
-	assertEqual(t, map[string]interface{}{"a": "foo"}, scope.extra)
-}
-
-func TestScopeRemoveExtraOnEmptyScope(t *testing.T) {
-	scope := NewScope()
-	scope.RemoveExtra("b")
-
-	assertEqual(t, make(map[string]Context), scope.contexts)
-}
-
 func TestScopeSetFingerprint(t *testing.T) {
 	scope := NewScope()
 	scope.SetFingerprint([]string{"abcd"})
@@ -430,14 +359,14 @@ func TestAddAttachmentAppendsAttachment(t *testing.T) {
 
 func TestScopeBasicInheritance(t *testing.T) {
 	scope := NewScope()
-	scope.SetExtra("a", 1)
+	scope.SetAttributes(attribute.Int("a", 1))
 	scope.SetRequestBody([]byte("requestbody"))
 	scope.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
 		return event
 	})
 	clone := scope.Clone()
 
-	assertEqual(t, scope.extra, clone.extra)
+	assertEqual(t, scope.attributes, clone.attributes)
 	assertEqual(t, scope.requestBody, clone.requestBody)
 	assertEqual(t, scope.eventProcessors, clone.eventProcessors)
 }
@@ -448,7 +377,7 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 
 	clone.SetTag("foo", "bar")
 	clone.SetContext("foo", Context{"foo": "bar"})
-	clone.SetExtra("foo", "bar")
+	clone.SetAttributes(attribute.String("foo", "bar"))
 	clone.SetLevel(LevelDebug)
 	clone.SetFingerprint([]string{"foo"})
 	clone.AddBreadcrumb(&Breadcrumb{Timestamp: testNow, Message: "foo"}, defaultMaxBreadcrumbs)
@@ -463,7 +392,7 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 
 	scope.SetTag("foo", "baz")
 	scope.SetContext("foo", Context{"foo": "baz"})
-	scope.SetExtra("foo", "baz")
+	scope.SetAttributes(attribute.String("foo", "baz"))
 	scope.SetLevel(LevelFatal)
 	scope.SetFingerprint([]string{"bar"})
 	scope.AddBreadcrumb(&Breadcrumb{Timestamp: testNow, Message: "bar"}, defaultMaxBreadcrumbs)
@@ -478,7 +407,7 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 
 	assertEqual(t, map[string]string{"foo": "bar"}, clone.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "bar"}}, clone.contexts)
-	assertEqual(t, map[string]interface{}{"foo": "bar"}, clone.extra)
+	assertEqual(t, map[string]attribute.Value{"foo": attribute.StringValue("bar")}, clone.attributes)
 	assertEqual(t, LevelDebug, clone.level)
 	assertEqual(t, []string{"foo"}, clone.fingerprint)
 	assertEqual(t, []*Breadcrumb{{Timestamp: testNow, Message: "foo"}}, clone.breadcrumbs)
@@ -490,7 +419,7 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 
 	assertEqual(t, map[string]string{"foo": "baz"}, scope.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "baz"}}, scope.contexts)
-	assertEqual(t, map[string]interface{}{"foo": "baz"}, scope.extra)
+	assertEqual(t, map[string]attribute.Value{"foo": attribute.StringValue("baz")}, scope.attributes)
 	assertEqual(t, LevelFatal, scope.level)
 	assertEqual(t, []string{"bar"}, scope.fingerprint)
 	assertEqual(t, []*Breadcrumb{{Timestamp: testNow, Message: "bar"}}, scope.breadcrumbs)
@@ -505,7 +434,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 
 	scope.SetTag("foo", "baz")
 	scope.SetContext("foo", Context{"foo": "baz"})
-	scope.SetExtra("foo", "baz")
+	scope.SetAttributes(attribute.String("foo", "baz"))
 	scope.SetLevel(LevelFatal)
 	scope.SetFingerprint([]string{"bar"})
 	scope.AddBreadcrumb(&Breadcrumb{Timestamp: testNow, Message: "bar"}, defaultMaxBreadcrumbs)
@@ -524,7 +453,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 	clone := scope.Clone()
 	clone.SetTag("foo", "bar")
 	clone.SetContext("foo", Context{"foo": "bar"})
-	clone.SetExtra("foo", "bar")
+	clone.SetAttributes(attribute.String("foo", "bar"))
 	clone.SetLevel(LevelDebug)
 	clone.SetFingerprint([]string{"foo"})
 	clone.AddBreadcrumb(&Breadcrumb{Timestamp: testNow, Message: "foo"}, defaultMaxBreadcrumbs)
@@ -542,7 +471,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 
 	assertEqual(t, map[string]string{"foo": "bar"}, clone.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "bar"}}, clone.contexts)
-	assertEqual(t, map[string]interface{}{"foo": "bar"}, clone.extra)
+	assertEqual(t, map[string]attribute.Value{"foo": attribute.StringValue("bar")}, clone.attributes)
 	assertEqual(t, LevelDebug, clone.level)
 	assertEqual(t, []string{"foo"}, clone.fingerprint)
 	assertEqual(t, []*Breadcrumb{
@@ -560,7 +489,7 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 
 	assertEqual(t, map[string]string{"foo": "baz"}, scope.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "baz"}}, scope.contexts)
-	assertEqual(t, map[string]interface{}{"foo": "baz"}, scope.extra)
+	assertEqual(t, map[string]attribute.Value{"foo": attribute.StringValue("baz")}, scope.attributes)
 	assertEqual(t, LevelFatal, scope.level)
 	assertEqual(t, []string{"bar"}, scope.fingerprint)
 	assertEqual(t, []*Breadcrumb{{Timestamp: testNow, Message: "bar"}}, scope.breadcrumbs)
@@ -583,7 +512,7 @@ func TestClear(t *testing.T) {
 	assertEqual(t, User{}, scope.user)
 	assertEqual(t, map[string]string{}, scope.tags)
 	assertEqual(t, map[string]Context{}, scope.contexts)
-	assertEqual(t, map[string]interface{}{}, scope.extra)
+	assertEqual(t, map[string]attribute.Value{}, scope.attributes)
 	assertEqual(t, []string{}, scope.fingerprint)
 	assertEqual(t, Level(""), scope.level)
 	assertEqual(t, (*http.Request)(nil), scope.request)
@@ -596,7 +525,7 @@ func TestClearAndReconfigure(t *testing.T) {
 
 	scope.SetTag("foo", "bar")
 	scope.SetContext("foo", Context{"foo": "bar"})
-	scope.SetExtra("foo", "bar")
+	scope.SetAttributes(attribute.String("foo", "bar"))
 	scope.SetLevel(LevelDebug)
 	scope.SetFingerprint([]string{"foo"})
 	scope.AddBreadcrumb(&Breadcrumb{Timestamp: testNow, Message: "foo"}, defaultMaxBreadcrumbs)
@@ -611,7 +540,7 @@ func TestClearAndReconfigure(t *testing.T) {
 
 	assertEqual(t, map[string]string{"foo": "bar"}, scope.tags)
 	assertEqual(t, map[string]Context{"foo": {"foo": "bar"}}, scope.contexts)
-	assertEqual(t, map[string]interface{}{"foo": "bar"}, scope.extra)
+	assertEqual(t, map[string]attribute.Value{"foo": attribute.StringValue("bar")}, scope.attributes)
 	assertEqual(t, LevelDebug, scope.level)
 	assertEqual(t, []string{"foo"}, scope.fingerprint)
 	assertEqual(t, []*Breadcrumb{{Timestamp: testNow, Message: "foo"}}, scope.breadcrumbs)
@@ -647,7 +576,6 @@ func TestApplyToEventWithCorrectScopeAndEvent(t *testing.T) {
 	assertEqual(t, 2, len(processedEvent.Tags), "should merge tags")
 	assertEqual(t, 4, len(processedEvent.Contexts), "should merge contexts")
 	assertEqual(t, event.Contexts[sharedContextsKey], processedEvent.Contexts[sharedContextsKey], "should not override event trace context")
-	assertEqual(t, 2, len(processedEvent.Extra), "should merge extra")
 	assertEqual(t, LevelDebug, processedEvent.Level, "should use event level if set")
 	assertEqual(t, event.User, processedEvent.User, "should use event user if one exists")
 	assertEqual(t, event.Request, processedEvent.Request, "should use event request if one exists")
@@ -666,7 +594,6 @@ func TestApplyToEventUsingEmptyScope(t *testing.T) {
 	assertEqual(t, len(processedEvent.Attachments), 1, "should use event attachments")
 	assertEqual(t, len(processedEvent.Tags), 1, "should use event tags")
 	assertEqual(t, len(processedEvent.Contexts), 3, "should use event contexts")
-	assertEqual(t, len(processedEvent.Extra), 1, "should use event extra")
 	assertEqual(t, processedEvent.User, event.User, "should use event user")
 	assertEqual(t, processedEvent.Fingerprint, event.Fingerprint, "should use event fingerprint")
 	assertEqual(t, processedEvent.Level, event.Level, "should use event level")
@@ -682,7 +609,6 @@ func TestApplyToEventUsingEmptyEvent(t *testing.T) {
 	assertEqual(t, len(processedEvent.Attachments), 1, "should use scope attachments")
 	assertEqual(t, len(processedEvent.Tags), 1, "should use scope tags")
 	assertEqual(t, len(processedEvent.Contexts), 3, "should use scope contexts")
-	assertEqual(t, len(processedEvent.Extra), 1, "should use scope extra")
 	assertEqual(t, processedEvent.User, scope.user, "should use scope user")
 	assertEqual(t, processedEvent.Fingerprint, scope.fingerprint, "should use scope fingerprint")
 	assertEqual(t, processedEvent.Level, scope.level, "should use scope level")

--- a/slog/converter.go
+++ b/slog/converter.go
@@ -93,9 +93,9 @@ func attrToSentryEvent(attr slog.Attr, event *sentry.Event) {
 	case k == "fingerprint" && kind == slog.KindAny:
 		handleFingerprint(v, event)
 	case kind == slog.KindGroup:
-		event.Extra[k] = attrsToMap(v.Group()...)
+		event.Tags[k] = fmt.Sprint(attrsToMap(v.Group()...))
 	default:
-		event.Extra[k] = v.Any()
+		event.Tags[k] = fmt.Sprint(v.Any())
 	}
 }
 

--- a/slog/converter.go
+++ b/slog/converter.go
@@ -83,7 +83,9 @@ func attrToSentryEvent(attr slog.Attr, event *sentry.Event) {
 	case k == "server_name" && kind == slog.KindString:
 		event.ServerName = v.String()
 	case k == "tags" && kind == slog.KindGroup:
-		event.Tags = attrsToString(v.Group()...)
+		for tk, tv := range attrsToString(v.Group()...) {
+			event.Tags[tk] = tv
+		}
 	case k == "transaction" && kind == slog.KindString:
 		event.Transaction = v.String()
 	case k == "user" && kind == slog.KindGroup:

--- a/slog/converter_test.go
+++ b/slog/converter_test.go
@@ -41,14 +41,7 @@ func TestDefaultConverter(t *testing.T) {
 	assert.Equal(t, name, event.Logger)
 
 	// Check if the attributes are correctly converted
-	var foundMockKey bool
-	for key, value := range event.Extra {
-		if key == "mockKey" && value == "mockValue" {
-			foundMockKey = true
-			break
-		}
-	}
-	assert.True(t, foundMockKey)
+	assert.Equal(t, "mockValue", event.Tags["mockKey"])
 }
 
 func TestAttrToSentryEvent(t *testing.T) {
@@ -142,19 +135,16 @@ func TestAttrToSentryEvent(t *testing.T) {
 		},
 		"request_str": {
 			attr:     slog.Attr{Key: "request", Value: slog.StringValue("GET http://")},
-			expected: &sentry.Event{Extra: map[string]any{"request": "GET http://"}},
+			expected: &sentry.Event{Tags: map[string]string{"request": "GET http://"}},
 		},
 		"context_group": {
 			attr: slog.Attr{Key: "context", Value: slog.GroupValue(
 				slog.Attr{Key: "key1", Value: slog.StringValue("value1")},
 				slog.Attr{Key: "key2", Value: slog.StringValue("value2")},
 			)},
-			expected: &sentry.Event{Extra: map[string]any{
-				"context": map[string]any{
-					"key1": "value1",
-					"key2": "value2",
-				}},
-			},
+			expected: &sentry.Event{Tags: map[string]string{
+				"context": "map[key1:value1 key2:value2]",
+			}},
 		},
 		"fingerprint": {
 			attr:     slog.Attr{Key: "fingerprint", Value: slog.AnyValue([]string{"value1", "value2"})},
@@ -181,10 +171,10 @@ func TestAttrToSentryEvent(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.expected.Tags, event.Tags)
 			}
-			if len(tc.expected.Extra) == 0 {
-				assert.Empty(t, event.Extra)
+			if len(tc.expected.Tags) == 0 {
+				assert.Empty(t, event.Tags)
 			} else {
-				assert.Equal(t, tc.expected.Extra, event.Extra)
+				assert.Equal(t, tc.expected.Tags, event.Tags)
 			}
 		})
 	}

--- a/slog/converter_test.go
+++ b/slog/converter_test.go
@@ -44,6 +44,25 @@ func TestDefaultConverter(t *testing.T) {
 	assert.Equal(t, "mockValue", event.Tags["mockKey"])
 }
 
+func TestDefaultConverterTagsDoesNotOverrideExistingTags(t *testing.T) {
+	record := &slog.Record{
+		Time:    time.Now(),
+		Level:   slog.LevelInfo,
+		Message: "Test message",
+	}
+	record.AddAttrs(
+		slog.String("custom_key", "custom_val"),
+		slog.Group("tags",
+			slog.String("t1", "v1"),
+		),
+	)
+
+	event := DefaultConverter(false, nil, nil, nil, record, nil)
+
+	assert.Equal(t, "custom_val", event.Tags["custom_key"])
+	assert.Equal(t, "v1", event.Tags["t1"])
+}
+
 func TestAttrToSentryEvent(t *testing.T) {
 	reqURL, _ := url.Parse("http://example.com")
 

--- a/slog/converter_test.go
+++ b/slog/converter_test.go
@@ -171,11 +171,6 @@ func TestAttrToSentryEvent(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.expected.Tags, event.Tags)
 			}
-			if len(tc.expected.Tags) == 0 {
-				assert.Empty(t, event.Tags)
-			} else {
-				assert.Equal(t, tc.expected.Tags, event.Tags)
-			}
 		})
 	}
 }

--- a/slog/sentryslog_test.go
+++ b/slog/sentryslog_test.go
@@ -630,8 +630,8 @@ func TestSentryHandler_EventType(t *testing.T) {
 	assert.Nil(t, events[0].Logs, "should not have logs for EventType")
 	assert.Equal(t, message, events[0].Message, "event message should match")
 
-	_, found := events[0].Extra["attr_key"]
-	assert.True(t, found, "attribute should be in event's Extra map")
+	_, found := events[0].Tags["attr_key"]
+	assert.True(t, found, "attribute should be in event tags")
 }
 
 func TestSentryHandler_EventTypeWithReplaceAttr(t *testing.T) {
@@ -657,14 +657,14 @@ func TestSentryHandler_EventTypeWithReplaceAttr(t *testing.T) {
 	assert.Equal(t, 1, len(events))
 
 	// Check if attribute was replaced
-	fooAttr, found := events[0].Extra["foo"]
+	fooAttr, found := events[0].Tags["foo"]
 	assert.True(t, found)
 	assert.Equal(t, "replaced_bar", fooAttr)
 
 	// Check if non-string attribute is unchanged
-	numAttr, found := events[0].Extra["num"]
+	numAttr, found := events[0].Tags["num"]
 	assert.True(t, found)
-	assert.Equal(t, int64(123), numAttr)
+	assert.Equal(t, "123", numAttr)
 }
 
 func TestSentryHandler_CaptureAsEventAndLog(t *testing.T) {
@@ -685,8 +685,8 @@ func TestSentryHandler_CaptureAsEventAndLog(t *testing.T) {
 
 	assert.Equal(t, message, event.Message, "event message should match")
 	assert.Equal(t, sentry.LevelWarning, event.Level)
-	eventAttrVal, found := event.Extra["common_attr"]
-	assert.True(t, found, "attribute should be in event's Extra map")
+	eventAttrVal, found := event.Tags["common_attr"]
+	assert.True(t, found, "attribute should be in event tags")
 	assert.Equal(t, "common_value", eventAttrVal)
 
 	event = events[1]

--- a/telemetry_processor_race_test.go
+++ b/telemetry_processor_race_test.go
@@ -41,11 +41,9 @@ func TestTelemetryProcessorRace(_ *testing.T) {
 		event.EventID = EventID(fmt.Sprintf("%032x", i))
 		event.Level = LevelError
 		event.Message = fmt.Sprintf("test event %d", i)
-		event.Extra = map[string]interface{}{
-			"initial_key": "initial_value",
-		}
 		event.Contexts = map[string]Context{
 			"initial_context": {"key": "value"},
+			"race_context":    {"initial_key": "initial_value"},
 		}
 		event.Breadcrumbs = []*Breadcrumb{
 			{Message: "initial breadcrumb", Timestamp: time.Now()},
@@ -60,7 +58,6 @@ func TestTelemetryProcessorRace(_ *testing.T) {
 			defer wg.Done()
 			for j := 0; j < numMutations; j++ {
 				// Map writes — "concurrent map read and map write"
-				ev.Extra[fmt.Sprintf("key-%d-%d", idx, j)] = fmt.Sprintf("value-%d", j)
 				ev.Contexts[fmt.Sprintf("ctx-%d-%d", idx, j)] = Context{
 					"dynamic": fmt.Sprintf("value-%d", j),
 				}

--- a/testdata/error_event.golden
+++ b/testdata/error_event.golden
@@ -13,9 +13,6 @@
     },
     "environment": "production",
     "event_id": "0123456789abcdef",
-    "extra": {
-        "extra_key": "extra_val"
-    },
     "fingerprint": [
         "abcd"
     ],

--- a/tracing.go
+++ b/tracing.go
@@ -45,22 +45,20 @@ const (
 //
 // Spans must be started with either StartSpan or Span.StartChild.
 type Span struct { //nolint: maligned // prefer readability over optimal memory layout (see note below *)
-	TraceID      TraceID           `json:"trace_id"`
-	SpanID       SpanID            `json:"span_id"`
-	ParentSpanID SpanID            `json:"parent_span_id,omitzero"`
-	Name         string            `json:"name,omitempty"`
-	Op           string            `json:"op,omitempty"`
-	Description  string            `json:"description,omitempty"`
-	Status       SpanStatus        `json:"status,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
-	StartTime    time.Time         `json:"start_timestamp,omitzero"`
-	EndTime      time.Time         `json:"timestamp,omitzero"`
-	// Deprecated: use Data instead. To be removed in 0.33.0
-	Extra   map[string]interface{} `json:"-"`
-	Data    map[string]interface{} `json:"data,omitempty"`
-	Sampled Sampled                `json:"-"`
-	Source  TransactionSource      `json:"-"`
-	Origin  SpanOrigin             `json:"origin,omitempty"`
+	TraceID      TraceID                `json:"trace_id"`
+	SpanID       SpanID                 `json:"span_id"`
+	ParentSpanID SpanID                 `json:"parent_span_id,omitzero"`
+	Name         string                 `json:"name,omitempty"`
+	Op           string                 `json:"op,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Status       SpanStatus             `json:"status,omitempty"`
+	Tags         map[string]string      `json:"tags,omitempty"`
+	StartTime    time.Time              `json:"start_timestamp,omitzero"`
+	EndTime      time.Time              `json:"timestamp,omitzero"`
+	Data         map[string]interface{} `json:"data,omitempty"`
+	Sampled      Sampled                `json:"-"`
+	Source       TransactionSource      `json:"-"`
+	Origin       SpanOrigin             `json:"origin,omitempty"`
 
 	// mu protects concurrent writes to map fields
 	mu sync.RWMutex

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -157,7 +157,7 @@ func TestStartSpan(t *testing.T) {
 			"Contexts", "EventID", "Level", "Platform",
 			"Release", "Sdk", "ServerName", "Modules",
 		),
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmpopts.EquateEmpty(),
 	}
 	if diff := cmp.Diff(want, events[0], opts); diff != "" {
@@ -222,7 +222,7 @@ func TestStartChild(t *testing.T) {
 			"EventID", "Level", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp", "StartTime",
 		),
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmpopts.IgnoreMapEntries(func(k string, _ interface{}) bool {
 			return k != "trace"
 		}),
@@ -300,7 +300,7 @@ func TestStartTransaction(t *testing.T) {
 			"Contexts", "EventID", "Level", "Platform",
 			"Release", "Sdk", "ServerName", "Modules",
 		),
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedExtra", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
 		cmpopts.EquateEmpty(),
 	}
 	if diff := cmp.Diff(want, events[0], opts); diff != "" {

--- a/transport.go
+++ b/transport.go
@@ -63,34 +63,26 @@ func getTLSConfig(options ClientOptions) *tls.Config {
 	return nil
 }
 
+// eventDebugContext returns a panic-safe summary of an event for debug logging.
+// It only touches scalar fields and len() of collections, which do not trigger
+// the runtime concurrent-map-access fatal nor invoke user-defined Stringers.
+func eventDebugContext(event *Event) string {
+	return fmt.Sprintf(
+		"event=%s type=%s level=%s "+
+			"breadcrumbs=%d exceptions=%d extra=%d tags=%d contexts=%d attachments=%d",
+		event.EventID, event.Type, event.Level,
+		len(event.Breadcrumbs), len(event.Exception), len(event.Extra),
+		len(event.Tags), len(event.Contexts), len(event.Attachments),
+	)
+}
+
 func getRequestBodyFromEvent(event *Event) []byte {
 	body, err := json.Marshal(event)
-	if err == nil {
-		return body
+	if err != nil {
+		debuglog.Printf("Could not encode event as JSON, skipping delivery. %s: %v", eventDebugContext(event), err)
+		return nil
 	}
-
-	msg := fmt.Sprintf("Could not encode original event as JSON. "+
-		"Succeeded by removing Breadcrumbs, Contexts and Extra. "+
-		"Please verify the data you attach to the scope. "+
-		"Error: %s", err)
-	// Try to serialize the event, with all the contextual data that allows for interface{} stripped.
-	event.Breadcrumbs = nil
-	event.Contexts = nil
-	event.Extra = map[string]interface{}{
-		"info": msg,
-	}
-	body, err = json.Marshal(event)
-	if err == nil {
-		debuglog.Println(msg)
-		return body
-	}
-
-	// This should _only_ happen when Event.Exception[0].Stacktrace.Frames[0].Vars is unserializable
-	// Which won't ever happen, as we don't use it now (although it's the part of public interface accepted by Sentry)
-	// Juuust in case something, somehow goes utterly wrong.
-	debuglog.Println("Event couldn't be marshaled, even with stripped contextual data. Skipping delivery. " +
-		"Please notify the SDK owners with possibly broken payload.")
-	return nil
+	return body
 }
 
 func encodeAttachment(enc *json.Encoder, b io.Writer, attachment *Attachment) error {
@@ -462,6 +454,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 	}
 	envelope, err := envelopeFromBody(event, t.dsn, time.Now(), body)
 	if err != nil {
+		debuglog.Printf("Failed to build envelope, skipping delivery. %s: %v", eventDebugContext(event), err)
 		recordForEvent(t.recorder, report.ReasonInternalError, event)
 		return
 	}
@@ -500,7 +493,7 @@ func (t *HTTPTransport) SendEventWithContext(ctx context.Context, event *Event) 
 			t.dsn.GetProjectID(),
 		)
 	default:
-		debuglog.Println("Event dropped due to transport buffer being full.")
+		debuglog.Printf("Event dropped due to transport buffer being full. %s", eventDebugContext(event))
 		recordForEvent(t.recorder, report.ReasonQueueOverflow, event)
 	}
 
@@ -799,6 +792,7 @@ func (t *HTTPSyncTransport) SendEventWithContext(ctx context.Context, event *Eve
 
 	envelope, err := envelopeFromBody(event, t.dsn, time.Now(), body)
 	if err != nil {
+		debuglog.Printf("Failed to build envelope, skipping delivery. %s: %v", eventDebugContext(event), err)
 		recordForEvent(t.recorder, report.ReasonInternalError, event)
 		return
 	}
@@ -946,7 +940,7 @@ func (a *internalAsyncTransportAdapter) SendEvent(event *Event) {
 	envelope := protocol.NewEnvelope(header)
 	item, err := event.ToEnvelopeItem()
 	if err != nil {
-		debuglog.Printf("Failed to convert event to envelope item: %v", err)
+		debuglog.Printf("Failed to convert event to envelope item, skipping delivery. %s: %v", eventDebugContext(event), err)
 		if a.recorder != nil {
 			recordForEvent(a.recorder, report.ReasonInternalError, event)
 		}

--- a/transport.go
+++ b/transport.go
@@ -69,9 +69,9 @@ func getTLSConfig(options ClientOptions) *tls.Config {
 func eventDebugContext(event *Event) string {
 	return fmt.Sprintf(
 		"event=%s type=%s level=%s "+
-			"breadcrumbs=%d exceptions=%d extra=%d tags=%d contexts=%d attachments=%d",
+			"breadcrumbs=%d exceptions=%d tags=%d contexts=%d attachments=%d",
 		event.EventID, event.Type, event.Level,
-		len(event.Breadcrumbs), len(event.Exception), len(event.Extra),
+		len(event.Breadcrumbs), len(event.Exception),
 		len(event.Tags), len(event.Contexts), len(event.Attachments),
 	)
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -28,8 +28,7 @@ type unserializableType struct {
 }
 
 const (
-	basicEvent         = `{"message":"mkey","sdk":{},"user":{}}`
-	invalidEventOutput = `{"extra":{"info":"Could not encode original event as JSON. Succeeded by removing Breadcrumbs, Contexts and Extra. Please verify the data you attach to the scope. Error: json: error calling MarshalJSON for type *sentry.Event: json: unsupported type: func()"},"message":"mkey","sdk":{},"user":{}}`
+	basicEvent = `{"message":"mkey","sdk":{},"user":{}}`
 )
 
 func TestGetRequestBodyFromEventValid(t *testing.T) {
@@ -45,81 +44,7 @@ func TestGetRequestBodyFromEventValid(t *testing.T) {
 	}
 }
 
-func TestGetRequestBodyFromEventInvalidBreadcrumbsField(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Breadcrumbs: []*Breadcrumb{{
-			Data: map[string]interface{}{
-				"wat": unserializableType{},
-			},
-		}},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventInvalidExtraField(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Extra: map[string]interface{}{
-			"wat": unserializableType{},
-		},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventInvalidContextField(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Contexts: map[string]Context{
-			"wat": {"key": unserializableType{}},
-		},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventMultipleInvalidFields(t *testing.T) {
-	body := getRequestBodyFromEvent(&Event{
-		Message: "mkey",
-		Breadcrumbs: []*Breadcrumb{{
-			Data: map[string]interface{}{
-				"wat": unserializableType{},
-			},
-		}},
-		Extra: map[string]interface{}{
-			"wat": unserializableType{},
-		},
-		Contexts: map[string]Context{
-			"wat": {"key": unserializableType{}},
-		},
-	})
-
-	got := string(body)
-	want := invalidEventOutput
-
-	if got != want {
-		t.Errorf("expected different shape of body. \ngot: %s\nwant: %s", got, want)
-	}
-}
-
-func TestGetRequestBodyFromEventCompletelyInvalid(t *testing.T) {
+func TestGetRequestBodyFromEventUnserializable(t *testing.T) {
 	body := getRequestBodyFromEvent(&Event{
 		Exception: []Exception{{
 			Stacktrace: &Stacktrace{
@@ -133,7 +58,7 @@ func TestGetRequestBodyFromEventCompletelyInvalid(t *testing.T) {
 	})
 
 	if body != nil {
-		t.Error("expected body to be nil")
+		t.Error("expected body to be nil when event cannot be marshaled")
 	}
 }
 

--- a/zerolog/sentryzerolog.go
+++ b/zerolog/sentryzerolog.go
@@ -162,14 +162,19 @@ func (w *Writer) addBreadcrumb(event *sentry.Event) {
 		breadcrumbType = "error"
 	}
 
-	category, _ := event.Extra["category"].(string)
+	category := event.Tags["category"]
+
+	data := make(map[string]interface{}, len(event.Tags))
+	for k, v := range event.Tags {
+		data[k] = v
+	}
 
 	w.hub.AddBreadcrumb(&sentry.Breadcrumb{
 		Type:     breadcrumbType,
 		Category: category,
 		Message:  event.Message,
 		Level:    event.Level,
-		Data:     event.Extra,
+		Data:     data,
 	}, nil)
 }
 
@@ -254,11 +259,9 @@ func parseLogLevel(data []byte) (zerolog.Level, error) {
 }
 
 func parseLogEvent(data []byte) (*sentry.Event, bool) {
-	event := sentry.Event{
-		Timestamp: now(),
-		Logger:    logger,
-		Extra:     map[string]any{},
-	}
+	event := sentry.NewEvent()
+	event.Timestamp = now()
+	event.Logger = logger
 
 	err := jsonparser.ObjectEach(data, func(key, value []byte, _ jsonparser.ValueType, _ int) error {
 		k := string(key)
@@ -275,7 +278,7 @@ func parseLogEvent(data []byte) (*sentry.Event, bool) {
 			var user sentry.User
 			err := json.Unmarshal(value, &user)
 			if err != nil {
-				event.Extra[k] = string(value)
+				event.Tags[k] = string(value)
 			} else {
 				event.User = user
 			}
@@ -285,15 +288,15 @@ func parseLogEvent(data []byte) (*sentry.Event, bool) {
 			var fp []string
 			err := json.Unmarshal(value, &fp)
 			if err != nil {
-				event.Extra[k] = string(value)
+				event.Tags[k] = string(value)
 			} else {
 				event.Fingerprint = fp
 			}
 		case FieldGoVersion, FieldMaxProcs:
 		default:
-			event.Extra[k] = string(value)
+			event.Tags[k] = string(value)
 		}
 		return nil
 	})
-	return &event, err == nil
+	return event, err == nil
 }

--- a/zerolog/sentryzerolog_test.go
+++ b/zerolog/sentryzerolog_test.go
@@ -38,8 +38,8 @@ func TestParseLogEvent(t *testing.T) {
 	require.Len(t, ev.Exception, 1)
 	assert.Equal(t, "dial timeout", ev.Exception[0].Value)
 
-	require.Len(t, ev.Extra, 1)
-	assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", ev.Extra["requestId"])
+	require.Len(t, ev.Tags, 1)
+	assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", ev.Tags["requestId"])
 }
 
 func TestFailedClientCreation(t *testing.T) {
@@ -79,7 +79,7 @@ func TestWrite(t *testing.T) {
 				require.Len(t, event.Exception, 1)
 				assert.Equal(t, "dial timeout", event.Exception[0].Value)
 				assert.True(t, time.Since(event.Timestamp).Minutes() < 1)
-				assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Extra["requestId"])
+				assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Tags["requestId"])
 				beforeSendCalled = true
 				return event
 			},
@@ -162,7 +162,7 @@ func TestWriteLevel(t *testing.T) {
 				require.Len(t, event.Exception, 1)
 				assert.Equal(t, "dial timeout", event.Exception[0].Value)
 				assert.True(t, time.Since(event.Timestamp).Minutes() < 1)
-				assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Extra["requestId"])
+				assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Tags["requestId"])
 				beforeSendCalled = true
 				return event
 			},
@@ -196,7 +196,7 @@ func TestWriteInvalidLevel(t *testing.T) {
 				require.Len(t, event.Exception, 1)
 				assert.Equal(t, "dial timeout", event.Exception[0].Value)
 				assert.True(t, time.Since(event.Timestamp).Minutes() < 1)
-				assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Extra["requestId"])
+				assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Tags["requestId"])
 				return event
 			},
 		},


### PR DESCRIPTION
### Description
This PR removes deprecated `SetExtra` and update the code to either `SetTag` or `SetAttribute` instead.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
