### PR TITLE
fix(lint): Resolve workspace submodule lint issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache-dependency-path: "**/go.sum"
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Compute lint targets
         id: lint-targets
         run: echo "targets=$(go work edit -json | jq -r '[.Use[].DiskPath | . + "/..."] | join(" ")')" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,5 @@ jobs:
         with:
           version: v2.11.4
           args: --timeout=10m ${{ steps.lint-targets.outputs.targets }}
+          cache-dependency-path: "**/go.sum"
     timeout-minutes: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
+          cache-dependency-path: "**/go.sum"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Compute lint targets
         id: lint-targets
@@ -30,5 +31,4 @@ jobs:
         with:
           version: v2.11.4
           args: --timeout=10m ${{ steps.lint-targets.outputs.targets }}
-          cache-dependency-path: "**/go.sum"
     timeout-minutes: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,12 @@ jobs:
         with:
           go-version: "1.25"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Compute lint targets
+        id: lint-targets
+        run: echo "targets=$(go work edit -json | jq -r '[.Use[].DiskPath | . + "/..."] | join(" ")')" >> $GITHUB_OUTPUT
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # pin@v8.0
         with:
           version: v2.11.4
-          args: --timeout=10m
+          args: --timeout=10m ${{ steps.lint-targets.outputs.targets }}
     timeout-minutes: 10

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 GO = go
-ALL_GO_MOD_DIRS := $(shell $(GO) work edit -json | sed -n 's/^[[:space:]]*"DiskPath": "\(.*\)".*/\1/p')
+ALL_GO_MOD_DIRS := $(shell $(GO) work edit -json | jq -r '.Use[].DiskPath')
 WORK_LINT_TARGETS := $(patsubst %, %/..., $(ALL_GO_MOD_DIRS))
 TIMEOUT = 300
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .DEFAULT_GOAL := help
 
-ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 GO = go
+ALL_GO_MOD_DIRS := $(shell $(GO) work edit -json | sed -n 's/^[[:space:]]*"DiskPath": "\(.*\)".*/\1/p')
+WORK_LINT_TARGETS := $(patsubst %, %/..., $(ALL_GO_MOD_DIRS))
 TIMEOUT = 300
 
 help: ## Show help
@@ -58,7 +59,7 @@ gotidy/%:
 .PHONY: gotidy
 
 lint: ## Lint (using "golangci-lint")
-	golangci-lint run
+	golangci-lint run $(WORK_LINT_TARGETS)
 .PHONY: lint
 
 fmt: ## Format all Go files

--- a/crosstest/http_link_test.go
+++ b/crosstest/http_link_test.go
@@ -51,9 +51,9 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		sentrytest.Run(t, func(t *testing.T, f *sentrytest.Fixture) {
 			const identifier = "http"
 			baseCtx := sentry.SetHubOnContext(context.Background(), f.Hub)
-			var logger sentry.Logger = sentry.NewLogger(baseCtx)
-			var meter sentry.Meter = sentry.NewMeter(baseCtx)
-			handler := sentryhttp.New(sentryhttp.Options{WaitForDelivery: true}).HandleFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger := sentry.NewLogger(baseCtx)
+			meter := sentry.NewMeter(baseCtx)
+			handler := sentryhttp.New(sentryhttp.Options{WaitForDelivery: true}).HandleFunc(func(_ http.ResponseWriter, r *http.Request) {
 				sendSignals(r.Context(), identifier, logger, meter)
 			})
 
@@ -71,8 +71,8 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		sentrytest.Run(t, func(t *testing.T, f *sentrytest.Fixture) {
 			const identifier = "gin"
 			baseCtx := sentry.SetHubOnContext(context.Background(), f.Hub)
-			var logger sentry.Logger = sentry.NewLogger(baseCtx)
-			var meter sentry.Meter = sentry.NewMeter(baseCtx)
+			logger := sentry.NewLogger(baseCtx)
+			meter := sentry.NewMeter(baseCtx)
 			gin.SetMode(gin.ReleaseMode)
 			router := gin.New()
 			router.Use(func(c *gin.Context) {
@@ -97,8 +97,8 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		sentrytest.Run(t, func(t *testing.T, f *sentrytest.Fixture) {
 			const identifier = "echo"
 			baseCtx := sentry.SetHubOnContext(context.Background(), f.Hub)
-			var logger sentry.Logger = sentry.NewLogger(baseCtx)
-			var meter sentry.Meter = sentry.NewMeter(baseCtx)
+			logger := sentry.NewLogger(baseCtx)
+			meter := sentry.NewMeter(baseCtx)
 			e := echo.New()
 			e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 				return func(c *echo.Context) error {
@@ -126,14 +126,14 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		sentrytest.Run(t, func(t *testing.T, f *sentrytest.Fixture) {
 			const identifier = "negroni"
 			baseCtx := sentry.SetHubOnContext(context.Background(), f.Hub)
-			var logger sentry.Logger = sentry.NewLogger(baseCtx)
-			var meter sentry.Meter = sentry.NewMeter(baseCtx)
+			logger := sentry.NewLogger(baseCtx)
+			meter := sentry.NewMeter(baseCtx)
 			n := negroni.New()
 			n.Use(negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 				next(w, r.WithContext(sentry.SetHubOnContext(otelCtx, f.Hub)))
 			}))
 			n.Use(sentrynegroni.New(sentrynegroni.Options{WaitForDelivery: true}))
-			n.UseHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n.UseHandler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				sendSignals(r.Context(), identifier, logger, meter)
 			}))
 
@@ -150,8 +150,8 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		sentrytest.Run(t, func(t *testing.T, f *sentrytest.Fixture) {
 			const identifier = "iris"
 			baseCtx := sentry.SetHubOnContext(context.Background(), f.Hub)
-			var logger sentry.Logger = sentry.NewLogger(baseCtx)
-			var meter sentry.Meter = sentry.NewMeter(baseCtx)
+			logger := sentry.NewLogger(baseCtx)
+			meter := sentry.NewMeter(baseCtx)
 			app := iris.New()
 			app.Use(func(ctx iris.Context) {
 				ctx.ResetRequest(ctx.Request().WithContext(sentry.SetHubOnContext(otelCtx, f.Hub)))
@@ -181,8 +181,8 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		f := sentrytest.NewFixture(t, otelOpts()...)
 		const identifier = "fiber"
 		baseCtx := sentry.SetHubOnContext(context.Background(), f.Hub)
-		var logger sentry.Logger = sentry.NewLogger(baseCtx)
-		var meter sentry.Meter = sentry.NewMeter(baseCtx)
+		logger := sentry.NewLogger(baseCtx)
+		meter := sentry.NewMeter(baseCtx)
 		app := fiber.New()
 		app.Use(func(c *fiber.Ctx) error {
 			c.SetUserContext(sentry.SetHubOnContext(otelCtx, f.Hub))
@@ -196,9 +196,11 @@ func TestHTTPFamilyIntegrationsLinkManualErrorsLogsMetricsAndPanicsToOTel(t *tes
 		})
 
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/test", nil)
-		if _, err := app.Test(req); err != nil {
+		resp, err := app.Test(req)
+		if err != nil {
 			t.Fatalf("fiber request: %v", err)
 		}
+		defer resp.Body.Close()
 
 		f.Flush()
 		requireRequestSignalsLinked(t, f.Events(), traceID, spanID, identifier)

--- a/crosstest/logging_link_test.go
+++ b/crosstest/logging_link_test.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/zap"
 )
 
+type noopContextKey struct{}
+
 func TestLogrusLogHookLinksOTelTrace(t *testing.T) {
 	t.Parallel()
 	sentrytest.Run(t, func(t *testing.T, f *sentrytest.Fixture) {
@@ -22,7 +24,7 @@ func TestLogrusLogHookLinksOTelTrace(t *testing.T) {
 
 		logger := logrus.New()
 		logger.AddHook(sentrylogrus.NewLogHookFromClient([]logrus.Level{logrus.InfoLevel}, f.Client))
-		logger.WithContext(context.WithValue(otelCtx, struct{}{}, "noop")).Info("logrus linked log")
+		logger.WithContext(context.WithValue(otelCtx, noopContextKey{}, "noop")).Info("logrus linked log")
 
 		f.Flush()
 		requireLinked(t, f.Events(), linkedLogEvent(traceID, spanID, "logrus linked log"))
@@ -35,6 +37,7 @@ func TestLogrusEventHookLinksOTelTrace(t *testing.T) {
 		otelCtx, traceID, spanID := fixedOTelContext()
 
 		logger := logrus.New()
+		//nolint:staticcheck // coverage for the deprecated event hook remains intentional until removal.
 		logger.AddHook(sentrylogrus.NewEventHookFromClient([]logrus.Level{logrus.ErrorLevel}, f.Client))
 		logger.WithContext(otelCtx).WithError(errors.New("logrus linked error event")).Error("logrus linked error event")
 

--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -37,7 +37,7 @@ func TestIntegration(t *testing.T) {
 			RoutePath:   "/panic/:id",
 			Method:      "GET",
 			WantStatus:  200,
-			Handler: func(c *echo.Context) error {
+			Handler: func(_ *echo.Context) error {
 				panic("test")
 			},
 			WantEvent: &sentry.Event{
@@ -359,11 +359,11 @@ func TestIntegration(t *testing.T) {
 		EnableTracing:          true,
 		TracesSampleRate:       1.0,
 		TraceIgnoreStatusCodes: make([][]int, 0), // don't ignore any status codes
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			transactionsCh <- tx
 			return tx
 		},
@@ -477,7 +477,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Request{},
 			"Env",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {
 				if k == e {

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -326,11 +326,11 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			transactionsCh <- tx
 			return tx
 		},
@@ -359,7 +359,7 @@ func TestIntegration(t *testing.T) {
 	}()
 
 	c := &fasthttp.Client{
-		Dial: func(addr string) (net.Conn, error) {
+		Dial: func(_ string) (net.Conn, error) {
 			return ln.Dial()
 		},
 		ReadTimeout:  time.Second,
@@ -410,7 +410,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Exception{},
 			"Stacktrace",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v string) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ string) bool {
 			// fasthttp changed Content-Length behavior in
 			// https://github.com/valyala/fasthttp/commit/097fa05a697fc638624a14ab294f1336da9c29b0.
 			// fasthttp changed Content-Type behavior in
@@ -452,7 +452,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Exception{},
 			"Stacktrace",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v string) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ string) bool {
 			// fasthttp changed Content-Length behavior in
 			// https://github.com/valyala/fasthttp/commit/097fa05a697fc638624a14ab294f1336da9c29b0.
 			// fasthttp changed Content-Type behavior in
@@ -462,7 +462,7 @@ func TestIntegration(t *testing.T) {
 			// ignore them.
 			return k == "Content-Length" || k == "Content-Type"
 		}),
-		cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {
 				if k == e {
@@ -533,7 +533,7 @@ func TestGetTransactionFromContext(t *testing.T) {
 			}()
 
 			c := &fasthttp.Client{
-				Dial: func(addr string) (net.Conn, error) {
+				Dial: func(_ string) (net.Conn, error) {
 					return ln.Dial()
 				},
 				ReadTimeout:  time.Second,
@@ -579,7 +579,7 @@ func TestSetHubOnContext(t *testing.T) {
 }
 
 // TestMalformedURLNoPanic verifies that malformed URLs don't cause panics
-// when tracing is enabled
+// when tracing is enabled.
 func TestMalformedURLNoPanic(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -45,7 +45,7 @@ type Options struct {
 	Timeout time.Duration
 }
 
-// New returns a handler struct which satisfies Fiber's middleware interface
+// New returns a handler struct which satisfies Fiber's middleware interface.
 func New(options Options) fiber.Handler {
 	if options.Timeout == 0 {
 		options.Timeout = sentry.DefaultFlushTimeout

--- a/fiber/sentryfiber_test.go
+++ b/fiber/sentryfiber_test.go
@@ -19,6 +19,39 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+func wantFiberTransaction(path, method, body string, status int) *sentry.Event {
+	headers := map[string]string{
+		"Host":       "example.com",
+		"User-Agent": "fiber",
+	}
+	if body != "" || method == http.MethodPost {
+		headers["Content-Length"] = fmt.Sprintf("%d", len(body))
+	}
+
+	return &sentry.Event{
+		Level:       sentry.LevelInfo,
+		Type:        "transaction",
+		Transaction: fmt.Sprintf("%s %s", method, path),
+		Request: &sentry.Request{
+			URL:     "http://example.com" + path,
+			Method:  method,
+			Data:    body,
+			Headers: headers,
+		},
+		TransactionInfo: &sentry.TransactionInfo{Source: "url"},
+		Contexts: map[string]sentry.Context{
+			"trace": sentry.TraceContext{
+				Data: map[string]interface{}{
+					"http.request.method":       method,
+					"http.response.status_code": status,
+				},
+				Op:     "http.server",
+				Status: sentry.HTTPtoSpanStatus(status),
+			}.Map(),
+		},
+	}
+}
+
 func TestIntegration(t *testing.T) {
 	largePayload := strings.Repeat("Large", 3*1024) // 15 KB
 	sentryHandler := sentryfiber.New(sentryfiber.Options{Timeout: 3 * time.Second, WaitForDelivery: true})
@@ -34,7 +67,7 @@ func TestIntegration(t *testing.T) {
 
 	app.Use(sentryHandler)
 
-	app.Get("/panic", func(c *fiber.Ctx) error {
+	app.Get("/panic", func(_ *fiber.Ctx) error {
 		panic("test")
 	})
 	app.Post("/post", func(c *fiber.Ctx) error {
@@ -65,7 +98,7 @@ func TestIntegration(t *testing.T) {
 		hub.CaptureMessage("body ignored")
 		return nil
 	})
-	app.Post("/post/error-handler", func(c *fiber.Ctx) error {
+	app.Post("/post/error-handler", func(_ *fiber.Ctx) error {
 		return exception
 	})
 
@@ -137,32 +170,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			WantTransaction: &sentry.Event{
-				Level:       sentry.LevelInfo,
-				Type:        "transaction",
-				Transaction: "POST /post",
-				Request: &sentry.Request{
-					URL:    "http://example.com/post",
-					Method: http.MethodPost,
-					Data:   "payload",
-					Headers: map[string]string{
-						"Host":           "example.com",
-						"Content-Length": "7",
-						"User-Agent":     "fiber",
-					},
-				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
-				Contexts: map[string]sentry.Context{
-					"trace": sentry.TraceContext{
-						Data: map[string]interface{}{
-							"http.request.method":       http.MethodPost,
-							"http.response.status_code": http.StatusOK,
-						},
-						Op:     "http.server",
-						Status: sentry.SpanStatusOK,
-					}.Map(),
-				},
-			},
+			WantTransaction: wantFiberTransaction("/post", http.MethodPost, "payload", http.StatusOK),
 		},
 		{
 			Path:       "/get",
@@ -314,32 +322,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			WantTransaction: &sentry.Event{
-				Level:       sentry.LevelInfo,
-				Type:        "transaction",
-				Transaction: "POST /post/body-ignored",
-				Request: &sentry.Request{
-					URL:    "http://example.com/post/body-ignored",
-					Method: http.MethodPost,
-					Data:   "client sends, fiber always reads, SDK reports",
-					Headers: map[string]string{
-						"Content-Length": "45",
-						"Host":           "example.com",
-						"User-Agent":     "fiber",
-					},
-				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
-				Contexts: map[string]sentry.Context{
-					"trace": sentry.TraceContext{
-						Data: map[string]interface{}{
-							"http.request.method":       http.MethodPost,
-							"http.response.status_code": http.StatusOK,
-						},
-						Op:     "http.server",
-						Status: sentry.SpanStatusOK,
-					}.Map(),
-				},
-			},
+			WantTransaction: wantFiberTransaction("/post/body-ignored", http.MethodPost, "client sends, fiber always reads, SDK reports", http.StatusOK),
 		},
 		{
 			Path:       "/post/error-handler",
@@ -397,11 +380,11 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			transactionsCh <- tx
 			return tx
 		},
@@ -492,7 +475,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Exception{},
 			"Stacktrace",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {
 				if k == e {
@@ -603,7 +586,7 @@ func TestSetHubOnContext(t *testing.T) {
 }
 
 // TestMalformedURLNoPanic verifies that malformed URLs don't cause panics
-// when tracing is enabled,
+// when tracing is enabled.
 func TestMalformedURLNoPanic(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -38,7 +38,7 @@ func TestIntegration(t *testing.T) {
 			RoutePath:   "/panic/:id",
 			Method:      "GET",
 			WantStatus:  200,
-			Handler: func(c *gin.Context) {
+			Handler: func(_ *gin.Context) {
 				panic("test")
 			},
 			WantTransaction: &sentry.Event{
@@ -357,11 +357,11 @@ func TestIntegration(t *testing.T) {
 		EnableTracing:          true,
 		TracesSampleRate:       1.0,
 		TraceIgnoreStatusCodes: make([][]int, 0), // don't ignore any status codes
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			fmt.Println("BeforeSendTransaction")
 			transactionsCh <- tx
 			return tx
@@ -466,7 +466,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Request{},
 			"Env",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {
 				if k == e {

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -148,11 +148,12 @@ func (s *sentryClientStream) SendMsg(m any) error {
 
 func (s *sentryClientStream) RecvMsg(m any) error {
 	err := s.ClientStream.RecvMsg(m)
-	if err == nil && !s.serverStreams {
+	switch {
+	case err == nil && !s.serverStreams:
 		s.finish(nil)
-	} else if errors.Is(err, io.EOF) {
+	case errors.Is(err, io.EOF):
 		s.finish(nil)
-	} else if err != nil {
+	case err != nil:
 		s.finish(err)
 	}
 	return err

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -77,11 +77,37 @@ func flushEventCount(t *testing.T, transport *sentry.MockTransport) int {
 	return len(transport.Events())
 }
 
+func requireUnaryClientBaggagePropagation(
+	t *testing.T,
+	existingBaggage string,
+	assertBaggage func(t *testing.T, baggageHeader string),
+) {
+	t.Helper()
+
+	transport := initMockTransport(t)
+	interceptor := sentrygrpc.UnaryClientInterceptor()
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		sentry.SentryBaggageHeader, existingBaggage,
+	))
+
+	err := interceptor(ctx, "/test.TestService/Method", struct{}{}, struct{}{}, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		assertBaggage(t, strings.Join(md.Get(sentry.SentryBaggageHeader), ","))
+		return nil
+	})
+
+	require.NoError(t, err)
+	sentry.Flush(testutils.FlushTimeout())
+	assert.Equal(t, int(codes.OK), spanStatusCode(t, transport))
+}
+
 func TestUnaryClientInterceptor(t *testing.T) {
 	tests := map[string]struct {
-		ctx      context.Context
-		invoker  grpc.UnaryInvoker
-		wantCode codes.Code
+		ctx       context.Context
+		invoker   grpc.UnaryInvoker
+		assertErr assert.ErrorAssertionFunc
+		wantCode  codes.Code
 	}{
 		"records span and propagates trace headers": {
 			ctx: metadata.NewOutgoingContext(context.Background(), metadata.Pairs("existing", "value")),
@@ -93,14 +119,16 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				assert.Contains(t, md, "existing")
 				return nil
 			},
-			wantCode: codes.OK,
+			assertErr: assert.NoError,
+			wantCode:  codes.OK,
 		},
 		"records span with error status on handler error": {
 			ctx: context.Background(),
 			invoker: func(_ context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 				return status.Error(codes.NotFound, "not found")
 			},
-			wantCode: codes.NotFound,
+			assertErr: assert.Error,
+			wantCode:  codes.NotFound,
 		},
 	}
 
@@ -109,7 +137,8 @@ func TestUnaryClientInterceptor(t *testing.T) {
 			transport := initMockTransport(t)
 			interceptor := sentrygrpc.UnaryClientInterceptor()
 
-			interceptor(tc.ctx, "/test.TestService/Method", struct{}{}, struct{}{}, nil, tc.invoker)
+			err := interceptor(tc.ctx, "/test.TestService/Method", struct{}{}, struct{}{}, nil, tc.invoker)
+			tc.assertErr(t, err)
 			sentry.Flush(testutils.FlushTimeout())
 
 			assert.Equal(t, int(tc.wantCode), spanStatusCode(t, transport))
@@ -146,47 +175,17 @@ func TestUnaryClientInterceptor_ReplacesExistingTraceHeaders(t *testing.T) {
 }
 
 func TestUnaryClientInterceptor_PreservesExistingBaggageMembers(t *testing.T) {
-	transport := initMockTransport(t)
-	interceptor := sentrygrpc.UnaryClientInterceptor()
-
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
-		sentry.SentryBaggageHeader, "othervendor=bla",
-	))
-
-	err := interceptor(ctx, "/test.TestService/Method", struct{}{}, struct{}{}, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		md, ok := metadata.FromOutgoingContext(ctx)
-		require.True(t, ok)
-		baggageHeader := strings.Join(md.Get(sentry.SentryBaggageHeader), ",")
+	requireUnaryClientBaggagePropagation(t, "othervendor=bla", func(t *testing.T, baggageHeader string) {
 		assert.Contains(t, baggageHeader, "othervendor=bla")
 		assert.Contains(t, baggageHeader, "sentry-trace_id")
-		return nil
 	})
-
-	require.NoError(t, err)
-	sentry.Flush(testutils.FlushTimeout())
-	assert.Equal(t, int(codes.OK), spanStatusCode(t, transport))
 }
 
 func TestUnaryClientInterceptor_PropagatesSentryBaggageWhenExistingBaggageIsMalformed(t *testing.T) {
-	transport := initMockTransport(t)
-	interceptor := sentrygrpc.UnaryClientInterceptor()
-
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
-		sentry.SentryBaggageHeader, "not-valid",
-	))
-
-	err := interceptor(ctx, "/test.TestService/Method", struct{}{}, struct{}{}, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		md, ok := metadata.FromOutgoingContext(ctx)
-		require.True(t, ok)
-		baggageHeader := strings.Join(md.Get(sentry.SentryBaggageHeader), ",")
+	requireUnaryClientBaggagePropagation(t, "not-valid", func(t *testing.T, baggageHeader string) {
 		assert.NotContains(t, baggageHeader, "not-valid")
 		assert.Contains(t, baggageHeader, "sentry-trace_id")
-		return nil
 	})
-
-	require.NoError(t, err)
-	sentry.Flush(testutils.FlushTimeout())
-	assert.Equal(t, int(codes.OK), spanStatusCode(t, transport))
 }
 
 func TestStreamClientInterceptor(t *testing.T) {
@@ -205,7 +204,7 @@ func TestStreamClientInterceptor(t *testing.T) {
 				assert.Contains(t, md, sentry.SentryBaggageHeader)
 				return &mockClientStream{recvMsgFn: func(_ any) error { return io.EOF }}, nil
 			},
-			streamOp: func(stream grpc.ClientStream) { stream.RecvMsg(nil) },
+			streamOp: func(stream grpc.ClientStream) { require.ErrorIs(t, stream.RecvMsg(nil), io.EOF) },
 			wantCode: codes.OK,
 		},
 		"streamer error records span with error status": {
@@ -227,7 +226,7 @@ func TestStreamClientInterceptor(t *testing.T) {
 			streamer: func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 				return &mockClientStream{recvMsgFn: func(_ any) error { return io.EOF }}, nil
 			},
-			streamOp: func(stream grpc.ClientStream) { stream.RecvMsg(nil) },
+			streamOp: func(stream grpc.ClientStream) { require.Error(t, stream.RecvMsg(nil)) },
 			wantCode: codes.OK,
 		},
 		"RecvMsg error records error status": {
@@ -235,7 +234,7 @@ func TestStreamClientInterceptor(t *testing.T) {
 			streamer: func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 				return &mockClientStream{recvMsgFn: func(_ any) error { return status.Error(codes.Unavailable, "down") }}, nil
 			},
-			streamOp: func(stream grpc.ClientStream) { stream.RecvMsg(nil) },
+			streamOp: func(stream grpc.ClientStream) { require.Error(t, stream.RecvMsg(nil)) },
 			wantCode: codes.Unavailable,
 		},
 		"SendMsg error records error status": {
@@ -243,7 +242,7 @@ func TestStreamClientInterceptor(t *testing.T) {
 			streamer: func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 				return &mockClientStream{sendMsgFn: func(_ any) error { return status.Error(codes.DeadlineExceeded, "timeout") }}, nil
 			},
-			streamOp: func(stream grpc.ClientStream) { stream.SendMsg(nil) },
+			streamOp: func(stream grpc.ClientStream) { require.Error(t, stream.SendMsg(nil)) },
 			wantCode: codes.DeadlineExceeded,
 		},
 		"Header error records error status": {
@@ -251,7 +250,7 @@ func TestStreamClientInterceptor(t *testing.T) {
 			streamer: func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 				return &mockClientStream{headerFn: func() (metadata.MD, error) { return nil, status.Error(codes.NotFound, "not found") }}, nil
 			},
-			streamOp: func(stream grpc.ClientStream) { stream.Header() },
+			streamOp: func(stream grpc.ClientStream) { _, err := stream.Header(); require.Error(t, err) },
 			wantCode: codes.NotFound,
 		},
 		"finish is idempotent across multiple error paths": {
@@ -264,8 +263,8 @@ func TestStreamClientInterceptor(t *testing.T) {
 				}, nil
 			},
 			streamOp: func(stream grpc.ClientStream) {
-				stream.SendMsg(nil)
-				stream.RecvMsg(nil)
+				require.Error(t, stream.SendMsg(nil))
+				require.Error(t, stream.RecvMsg(nil))
 			},
 			wantCode: codes.Canceled,
 		},
@@ -276,7 +275,10 @@ func TestStreamClientInterceptor(t *testing.T) {
 			transport := initMockTransport(t)
 			interceptor := sentrygrpc.StreamClientInterceptor()
 
-			stream, _ := interceptor(tc.ctx, &grpc.StreamDesc{}, nil, "/test.TestService/Method", tc.streamer)
+			stream, err := interceptor(tc.ctx, &grpc.StreamDesc{}, nil, "/test.TestService/Method", tc.streamer)
+			if tc.wantCode == codes.OK {
+				require.NoError(t, err)
+			}
 			if tc.streamOp != nil && stream != nil {
 				tc.streamOp(stream)
 			}

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -145,7 +145,7 @@ func StreamServerInterceptor(opts ServerOptions) grpc.StreamServerInterceptor {
 		ctx, hub, transaction := startServerTransaction(ss.Context(), info.FullMethod)
 		defer transaction.Finish()
 
-		stream := wrapServerStream(ss, ctx)
+		stream := wrapServerStream(ctx, ss)
 
 		defer recoverWithSentry(ctx, hub, opts, func() {
 			err = status.Error(codes.Internal, internalServerErrorMessage)
@@ -226,7 +226,7 @@ func parseGRPCMethod(fullMethod string) (name, service, method string) {
 }
 
 // wrapServerStream wraps a grpc.ServerStream, allowing you to inject a custom context.
-func wrapServerStream(ss grpc.ServerStream, ctx context.Context) grpc.ServerStream {
+func wrapServerStream(ctx context.Context, ss grpc.ServerStream) grpc.ServerStream {
 	return &wrappedServerStream{ServerStream: ss, ctx: ctx}
 }
 

--- a/grpc/server_test.go
+++ b/grpc/server_test.go
@@ -41,7 +41,7 @@ func summarizeTx(tx *sentry.Event) txSummary {
 		Data:   tx.Contexts["trace"]["data"].(map[string]any),
 	}
 	if g, ok := tx.Contexts["grpc"]; ok {
-		s.GRPC = map[string]any(g)
+		s.GRPC = g
 	}
 	return s
 }
@@ -53,7 +53,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 
 	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
 		FullMethod: "/test.TestService/Method",
-	}, func(ctx context.Context, _ any) (any, error) {
+	}, func(_ context.Context, _ any) (any, error) {
 		return struct{}{}, nil
 	})
 
@@ -93,7 +93,7 @@ func TestUnaryServerInterceptor_ScrubsSensitiveMetadata(t *testing.T) {
 
 	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
 		FullMethod: "/test.TestService/Method",
-	}, func(ctx context.Context, _ any) (any, error) {
+	}, func(_ context.Context, _ any) (any, error) {
 		return struct{}{}, nil
 	})
 
@@ -102,7 +102,7 @@ func TestUnaryServerInterceptor_ScrubsSensitiveMetadata(t *testing.T) {
 
 	events := transport.Events()
 	require.Len(t, events, 1)
-	grpcContext := map[string]any(events[0].Contexts["grpc"])
+	grpcContext := events[0].Contexts["grpc"]
 	metadataContext, ok := grpcContext["metadata"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, map[string]any{"key": "value"}, metadataContext)

--- a/iris/sentryiris_test.go
+++ b/iris/sentryiris_test.go
@@ -37,7 +37,7 @@ func TestIntegration(t *testing.T) {
 			RoutePath:   "/panic/{id}",
 			Method:      "GET",
 			WantStatus:  200,
-			Handler: func(ctx iris.Context) {
+			Handler: func(_ iris.Context) {
 				panic("test")
 			},
 			WantTransaction: &sentry.Event{
@@ -356,11 +356,11 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			transactionsCh <- tx
 			return tx
 		},
@@ -465,7 +465,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Request{},
 			"Env",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {
 				if k == e {

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -140,14 +140,14 @@ func TestEventHook_Fire(t *testing.T) {
 	t.Run("with fallback", func(t *testing.T) {
 		failClient, _ := sentry.NewClient(sentry.ClientOptions{
 			Dsn: "http://whatever@example.com/1337",
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(_ *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				return nil // Simulate failure by returning nil
 			},
 		})
 
 		var fallbackCalled bool
 		failHook := NewEventHookFromClient([]logrus.Level{logrus.ErrorLevel}, failClient)
-		failHook.SetFallback(func(entry *logrus.Entry) error {
+		failHook.SetFallback(func(_ *logrus.Entry) error {
 			fallbackCalled = true
 			return nil
 		})
@@ -166,7 +166,7 @@ func TestEventHook_Fire(t *testing.T) {
 	t.Run("capture fails no fallback", func(t *testing.T) {
 		failClient, _ := sentry.NewClient(sentry.ClientOptions{
 			Dsn: "http://whatever@example.com/1337",
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(_ *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				return nil
 			},
 			Transport: &sentry.MockTransport{},
@@ -498,7 +498,7 @@ func TestEventHook_AddTags(t *testing.T) {
 
 	tags := map[string]string{"tag1": "value1", "tag2": "value2"}
 	hook.AddTags(tags)
-	hook.Fire(&logrus.Entry{})
+	assert.NoError(t, hook.Fire(&logrus.Entry{}))
 	hook.Flush(testutils.FlushTimeout())
 	got := transport.Events()
 	assert.Equal(t, 1, len(got), "unexpected number of events")
@@ -557,7 +557,7 @@ func TestLogHookSetFallback(t *testing.T) {
 	hook := NewLogHookFromClient([]logrus.Level{logrus.InfoLevel}, client)
 
 	var called bool
-	fallback := FallbackFunc(func(entry *logrus.Entry) error {
+	fallback := FallbackFunc(func(_ *logrus.Entry) error {
 		called = true
 		return nil
 	})
@@ -657,11 +657,11 @@ func TestLogHook_AddTags(t *testing.T) {
 
 	tags := map[string]string{"tag1": "value1", "tag2": "value2"}
 	hook.AddTags(tags)
-	hook.Fire(&logrus.Entry{
+	assert.NoError(t, hook.Fire(&logrus.Entry{
 		Context: context.Background(),
 		Level:   logrus.InfoLevel,
 		Message: "Something",
-	})
+	}))
 	hook.Flush(testutils.FlushTimeout())
 	got := transport.Events()
 	assert.Equal(t, 1, len(got), "unexpected number of events")
@@ -739,7 +739,7 @@ func TestLogHookFireWithDifferentDataTypes(t *testing.T) {
 	assert.Equal(t, 1, len(got), "unexpected number of events")
 	if diff := cmp.Diff(wantLog.Attributes, got[0].Logs[0].Attributes,
 		cmp.AllowUnexported(attribute.Value{}),
-		cmpopts.IgnoreMapEntries(func(k string, v attribute.Value) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ attribute.Value) bool {
 			return k == "sentry.sdk.name" || k == "sentry.release" || k == "sentry.sdk.version" || k == "sentry.server.address"
 		}),
 	); diff != "" {

--- a/negroni/sentrynegroni_test.go
+++ b/negroni/sentrynegroni_test.go
@@ -78,7 +78,7 @@ func TestIntegration(t *testing.T) {
 			Path:   "/post",
 			Method: "POST",
 			Body:   "payload",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				body, err := io.ReadAll(r.Body)
 				if err != nil {
@@ -130,7 +130,7 @@ func TestIntegration(t *testing.T) {
 		},
 		{
 			Path: "/get",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				hub.CaptureMessage("get")
 			}),
@@ -176,7 +176,7 @@ func TestIntegration(t *testing.T) {
 			Path:   "/post/large",
 			Method: "POST",
 			Body:   largePayload,
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				body, err := io.ReadAll(r.Body)
 				if err != nil {
@@ -232,7 +232,7 @@ func TestIntegration(t *testing.T) {
 			Path:   "/post/body-ignored",
 			Method: "POST",
 			Body:   "client sends, server ignores, SDK doesn't read",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				hub.CaptureMessage("body ignored")
 			}),
@@ -287,11 +287,11 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
 		},
-		BeforeSendTransaction: func(tx *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			transactionsCh <- tx
 			return tx
 		},
@@ -399,7 +399,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Request{},
 			"Env",
 		),
-		cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {
 				if k == e {

--- a/otel/helpers_test.go
+++ b/otel/helpers_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 var assertEqual = testutils.AssertEqual
-var assertNotEqual = testutils.AssertNotEqual
 var assertTrue = testutils.AssertTrue
 var assertFalse = testutils.AssertFalse
 
@@ -23,7 +22,7 @@ var assertFalse = testutils.AssertFalse
 //
 // It is needed because some headers (e.g. "baggage") might contain the same set of values/attributes,
 // (and therefore be semantically equal), but serialized in different order.
-func assertMapCarrierEqual(t *testing.T, got, want propagation.MapCarrier, userMessage ...interface{}) {
+func assertMapCarrierEqual(t *testing.T, got, want propagation.MapCarrier, _ ...interface{}) {
 	t.Helper()
 
 	// Make sure that keys are the same
@@ -66,7 +65,7 @@ func assertMapCarrierEqual(t *testing.T, got, want propagation.MapCarrier, userM
 	}
 }
 
-// FIXME: copied from tracing_test.go
+// FIXME: copied from tracing_test.go.
 func TraceIDFromHex(s string) sentry.TraceID {
 	var id sentry.TraceID
 	_, err := hex.Decode(id[:], []byte(s))

--- a/otel/internal/utils/mapotelstatus_test.go
+++ b/otel/internal/utils/mapotelstatus_test.go
@@ -2,6 +2,9 @@ package utils_test
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/otel/internal/utils"
 	"go.opentelemetry.io/otel/attribute"
@@ -9,8 +12,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	"strconv"
-	"testing"
 )
 
 type mockReadOnlySpan struct {

--- a/otel/internal/utils/sentryrequest.go
+++ b/otel/internal/utils/sentryrequest.go
@@ -15,14 +15,14 @@ func IsSentryRequestSpan(ctx context.Context, s trace.ReadOnlySpan) bool {
 	// TODO(michi): can we access the attribute directly?
 	for _, attribute := range attributes {
 		if attribute.Key == semconv.HTTPURLKey {
-			return isSentryRequestUrl(ctx, attribute.Value.AsString())
+			return isSentryRequestURL(ctx, attribute.Value.AsString())
 		}
 	}
 
 	return false
 }
 
-func isSentryRequestUrl(ctx context.Context, url string) bool {
+func isSentryRequestURL(ctx context.Context, url string) bool {
 	hub := sentry.GetHubFromContext(ctx)
 	if hub == nil {
 		hub = sentry.CurrentHub()

--- a/otel/internal/utils/spanattributes.go
+++ b/otel/internal/utils/spanattributes.go
@@ -19,7 +19,7 @@ type SpanAttributes struct {
 func ParseSpanAttributes(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 	for _, attribute := range s.Attributes() {
 		if attribute.Key == semconv.HTTPMethodKey {
-			return descriptionForHttpMethod(s)
+			return descriptionForHTTPMethod(s)
 		}
 		if attribute.Key == semconv.DBSystemKey {
 			return descriptionForDbSystem(s)
@@ -74,7 +74,7 @@ func descriptionForDbSystem(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 	}
 }
 
-func descriptionForHttpMethod(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
+func descriptionForHTTPMethod(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 	op := "http"
 	switch s.SpanKind() {
 	case otelTrace.SpanKindClient:
@@ -86,7 +86,7 @@ func descriptionForHttpMethod(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 	var httpTarget string
 	var httpRoute string
 	var httpMethod string
-	var httpUrl string
+	var httpURL string
 
 	for _, attribute := range s.Attributes() {
 		switch attribute.Key {
@@ -97,27 +97,28 @@ func descriptionForHttpMethod(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 		case semconv.HTTPMethodKey:
 			httpMethod = attribute.Value.AsString()
 		case semconv.HTTPURLKey:
-			httpUrl = attribute.Value.AsString()
+			httpURL = attribute.Value.AsString()
 		}
 	}
 
 	var httpPath string
 
 	// Prefer httpRoute if available
-	if httpRoute != "" {
+	switch {
+	case httpRoute != "":
 		httpPath = httpRoute
-	} else if httpTarget != "" {
-		if parsedUrl, err := url.Parse(httpTarget); err == nil {
+	case httpTarget != "":
+		if parsedURL, err := url.Parse(httpTarget); err == nil {
 			// Do not include the query and fragment parts
-			httpPath = parsedUrl.Path
+			httpPath = parsedURL.Path
 		} else {
 			httpPath = httpTarget
 		}
-	} else if httpUrl != "" {
+	case httpURL != "":
 		// This is normally the HTTP-client case
-		if parsedUrl, err := url.Parse(httpUrl); err == nil {
+		if parsedURL, err := url.Parse(httpURL); err == nil {
 			// Do not include the query and fragment parts
-			httpPath = fmt.Sprintf("%s://%s%s", parsedUrl.Scheme, parsedUrl.Host, parsedUrl.Path)
+			httpPath = fmt.Sprintf("%s://%s%s", parsedURL.Scheme, parsedURL.Host, parsedURL.Path)
 		}
 	}
 

--- a/otel/propagator_test.go
+++ b/otel/propagator_test.go
@@ -200,7 +200,7 @@ func TestInjectUsesSetsValidTraceFromChildSpan(t *testing.T) {
 
 /// Extract
 
-// No sentry-trace header, no baggage header
+// No sentry-trace header, no baggage header.
 func TestExtractDoesNotChangeContextWithEmptyHeaders(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 
@@ -212,7 +212,7 @@ func TestExtractDoesNotChangeContextWithEmptyHeaders(t *testing.T) {
 	)
 }
 
-// No sentry-trace header, 3rd-party baggage header
+// No sentry-trace header, 3rd-party baggage header.
 func TestExtractSetsUndefinedDynamicSamplingContext(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 	carrier.Set(sentry.SentryBaggageHeader, "othervendor=bla")
@@ -225,7 +225,7 @@ func TestExtractSetsUndefinedDynamicSamplingContext(t *testing.T) {
 	)
 }
 
-// With sentry-trace header, no baggage header
+// With sentry-trace header, no baggage header.
 func TestExtractSetsSentrySpanContext(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 	carrier.Set(
@@ -237,20 +237,20 @@ func TestExtractSetsSentrySpanContext(t *testing.T) {
 
 	// Make sure that Extract added a proper span context to context
 	spanContext := trace.SpanContextFromContext(ctx)
-	spanId, _ := trace.SpanIDFromHex("6e0c63257de34c92")
-	traceId, _ := trace.TraceIDFromHex("d4cda95b652f4a1592b449d5929fda1b")
+	spanID, _ := trace.SpanIDFromHex("6e0c63257de34c92")
+	traceID, _ := trace.TraceIDFromHex("d4cda95b652f4a1592b449d5929fda1b")
 	assertEqual(t,
 		spanContext,
 		trace.NewSpanContext(trace.SpanContextConfig{
 			Remote:     true,
-			SpanID:     spanId,
-			TraceID:    traceId,
+			SpanID:     spanID,
+			TraceID:    traceID,
 			TraceFlags: trace.FlagsSampled,
 		}),
 	)
 }
 
-// With sentry-trace header, no baggage header
+// With sentry-trace header, no baggage header.
 func TestExtractHandlesInvalidTraceHeader(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 	carrier.Set(
@@ -266,7 +266,7 @@ func TestExtractHandlesInvalidTraceHeader(t *testing.T) {
 	assertEqual(t, spanContext.IsValid(), false)
 }
 
-// No sentry-trace header, with baggage header
+// No sentry-trace header, with baggage header.
 func TestExtractSetsDefinedDynamicSamplingContext(t *testing.T) {
 	propagator, carrier := setupPropagatorTest()
 	carrier.Set(

--- a/otel/span_processor.go
+++ b/otel/span_processor.go
@@ -67,15 +67,15 @@ func (ssp *sentrySpanProcessor) OnStart(parent context.Context, s otelSdkTrace.R
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onendspan
 func (ssp *sentrySpanProcessor) OnEnd(s otelSdkTrace.ReadOnlySpan) {
-	otelSpanId := s.SpanContext().SpanID()
-	otelTraceId := s.SpanContext().TraceID()
-	sentrySpan, ok := sentrySpanMap.Get(otelTraceId, otelSpanId)
+	otelSpanID := s.SpanContext().SpanID()
+	otelTraceID := s.SpanContext().TraceID()
+	sentrySpan, ok := sentrySpanMap.Get(otelTraceID, otelSpanID)
 	if !ok || sentrySpan == nil {
 		return
 	}
 
 	if utils.IsSentryRequestSpan(sentrySpan.Context(), s) {
-		sentrySpanMap.MarkFinished(otelSpanId, otelTraceId)
+		sentrySpanMap.MarkFinished(otelSpanID, otelTraceID)
 		return
 	}
 
@@ -88,7 +88,7 @@ func (ssp *sentrySpanProcessor) OnEnd(s otelSdkTrace.ReadOnlySpan) {
 	sentrySpan.EndTime = s.EndTime()
 	sentrySpan.Finish()
 
-	sentrySpanMap.MarkFinished(otelSpanId, otelTraceId)
+	sentrySpanMap.MarkFinished(otelSpanID, otelTraceID)
 }
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-1

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func setupSpanProcessorTest() (otelSdkTrace.SpanProcessor, *otelSdkTrace.TracerProvider, trace.Tracer) {
+func setupSpanProcessorTest() (otelSdkTrace.SpanProcessor, trace.Tracer) {
 	// Make sure that the global span map is empty
 	sentrySpanMap.Clear()
 
@@ -31,7 +31,7 @@ func setupSpanProcessorTest() (otelSdkTrace.SpanProcessor, *otelSdkTrace.TracerP
 	)
 	tp.RegisterSpanProcessor(spanProcessor)
 	tracer := tp.Tracer("test-tracer")
-	return spanProcessor, tp, tracer
+	return spanProcessor, tracer
 }
 
 func emptyContextWithSentry() context.Context {
@@ -70,7 +70,7 @@ func TestNewSentrySpanProcessor(t *testing.T) {
 }
 
 func TestSpanProcessorShutdown(t *testing.T) {
-	spanProcessor, _, tracer := setupSpanProcessorTest()
+	spanProcessor, tracer := setupSpanProcessorTest()
 	ctx := context.Background()
 	tracer.Start(emptyContextWithSentry(), "spanName")
 
@@ -87,7 +87,7 @@ func TestSpanProcessorForceFlush(t *testing.T) {
 	// ForceFlush() doesn't crash or return an error. Ideally we test it
 	// with a Sentry transport that can be checked to see if events were
 	// actually flushed.
-	spanProcessor, _, tracer := setupSpanProcessorTest()
+	spanProcessor, tracer := setupSpanProcessorTest()
 	ctx, span := tracer.Start(emptyContextWithSentry(), "spanName")
 	span.End()
 
@@ -98,7 +98,7 @@ func TestSpanProcessorForceFlush(t *testing.T) {
 }
 
 func TestOnStartRootSpan(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	_, otelSpan := tracer.Start(emptyContextWithSentry(), "spanName")
 
 	if sentrySpanMap.Len() != 1 {
@@ -109,12 +109,12 @@ func TestOnStartRootSpan(t *testing.T) {
 		t.Errorf("Sentry span not found in the map")
 	}
 
-	otelTraceId := otelSpan.SpanContext().TraceID()
-	otelSpanId := otelSpan.SpanContext().SpanID()
+	otelTraceID := otelSpan.SpanContext().TraceID()
+	otelSpanID := otelSpan.SpanContext().SpanID()
 	// TODO(anton): use a simple "assert", not "assertEqual"
 	assertTrue(t, otelSpan.SpanContext().IsValid())
-	assertEqual(t, sentrySpan.SpanID.String(), otelSpanId.String())
-	assertEqual(t, sentrySpan.TraceID.String(), otelTraceId.String())
+	assertEqual(t, sentrySpan.SpanID.String(), otelSpanID.String())
+	assertEqual(t, sentrySpan.TraceID.String(), otelTraceID.String())
 	assertEqual(t, sentrySpan.ParentSpanID, sentry.SpanID{})
 	assertTrue(t, sentrySpan.IsTransaction())
 	assertEqual(t, sentrySpan.Sampled, sentry.SampledTrue)
@@ -123,12 +123,12 @@ func TestOnStartRootSpan(t *testing.T) {
 	testutils.AssertBaggageStringsEqual(
 		t,
 		sentrySpan.ToBaggage(),
-		"sentry-transaction=spanName,sentry-environment=testing,sentry-public_key=abc,sentry-release=1.2.3,sentry-sample_rate=1,sentry-sampled=true,sentry-trace_id="+otelTraceId.String(),
+		"sentry-transaction=spanName,sentry-environment=testing,sentry-public_key=abc,sentry-release=1.2.3,sentry-sample_rate=1,sentry-sampled=true,sentry-trace_id="+otelTraceID.String(),
 	)
 }
 
 func TestOnStartWithTraceParentContext(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 
 	// Sentry context
 	ctx := context.WithValue(
@@ -184,7 +184,7 @@ func TestOnStartWithTraceParentContext(t *testing.T) {
 }
 
 func TestOnStartWithExistingParentSpan(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 
 	// Otel span context
 	ctx := trace.ContextWithSpanContext(
@@ -222,7 +222,7 @@ func TestOnStartWithExistingParentSpan(t *testing.T) {
 }
 
 func TestOnEndWithTransaction(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	ctx, otelSpan := tracer.Start(
 		emptyContextWithSentry(),
 		"transactionName",
@@ -267,7 +267,7 @@ func TestOnEndWithTransaction(t *testing.T) {
 }
 
 func TestOnEndWithChildSpan(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	ctx, otelRootSpan := tracer.Start(emptyContextWithSentry(), "rootSpan")
 	_, otelChildSpan := tracer.Start(
 		ctx,
@@ -307,7 +307,7 @@ func TestOnEndWithChildSpan(t *testing.T) {
 }
 
 func TestOnEndDoesNotFinishSentryRequests(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	ctx, otelSpan := tracer.Start(
 		emptyContextWithSentry(),
 		"POST to Sentry",
@@ -328,7 +328,7 @@ func TestOnEndDoesNotFinishSentryRequests(t *testing.T) {
 }
 
 func TestParseSpanAttributesHttpClient(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	ctx, otelRootSpan := tracer.Start(
 		emptyContextWithSentry(),
 		"rootSpan",
@@ -363,7 +363,7 @@ func TestParseSpanAttributesHttpClient(t *testing.T) {
 }
 
 func TestParseSpanAttributesHttpServer(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	ctx, otelRootSpan := tracer.Start(
 		emptyContextWithSentry(),
 		"rootSpan",
@@ -402,7 +402,7 @@ func TestParseSpanAttributesHttpServer(t *testing.T) {
 }
 
 func TestSpanBecomesChildOfFinishedSpan(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	ctx, otelRootSpan := tracer.Start(
 		emptyContextWithSentry(),
 		"rootSpan",
@@ -433,7 +433,7 @@ func TestSpanBecomesChildOfFinishedSpan(t *testing.T) {
 }
 
 func TestSpanWithFinishedParentShouldBeDeleted(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 
 	ctx, parent := tracer.Start(context.Background(), "parent")
 	traceID := parent.SpanContext().TraceID()
@@ -459,7 +459,7 @@ func TestSpanWithFinishedParentShouldBeDeleted(t *testing.T) {
 }
 
 func TestTransactionsStayIndependent(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 	sharedTraceID := "bc6d53f15eb88f4320054569b8c553d4"
 
 	ctx1 := trace.ContextWithSpanContext(
@@ -495,7 +495,7 @@ func TestTransactionsStayIndependent(t *testing.T) {
 }
 
 func TestLinkTraceContextToErrorEventWithSpanProcessor(t *testing.T) {
-	_, _, tracer := setupSpanProcessorTest()
+	_, tracer := setupSpanProcessorTest()
 
 	ctx, otelSpan := tracer.Start(emptyContextWithSentry(), "spanName")
 	hub := sentry.GetHubFromContext(ctx)

--- a/slog/common.go
+++ b/slog/common.go
@@ -175,7 +175,7 @@ func removeEmptyAttrs(attrs []slog.Attr) []slog.Attr {
 }
 
 func contextExtractor(ctx context.Context, fns []func(ctx context.Context) []slog.Attr) []slog.Attr {
-	attrs := []slog.Attr{}
+	attrs := make([]slog.Attr, 0, len(fns))
 	for _, fn := range fns {
 		attrs = append(attrs, fn(ctx)...)
 	}

--- a/slog/common_test.go
+++ b/slog/common_test.go
@@ -388,7 +388,7 @@ func TestContextExtractor(t *testing.T) {
 		"SingleFunction": {
 			ctx: context.Background(),
 			fns: []func(ctx context.Context) []slog.Attr{
-				func(ctx context.Context) []slog.Attr {
+				func(_ context.Context) []slog.Attr {
 					return []slog.Attr{slog.String("key1", "value1")}
 				},
 			},
@@ -397,10 +397,10 @@ func TestContextExtractor(t *testing.T) {
 		"MultipleFunctions": {
 			ctx: context.Background(),
 			fns: []func(ctx context.Context) []slog.Attr{
-				func(ctx context.Context) []slog.Attr {
+				func(_ context.Context) []slog.Attr {
 					return []slog.Attr{slog.String("key1", "value1")}
 				},
-				func(ctx context.Context) []slog.Attr {
+				func(_ context.Context) []slog.Attr {
 					return []slog.Attr{slog.String("key2", "value2")}
 				},
 			},

--- a/slog/converter_test.go
+++ b/slog/converter_test.go
@@ -26,7 +26,7 @@ func TestDefaultConverter(t *testing.T) {
 	}
 
 	// Mock replaceAttr function
-	replaceAttr := func(groups []string, a slog.Attr) slog.Attr {
+	replaceAttr := func(_ []string, a slog.Attr) slog.Attr {
 		return a
 	}
 

--- a/slog/sentryslog.go
+++ b/slog/sentryslog.go
@@ -46,7 +46,7 @@ var (
 	}
 )
 
-// LevelFatal is a custom [slog.Level] that maps to [sentry.LevelFatal]
+// LevelFatal is a custom [slog.Level] that maps to [sentry.LevelFatal].
 const LevelFatal = slog.Level(12)
 const SlogOrigin = "auto.log.slog"
 

--- a/slog/sentryslog_test.go
+++ b/slog/sentryslog_test.go
@@ -206,7 +206,7 @@ func TestOption_NewSentryHandler(t *testing.T) {
 	}
 }
 
-// Test backwards compatibility with the deprecated Level field
+// Test backwards compatibility with the deprecated Level field.
 func TestOption_NewSentryHandler_BackwardsCompatibility(t *testing.T) {
 	tests := map[string]struct {
 		option        Option
@@ -558,7 +558,7 @@ func TestSentryHandler_LogLevels(t *testing.T) {
 }
 
 func TestSentryHandler_ReplaceAttr(t *testing.T) {
-	replaceAttr := func(groups []string, a slog.Attr) slog.Attr {
+	replaceAttr := func(_ []string, a slog.Attr) slog.Attr {
 		if a.Value.Kind() == slog.KindString {
 			return slog.String(a.Key, "replaced")
 		}
@@ -635,7 +635,7 @@ func TestSentryHandler_EventType(t *testing.T) {
 }
 
 func TestSentryHandler_EventTypeWithReplaceAttr(t *testing.T) {
-	replaceAttr := func(groups []string, a slog.Attr) slog.Attr {
+	replaceAttr := func(_ []string, a slog.Attr) slog.Attr {
 		if a.Value.Kind() == slog.KindString {
 			return slog.String(a.Key, "replaced_"+a.Value.String())
 		}
@@ -767,7 +767,7 @@ func TestSentryHandler_CustomLogLevels(t *testing.T) {
 	}
 }
 
-// Test that Enabled returns false for levels not in the slices
+// Test that Enabled returns false for levels not in the slices.
 func TestSentryHandler_EnabledSpecificLevels(t *testing.T) {
 	tests := map[string]struct {
 		eventLevels []slog.Level

--- a/zap/converter.go
+++ b/zap/converter.go
@@ -97,6 +97,16 @@ type uint64LogEntry interface {
 	Uint64(key string, value uint64) sentry.LogEntry
 }
 
+func int64BitsToUint64(value int64) uint64 {
+	//nolint:gosec // zap stores unsigned integers and float bit patterns in Field.Integer.
+	return uint64(value)
+}
+
+func int64BitsToUint32(value int64) uint32 {
+	//nolint:gosec // zap stores float32 bit patterns in the lower 32 bits of Field.Integer.
+	return uint32(value)
+}
+
 // zapFieldToLogEntry converts a zap Field to a sentry LogEntry attribute.
 //
 //nolint:gocyclo
@@ -111,16 +121,16 @@ func zapFieldToLogEntry(entry sentry.LogEntry, field zapcore.Field) sentry.LogEn
 		return entry.Int64(key, field.Integer)
 	case zapcore.Uint64Type:
 		if e, ok := entry.(uint64LogEntry); ok {
-			return e.Uint64(key, uint64(field.Integer))
+			return e.Uint64(key, int64BitsToUint64(field.Integer))
 		}
 		debuglog.Println("Internal error: log entry does not implement unsigned int conversion")
 		return entry
 	case zapcore.UintptrType:
 		return entry.String(key, fmt.Sprintf("0x%x", field.Integer))
 	case zapcore.Float64Type:
-		return entry.Float64(key, math.Float64frombits(uint64(field.Integer)))
+		return entry.Float64(key, math.Float64frombits(int64BitsToUint64(field.Integer)))
 	case zapcore.Float32Type:
-		return entry.Float64(key, float64(math.Float32frombits(uint32(field.Integer))))
+		return entry.Float64(key, float64(math.Float32frombits(int64BitsToUint32(field.Integer))))
 	case zapcore.StringType:
 		return entry.String(key, field.String)
 	case zapcore.ByteStringType:

--- a/zap/converter.go
+++ b/zap/converter.go
@@ -97,12 +97,12 @@ type uint64LogEntry interface {
 	Uint64(key string, value uint64) sentry.LogEntry
 }
 
-func int64BitsToUint64(value int64) uint64 {
+func toUint64(value int64) uint64 {
 	//nolint:gosec // zap stores unsigned integers and float bit patterns in Field.Integer.
 	return uint64(value)
 }
 
-func int64BitsToUint32(value int64) uint32 {
+func toUint32(value int64) uint32 {
 	//nolint:gosec // zap stores float32 bit patterns in the lower 32 bits of Field.Integer.
 	return uint32(value)
 }
@@ -121,16 +121,16 @@ func zapFieldToLogEntry(entry sentry.LogEntry, field zapcore.Field) sentry.LogEn
 		return entry.Int64(key, field.Integer)
 	case zapcore.Uint64Type:
 		if e, ok := entry.(uint64LogEntry); ok {
-			return e.Uint64(key, int64BitsToUint64(field.Integer))
+			return e.Uint64(key, toUint64(field.Integer))
 		}
 		debuglog.Println("Internal error: log entry does not implement unsigned int conversion")
 		return entry
 	case zapcore.UintptrType:
 		return entry.String(key, fmt.Sprintf("0x%x", field.Integer))
 	case zapcore.Float64Type:
-		return entry.Float64(key, math.Float64frombits(int64BitsToUint64(field.Integer)))
+		return entry.Float64(key, math.Float64frombits(toUint64(field.Integer)))
 	case zapcore.Float32Type:
-		return entry.Float64(key, float64(math.Float32frombits(int64BitsToUint32(field.Integer))))
+		return entry.Float64(key, float64(math.Float32frombits(toUint32(field.Integer))))
 	case zapcore.StringType:
 		return entry.String(key, field.String)
 	case zapcore.ByteStringType:

--- a/zap/converter_test.go
+++ b/zap/converter_test.go
@@ -63,7 +63,7 @@ func TestZapFieldToLogEntry(t *testing.T) {
 	}
 
 	// Ignore timestamp key for cmp.Diff since time formatting can vary by locale
-	if diff := cmp.Diff(expected, entry.Attributes, cmpopts.IgnoreMapEntries(func(k string, v any) bool {
+	if diff := cmp.Diff(expected, entry.Attributes, cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 		return k == "timestamp"
 	}), cmpopts.EquateApprox(0, 0.0001)); diff != "" {
 		t.Errorf("Attributes mismatch (-want +got):\n%s", diff)

--- a/zap/sentryzap.go
+++ b/zap/sentryzap.go
@@ -135,7 +135,7 @@ func (c *SentryCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapco
 
 // Write serializes the Entry and any Fields and sends them to Sentry.
 func (c *SentryCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
-	logEntry := c.getLogEntry(entry.Level, c.ctx)
+	logEntry := c.getLogEntry(c.ctx, entry.Level)
 	if logEntry == nil {
 		return nil
 	}
@@ -179,7 +179,7 @@ func (c *SentryCore) Sync() error {
 }
 
 // getLogEntry returns the appropriate sentry.LogEntry for the given zap level.
-func (c *SentryCore) getLogEntry(level zapcore.Level, ctx context.Context) sentry.LogEntry {
+func (c *SentryCore) getLogEntry(ctx context.Context, level zapcore.Level) sentry.LogEntry {
 	var logEntry sentry.LogEntry
 
 	switch level {

--- a/zap/sentryzap_test.go
+++ b/zap/sentryzap_test.go
@@ -209,9 +209,9 @@ func TestSentryCore_WriteWithAccumulatedFields(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, "my-service", serviceAttr.AsInterface())
 
-	reqIdAttr, found := log.Attributes["request_id"]
+	reqIDAttr, found := log.Attributes["request_id"]
 	assert.True(t, found)
-	assert.Equal(t, "123", reqIdAttr.AsInterface())
+	assert.Equal(t, "123", reqIDAttr.AsInterface())
 }
 
 func TestSentryCore_WriteWithCaller(t *testing.T) {
@@ -422,9 +422,9 @@ func TestSentryCore_Integration(t *testing.T) {
 	assert.Equal(t, "user logged in", log1.Body)
 	assert.Equal(t, sentry.LogLevelInfo, log1.Level)
 
-	userIdAttr, found := log1.Attributes["user_id"]
+	userIDAttr, found := log1.Attributes["user_id"]
 	assert.True(t, found)
-	assert.Equal(t, "123", userIdAttr.AsInterface())
+	assert.Equal(t, "123", userIDAttr.AsInterface())
 
 	// Check second log
 	log2 := events[0].Logs[1]

--- a/zerolog/sentryzerolog.go
+++ b/zerolog/sentryzerolog.go
@@ -106,7 +106,7 @@ func New(cfg Config) (*Writer, error) {
 
 	client.SetSDKIdentifier(sdkIdentifier)
 
-	cfg.Options.SetDefaults()
+	cfg.SetDefaults()
 
 	levels := make(map[zerolog.Level]struct{}, len(cfg.Levels))
 	for _, lvl := range cfg.Levels {

--- a/zerolog/sentryzerolog_test.go
+++ b/zerolog/sentryzerolog_test.go
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) {
 	var beforeSendCalled bool
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				assert.Equal(t, sentry.LevelError, event.Level)
 				assert.Equal(t, "test message", event.Message)
 				require.Len(t, event.Exception, 1)
@@ -122,7 +122,7 @@ func TestWrite_TraceDoesNotPanic(t *testing.T) {
 	var beforeSendCalled bool
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				beforeSendCalled = true
 				return event
 			},
@@ -156,7 +156,7 @@ func TestWriteLevel(t *testing.T) {
 	var beforeSendCalled bool
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				assert.Equal(t, sentry.LevelError, event.Level)
 				assert.Equal(t, "test message", event.Message)
 				require.Len(t, event.Exception, 1)
@@ -190,7 +190,7 @@ func TestWriteLevel(t *testing.T) {
 func TestWriteInvalidLevel(t *testing.T) {
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				assert.Equal(t, sentry.LevelError, event.Level)
 				assert.Equal(t, "test message", event.Message)
 				require.Len(t, event.Exception, 1)
@@ -217,7 +217,7 @@ func TestWrite_Disabled(t *testing.T) {
 	var beforeSendCalled bool
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				beforeSendCalled = true
 				return event
 			},
@@ -252,7 +252,7 @@ func TestWriteLevel_Disabled(t *testing.T) {
 	var beforeSendCalled bool
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				beforeSendCalled = true
 				return event
 			},
@@ -285,7 +285,7 @@ func TestWriteLevelFatal(t *testing.T) {
 	var beforeSendCalled bool
 	cfg := Config{
 		ClientOptions: sentry.ClientOptions{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 				beforeSendCalled = true
 				return event
 			},


### PR DESCRIPTION
Update the workspace lint target to run across go.work modules and fix the issues that surfaced once submodules were included.

Clean up tests and integration helpers so the expanded golangci-lint run passes across the root module and submodules.

#skip-changelog

Co-Authored-By: GPT-5.4 <noreply@example.com>
