### PR TITLE
fix(fasthttp,fiber): correctly capture request body on scope

### DIFF
--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -94,7 +93,7 @@ func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandle
 
 		scope := hub.Scope()
 		scope.SetRequest(r)
-		scope.SetRequestBody(ctx.Request.Body())
+		scope.SetRequestBody(bytes.Clone(ctx.Request.Body()))
 		ctx.SetUserValue(valuesKey, hub)
 		ctx.SetUserValue(transactionKey, transaction)
 		defer h.recoverWithSentry(hub, ctx)
@@ -177,8 +176,6 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 	})
 
 	r.RemoteAddr = ctx.RemoteAddr().String()
-
-	r.Body = io.NopCloser(bytes.NewReader(ctx.Request.Body()))
 
 	return r
 }

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -104,7 +103,7 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 
 	scope := hub.Scope()
 	scope.SetRequest(r)
-	scope.SetRequestBody(ctx.Request().Body())
+	scope.SetRequestBody(bytes.Clone(ctx.Request().Body()))
 	ctx.Locals(valuesKey, hub)
 	ctx.Locals(transactionKey, transaction)
 	defer h.recoverWithSentry(hub, ctx)
@@ -185,8 +184,6 @@ func convert(ctx *fiber.Ctx) *http.Request {
 	})
 
 	r.RemoteAddr = ctx.Context().RemoteAddr().String()
-
-	r.Body = io.NopCloser(bytes.NewReader(ctx.Request().Body()))
 
 	return r
 }


### PR DESCRIPTION
### Description
These integrations don't re-read r.Body, so the io.TeeReader trick in SetRequest is never used. SetRequestBody is required to capture the body. This changes behavior to drop the redundant r.Body wiring in convert() (which sets a TeeReader that immediately gets overwritten by SetRequestBody) and copies the bytes via bytes.Clone, since fasthttp recycles the body buffer between requests.

### Issues
* resolves: SDK-1185

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)

-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>

### Changelog Entry
- Correctly capture request body for fasthttp and fiber
