### PR TITLE
fix: safe concurrent access for span and scope

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -91,7 +91,7 @@ func TestCaptureMessageEmptyString(t *testing.T) {
 	}
 	got := transport.lastEvent
 	opts := cmp.Options{
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 			return &Event{
 				Exception: e.Exception,
@@ -340,7 +340,7 @@ func TestCaptureEvent(t *testing.T) {
 		},
 	}
 	got := transport.lastEvent
-	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release"), cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser")}
+	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release"), cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe")}
 	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Errorf("Event mismatch (-want +got):\n%s", diff)
 	}
@@ -368,7 +368,7 @@ func TestCaptureEventNil(t *testing.T) {
 	}
 	got := transport.lastEvent
 	opts := cmp.Options{
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 			return &Event{
 				Exception: e.Exception,
@@ -984,7 +984,7 @@ func TestRecover(t *testing.T) {
 		}
 		got := events[0]
 		opts := cmp.Options{
-			cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+			cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 			cmp.Transformer("SimplifiedEvent", func(e *Event) *Event {
 				return &Event{
 					Message:   e.Message,

--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -444,7 +444,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
@@ -471,7 +471,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData", "StartTime", "Spans",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -404,7 +404,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Exception{},
@@ -442,7 +442,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData", "StartTime", "Spans",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/fiber/sentryfiber_test.go
+++ b/fiber/sentryfiber_test.go
@@ -433,7 +433,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
@@ -465,7 +465,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData", "StartTime", "Spans",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -433,7 +433,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
@@ -460,7 +460,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData", "StartTime", "Spans",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -362,7 +362,7 @@ func TestIntegration(t *testing.T) {
 			"Contexts", "EventID", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
-		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",
@@ -387,7 +387,7 @@ func TestIntegration(t *testing.T) {
 			"Release", "Sdk", "ServerName", "Timestamp",
 			"StartTime", "Spans",
 		),
-		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -287,7 +287,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Span{},
 			"TraceID", "SpanID", "ParentSpanID", "StartTime", "EndTime",
 			"mu", "parent", "sampleRate", "ctx", "dynamicSamplingContext", "recorder", "finishOnce", "contexts",
-			"explicitSampled", "serializedTags", "serializedData",
+			"explicitSampled", "serializedTags", "serializedData", "serializationSafe",
 		),
 	}
 	for i, tt := range tests {
@@ -377,7 +377,7 @@ func TestIntegration_GlobalClientOptions(t *testing.T) {
 			sentry.Span{},
 			"TraceID", "SpanID", "ParentSpanID", "StartTime", "EndTime",
 			"mu", "parent", "sampleRate", "ctx", "dynamicSamplingContext", "recorder", "finishOnce", "contexts",
-			"explicitSampled", "serializedTags", "serializedData",
+			"explicitSampled", "serializedTags", "serializedData", "serializationSafe",
 		),
 	}
 

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -287,7 +287,7 @@ func TestIntegration(t *testing.T) {
 			sentry.Span{},
 			"TraceID", "SpanID", "ParentSpanID", "StartTime", "EndTime",
 			"mu", "parent", "sampleRate", "ctx", "dynamicSamplingContext", "recorder", "finishOnce", "contexts",
-			"explicitSampled",
+			"explicitSampled", "serializedTags", "serializedData",
 		),
 	}
 	for i, tt := range tests {
@@ -377,7 +377,7 @@ func TestIntegration_GlobalClientOptions(t *testing.T) {
 			sentry.Span{},
 			"TraceID", "SpanID", "ParentSpanID", "StartTime", "EndTime",
 			"mu", "parent", "sampleRate", "ctx", "dynamicSamplingContext", "recorder", "finishOnce", "contexts",
-			"explicitSampled",
+			"explicitSampled", "serializedTags", "serializedData",
 		),
 	}
 

--- a/hub.go
+++ b/hub.go
@@ -390,23 +390,22 @@ func (hub *Hub) FlushWithContext(ctx context.Context) bool {
 // on the current span, or the scope's propagation context.
 func (hub *Hub) GetTraceparent() string {
 	scope := hub.Scope()
-
-	if scope.span != nil {
-		return scope.span.ToSentryTrace()
+	if span := scope.GetSpan(); span != nil {
+		return span.ToSentryTrace()
 	}
-
-	return fmt.Sprintf("%s-%s", scope.propagationContext.TraceID, scope.propagationContext.SpanID)
+	propagationContext := scope.propagationContextSnapshot()
+	return fmt.Sprintf("%s-%s", propagationContext.TraceID, propagationContext.SpanID)
 }
 
 // GetTraceparentW3C returns the current traceparent string in W3C format.
 // This is intended for propagation to downstream services that expect the W3C header.
 func (hub *Hub) GetTraceparentW3C() string {
 	scope := hub.Scope()
-	if scope.span != nil {
-		return scope.span.ToTraceparent()
+	if span := scope.GetSpan(); span != nil {
+		return span.ToTraceparent()
 	}
-
-	return fmt.Sprintf("00-%s-%s-00", scope.propagationContext.TraceID, scope.propagationContext.SpanID)
+	propagationContext := scope.propagationContextSnapshot()
+	return fmt.Sprintf("00-%s-%s-00", propagationContext.TraceID, propagationContext.SpanID)
 }
 
 // GetBaggage returns the current Sentry baggage string, to be used as a HTTP header value
@@ -415,12 +414,10 @@ func (hub *Hub) GetTraceparentW3C() string {
 // on the current span or the scope's propagation context.
 func (hub *Hub) GetBaggage() string {
 	scope := hub.Scope()
-
-	if scope.span != nil {
-		return scope.span.ToBaggage()
+	if span := scope.GetSpan(); span != nil {
+		return span.ToBaggage()
 	}
-
-	return scope.propagationContext.DynamicSamplingContext.String()
+	return scope.propagationContextSnapshot().DynamicSamplingContext.String()
 }
 
 // HasHubOnContext checks whether Hub instance is bound to a given Context struct.

--- a/interfaces.go
+++ b/interfaces.go
@@ -905,6 +905,6 @@ func (e *Event) MakeSerializationSafe() {
 	}
 
 	for _, span := range e.Spans {
-		span.MakeSerializationSafe()
+		span.makeSerializationSafe()
 	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -903,4 +903,8 @@ func (e *Event) MakeSerializationSafe() {
 			e.serializedUser = b
 		}
 	}
+
+	for _, span := range e.Spans {
+		span.MakeSerializationSafe()
+	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -425,6 +425,7 @@ type Event struct {
 	serializedBreadcrumbs json.RawMessage
 	serializedException   json.RawMessage
 	serializedUser        json.RawMessage
+	serializationSafe     bool
 }
 
 // SetException appends the unwrapped errors to the event's exception list.
@@ -596,11 +597,7 @@ func (e *Event) defaultMarshalJSON() ([]byte, error) {
 }
 
 func (e *Event) hasPreSerializedFields() bool {
-	return e.serializedTags != nil ||
-		e.serializedContexts != nil ||
-		e.serializedBreadcrumbs != nil ||
-		e.serializedException != nil ||
-		e.serializedUser != nil
+	return e.serializationSafe
 }
 
 // preSerializedMarshalJSON handles marshaling when MakeSerializationSafe has
@@ -907,4 +904,6 @@ func (e *Event) MakeSerializationSafe() {
 	for _, span := range e.Spans {
 		span.makeSerializationSafe()
 	}
+
+	e.serializationSafe = true
 }

--- a/iris/sentryiris_test.go
+++ b/iris/sentryiris_test.go
@@ -432,7 +432,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
@@ -459,7 +459,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData", "StartTime", "Spans",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -481,7 +481,7 @@ func TestEventHook_entryToEvent(t *testing.T) {
 			got := hook.entryToEvent(tt.entry)
 			opts := cmp.Options{
 				cmpopts.IgnoreFields(sentry.Event{}, "Contexts", "EventID", "Platform", "Release", "ServerName", "Modules", "Sdk", "Timestamp"),
-				cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+				cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 				cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 				cmpopts.EquateEmpty(),
 			}

--- a/negroni/sentrynegroni_test.go
+++ b/negroni/sentrynegroni_test.go
@@ -366,7 +366,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
@@ -393,7 +393,7 @@ func TestIntegration(t *testing.T) {
 			"sdkMetaData", "StartTime", "Spans",
 			"serializedTags",
 			"serializedContexts", "serializedBreadcrumbs",
-			"serializedException", "serializedUser",
+			"serializedException", "serializedUser", "serializationSafe",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/scope.go
+++ b/scope.go
@@ -304,6 +304,13 @@ func (scope *Scope) SetPropagationContext(propagationContext PropagationContext)
 	scope.propagationContext = propagationContext
 }
 
+func (scope *Scope) propagationContextSnapshot() PropagationContext {
+	scope.mu.RLock()
+	defer scope.mu.RUnlock()
+
+	return scope.propagationContext
+}
+
 // GetSpan returns the span from the current scope.
 func (scope *Scope) GetSpan() *Span {
 	scope.mu.RLock()

--- a/telemetry_processor_race_test.go
+++ b/telemetry_processor_race_test.go
@@ -77,3 +77,65 @@ func TestTelemetryProcessorRace(_ *testing.T) {
 	wg.Wait()
 	proc.Flush(2 * time.Second)
 }
+
+func TestTelemetryProcessorRaceSpans(_ *testing.T) {
+	transport := &testutils.MockTelemetryTransport{}
+	dsn := &protocol.Dsn{}
+	sdkInfo := &protocol.SdkInfo{Name: "test-sdk", Version: "1.0.0"}
+
+	buffers := map[ratelimit.Category]telemetry.Buffer[protocol.TelemetryItem]{
+		ratelimit.CategoryTransaction: telemetry.NewRingBuffer[protocol.TelemetryItem](
+			ratelimit.CategoryTransaction, 100, telemetry.OverflowPolicyDropOldest, 1, 0, report.NoopRecorder(),
+		),
+	}
+
+	proc := telemetry.NewProcessor(buffers, transport, dsn, func() *protocol.SdkInfo { return sdkInfo }, report.NoopRecorder())
+	defer proc.Close(2 * time.Second)
+
+	const numTransactions = 100
+	const numChildren = 4
+	const numMutations = 500
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < numTransactions; i++ {
+		children := make([]*Span, 0, numChildren)
+		for c := 0; c < numChildren; c++ {
+			child := &Span{
+				TraceID:   TraceID{},
+				SpanID:    SpanID{},
+				Op:        fmt.Sprintf("child.op.%d", c),
+				StartTime: time.Now(),
+				EndTime:   time.Now(),
+				Tags:      map[string]string{"initial": "value"},
+				Data:      map[string]interface{}{"initial": "value"},
+			}
+			children = append(children, child)
+		}
+
+		event := NewEvent()
+		event.EventID = EventID(fmt.Sprintf("%032x", i))
+		event.Type = transactionType
+		event.Transaction = fmt.Sprintf("tx %d", i)
+		event.StartTime = time.Now()
+		event.Timestamp = time.Now()
+		event.Spans = children
+
+		proc.Add(event)
+		runtime.Gosched()
+
+		wg.Add(1)
+		go func(spans []*Span, idx int) {
+			defer wg.Done()
+			for j := 0; j < numMutations; j++ {
+				for _, sp := range spans {
+					sp.SetTag(fmt.Sprintf("tag-%d-%d", idx, j), fmt.Sprintf("v-%d", j))
+					sp.SetData(fmt.Sprintf("data-%d-%d", idx, j), j)
+				}
+			}
+		}(children, i)
+	}
+
+	wg.Wait()
+	proc.Flush(2 * time.Second)
+}

--- a/tracing.go
+++ b/tracing.go
@@ -79,6 +79,9 @@ type Span struct { //nolint: maligned // prefer readability over optimal memory 
 	finishOnce sync.Once
 	// explicitSampled is a flag for configuring sampling by using `WithSpanSampled` option.
 	explicitSampled Sampled
+	// Pre-serialized copies of mutable fields, set by MakeSerializationSafe.
+	serializedTags json.RawMessage
+	serializedData json.RawMessage
 }
 
 // TraceParentContext describes the context of a (remote) parent span.
@@ -226,6 +229,41 @@ func (s *Span) Context() context.Context { return s.ctx }
 // StartSpan(span.Context(), operation, options...).
 func (s *Span) StartChild(operation string, options ...SpanOption) *Span {
 	return StartSpan(s.Context(), operation, options...)
+}
+
+// MakeSerializationSafe pre-serializes user mutable fields.
+func (s *Span) MakeSerializationSafe() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.Tags) > 0 {
+		if b, err := json.Marshal(s.Tags); err == nil {
+			s.serializedTags = b
+		}
+	}
+	if len(s.Data) > 0 {
+		if b, err := json.Marshal(s.Data); err == nil {
+			s.serializedData = b
+		}
+	}
+}
+
+// MarshalJSON emits the span using pre-serialized fields if available.
+func (s *Span) MarshalJSON() ([]byte, error) {
+	type spanAlias Span
+	if s.serializedTags == nil && s.serializedData == nil {
+		return json.Marshal((*spanAlias)(s))
+	}
+	type safeSpan struct {
+		*spanAlias
+		Tags json.RawMessage `json:"tags,omitempty"`
+		Data json.RawMessage `json:"data,omitempty"`
+	}
+	return json.Marshal(safeSpan{
+		spanAlias: (*spanAlias)(s),
+		Tags:      s.serializedTags,
+		Data:      s.serializedData,
+	})
 }
 
 // SetTag sets a tag on the span. It is recommended to use SetTag instead of

--- a/tracing.go
+++ b/tracing.go
@@ -695,7 +695,7 @@ func (s *Span) toEvent() *Event {
 	for k, v := range s.contexts {
 		contexts[k] = cloneContext(v)
 	}
-	contexts["trace"] = s.traceContextLocked().Map()
+	contexts["trace"] = s.traceContextLockFree().Map()
 
 	// Make sure that the transaction source is valid
 	transactionSource := s.Source
@@ -737,10 +737,10 @@ func (s *Span) traceContext() *TraceContext {
 	}
 }
 
-// traceContextLocked is the lock-free variant of traceContext.
+// traceContextLockFree is the lock-free variant of traceContext.
 //
 // This is supposed to be used only when span Finish() was already called.
-func (s *Span) traceContextLocked() *TraceContext {
+func (s *Span) traceContextLockFree() *TraceContext {
 	return &TraceContext{
 		TraceID:      s.TraceID,
 		SpanID:       s.SpanID,

--- a/tracing.go
+++ b/tracing.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -231,8 +232,8 @@ func (s *Span) StartChild(operation string, options ...SpanOption) *Span {
 	return StartSpan(s.Context(), operation, options...)
 }
 
-// MakeSerializationSafe pre-serializes user mutable fields.
-func (s *Span) MakeSerializationSafe() {
+// makeSerializationSafe pre-serializes user mutable fields.
+func (s *Span) makeSerializationSafe() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -683,7 +684,7 @@ func (s *Span) toEvent() *Event {
 	for k, v := range s.contexts {
 		contexts[k] = cloneContext(v)
 	}
-	contexts["trace"] = s.traceContext().Map()
+	contexts["trace"] = s.traceContextLocked().Map()
 
 	// Make sure that the transaction source is valid
 	transactionSource := s.Source
@@ -708,7 +709,27 @@ func (s *Span) toEvent() *Event {
 	}
 }
 
+// traceContext returns a TraceContext snapshot for an active span.
+//
+// It needs to clone span Data to avoid holding any user mutable state.
 func (s *Span) traceContext() *TraceContext {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return &TraceContext{
+		TraceID:      s.TraceID,
+		SpanID:       s.SpanID,
+		ParentSpanID: s.ParentSpanID,
+		Op:           s.Op,
+		Data:         maps.Clone(s.Data),
+		Description:  s.Description,
+		Status:       s.Status,
+	}
+}
+
+// traceContextLocked is the lock-free variant of traceContext.
+//
+// This is supposed to be used only when span Finish() was already called.
+func (s *Span) traceContextLocked() *TraceContext {
 	return &TraceContext{
 		TraceID:      s.TraceID,
 		SpanID:       s.SpanID,

--- a/tracing.go
+++ b/tracing.go
@@ -81,8 +81,9 @@ type Span struct { //nolint: maligned // prefer readability over optimal memory 
 	// explicitSampled is a flag for configuring sampling by using `WithSpanSampled` option.
 	explicitSampled Sampled
 	// Pre-serialized copies of mutable fields, set by MakeSerializationSafe.
-	serializedTags json.RawMessage
-	serializedData json.RawMessage
+	serializedTags    json.RawMessage
+	serializedData    json.RawMessage
+	serializationSafe bool
 }
 
 // TraceParentContext describes the context of a (remote) parent span.
@@ -247,23 +248,33 @@ func (s *Span) makeSerializationSafe() {
 			s.serializedData = b
 		}
 	}
+
+	s.serializationSafe = true
 }
 
 // MarshalJSON emits the span using pre-serialized fields if available.
 func (s *Span) MarshalJSON() ([]byte, error) {
-	type spanAlias Span
-	if s.serializedTags == nil && s.serializedData == nil {
-		return json.Marshal((*spanAlias)(s))
+	s.mu.RLock()
+	serializationSafe := s.serializationSafe
+	serializedTags := s.serializedTags
+	serializedData := s.serializedData
+	s.mu.RUnlock()
+
+	if !serializationSafe {
+		type span Span
+		return json.Marshal((*span)(s))
 	}
+
+	type span Span
 	type safeSpan struct {
-		*spanAlias
+		*span
 		Tags json.RawMessage `json:"tags,omitempty"`
 		Data json.RawMessage `json:"data,omitempty"`
 	}
 	return json.Marshal(safeSpan{
-		spanAlias: (*spanAlias)(s),
-		Tags:      s.serializedTags,
-		Data:      s.serializedData,
+		span: (*span)(s),
+		Tags: serializedTags,
+		Data: serializedData,
 	})
 }
 
@@ -696,7 +707,7 @@ func (s *Span) toEvent() *Event {
 		Type:        transactionType,
 		Transaction: s.Name,
 		Contexts:    contexts,
-		Tags:        s.Tags,
+		Tags:        maps.Clone(s.Tags),
 		Timestamp:   s.EndTime,
 		StartTime:   s.StartTime,
 		Spans:       finished,

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -157,7 +157,7 @@ func TestStartSpan(t *testing.T) {
 			"Contexts", "EventID", "Level", "Platform",
 			"Release", "Sdk", "ServerName", "Modules",
 		),
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmpopts.EquateEmpty(),
 	}
 	if diff := cmp.Diff(want, events[0], opts); diff != "" {
@@ -222,7 +222,7 @@ func TestStartChild(t *testing.T) {
 			"EventID", "Level", "Platform", "Modules",
 			"Release", "Sdk", "ServerName", "Timestamp", "StartTime",
 		),
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmpopts.IgnoreMapEntries(func(k string, _ interface{}) bool {
 			return k != "trace"
 		}),
@@ -300,7 +300,7 @@ func TestStartTransaction(t *testing.T) {
 			"Contexts", "EventID", "Level", "Platform",
 			"Release", "Sdk", "ServerName", "Modules",
 		),
-		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser"),
+		cmpopts.IgnoreFields(Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
 		cmpopts.EquateEmpty(),
 	}
 	if diff := cmp.Diff(want, events[0], opts); diff != "" {
@@ -593,7 +593,7 @@ func TestContinueTransactionFromHeaders(t *testing.T) {
 
 			if diff := cmp.Diff(tt.wantSpan, s, cmp.Options{
 				cmp.AllowUnexported(Span{}),
-				cmpopts.IgnoreFields(Span{}, "ctx", "mu", "finishOnce"),
+				cmpopts.IgnoreFields(Span{}, "ctx", "mu", "finishOnce", "serializationSafe"),
 			}); diff != "" {
 				t.Fatalf("Expected no difference on spans, got: %s", diff)
 			}


### PR DESCRIPTION
### Description
This PR makes tracing concurrent access dureing capture and serialization safe. It adds:
- child spans are made serialization safe
- span.traceContext now returns a locked snapshot of span.Data
- hub trace and baggage getters now access span and propagation context under locks.

### Issues
* resolves: SDK-1186
* resolves: SDK-1187
* resolves: SDK-1191

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
