### PR TITLE
fix(http): avoid async transport shutdown panics

### DIFF
--- a/internal/http/transport.go
+++ b/internal/http/transport.go
@@ -306,6 +306,8 @@ type AsyncTransport struct {
 
 	flushRequest chan chan struct{}
 
+	closeMu sync.RWMutex
+
 	QueueSize int
 	Timeout   time.Duration
 
@@ -392,6 +394,9 @@ func (t *AsyncTransport) HasCapacity() bool {
 }
 
 func (t *AsyncTransport) SendEnvelope(envelope *protocol.Envelope) error {
+	t.closeMu.RLock()
+	defer t.closeMu.RUnlock()
+
 	select {
 	case <-t.done:
 		return ErrTransportClosed
@@ -411,6 +416,8 @@ func (t *AsyncTransport) SendEnvelope(envelope *protocol.Envelope) error {
 	identifier := util.EnvelopeIdentifier(envelope)
 
 	select {
+	case <-t.done:
+		return ErrTransportClosed
 	case t.queue <- envelope:
 		debuglog.Printf(
 			"Sending %s to %s project: %s",
@@ -432,8 +439,14 @@ func (t *AsyncTransport) Flush(timeout time.Duration) bool {
 }
 
 func (t *AsyncTransport) FlushWithContext(ctx context.Context) bool {
+	t.closeMu.RLock()
+	defer t.closeMu.RUnlock()
+
 	flushResponse := make(chan struct{})
 	select {
+	case <-t.done:
+		debuglog.Println("Failed to flush, transport is closed.")
+		return false
 	case t.flushRequest <- flushResponse:
 		select {
 		case <-flushResponse:
@@ -451,9 +464,10 @@ func (t *AsyncTransport) FlushWithContext(ctx context.Context) bool {
 
 func (t *AsyncTransport) Close() {
 	t.closeOnce.Do(func() {
+		t.closeMu.Lock()
+		defer t.closeMu.Unlock()
+
 		close(t.done)
-		close(t.queue)
-		close(t.flushRequest)
 		t.wg.Wait()
 	})
 }

--- a/internal/http/transport_test.go
+++ b/internal/http/transport_test.go
@@ -330,6 +330,19 @@ func TestAsyncTransport_FlushWithContext(t *testing.T) {
 			t.Error("FlushWithContext should timeout")
 		}
 	})
+
+	t.Run("closed transport", func(t *testing.T) {
+		tr := NewAsyncTransport(TransportOptions{Dsn: "https://key@sentry.io/123"})
+		transport, ok := tr.(*AsyncTransport)
+		if !ok {
+			t.Fatalf("expected *AsyncTransport, got %T", tr)
+		}
+		transport.Close()
+
+		if transport.FlushWithContext(context.Background()) {
+			t.Error("FlushWithContext should fail for a closed transport")
+		}
+	})
 }
 
 func TestAsyncTransport_Close(t *testing.T) {


### PR DESCRIPTION
## Summary
- serialize async transport shutdown with queue and flush send paths
- stop closing the async transport work channels during 
- add a regression test that exercises  and  while shutdown is happening

Resolves SDK-1189