### PR TITLE
fix(scope): use scoped client for request PII

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -247,11 +247,11 @@ type Request struct {
 	Env         map[string]string `json:"env,omitempty"`
 }
 
-// NewRequest returns a new Sentry Request from the given http.Request.
-//
-// NewRequest avoids operations that depend on network access. In particular, it
-// does not read r.Body.
-func NewRequest(r *http.Request) *Request {
+func sendDefaultPIIEnabled(client *Client) bool {
+	return client != nil && client.options.SendDefaultPII
+}
+
+func newRequest(r *http.Request, sendDefaultPII bool) *Request {
 	prot := protocol.SchemeHTTP
 	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		prot = protocol.SchemeHTTPS
@@ -262,7 +262,7 @@ func NewRequest(r *http.Request) *Request {
 	var env map[string]string
 	headers := map[string]string{}
 
-	if client := CurrentHub().Client(); client != nil && client.options.SendDefaultPII {
+	if sendDefaultPII {
 		// We read only the first Cookie header because of the specification:
 		// https://tools.ietf.org/html/rfc6265#section-5.4
 		// When the user agent generates an HTTP request, the user agent MUST NOT
@@ -295,6 +295,14 @@ func NewRequest(r *http.Request) *Request {
 		Headers:     headers,
 		Env:         env,
 	}
+}
+
+// NewRequest returns a new Sentry Request from the given http.Request.
+//
+// NewRequest avoids operations that depend on network access. In particular, it
+// does not read r.Body.
+func NewRequest(r *http.Request) *Request {
+	return newRequest(r, sendDefaultPIIEnabled(CurrentHub().Client()))
 }
 
 // Mechanism is the mechanism by which an exception was generated and handled.

--- a/scope.go
+++ b/scope.go
@@ -456,7 +456,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 	}
 
 	if event.Request == nil && scope.request != nil {
-		event.Request = NewRequest(scope.request)
+		event.Request = newRequest(scope.request, sendDefaultPIIEnabled(client))
 		// NOTE: The SDK does not attempt to send partial request body data.
 		//
 		// The reason being that Sentry's ingest pipeline and UI are optimized

--- a/scope_test.go
+++ b/scope_test.go
@@ -615,6 +615,45 @@ func TestApplyToEventUsingEmptyEvent(t *testing.T) {
 	assertEqual(t, processedEvent.Request, NewRequest(scope.request), "should use scope request")
 }
 
+func TestApplyToEventUsesClientPIISettingsForRequest(t *testing.T) {
+	previousClient := currentHub.Client()
+	currentHub.BindClient(&Client{
+		options: ClientOptions{
+			SendDefaultPII: true,
+		},
+	})
+	defer currentHub.BindClient(previousClient)
+
+	scope := NewScope()
+	request := httptest.NewRequest("POST", "http://example.com/test", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	request.Header.Set("Cookie", "foo=bar")
+	request.Header.Set("Some-Header", "some-header value")
+	scope.SetRequest(request)
+
+	event := scope.ApplyToEvent(NewEvent(), nil, &Client{
+		options: ClientOptions{
+			SendDefaultPII: false,
+		},
+	})
+
+	if event.Request == nil {
+		t.Fatal("expected request to be attached")
+	}
+
+	want := &Request{
+		URL:         "http://example.com/test",
+		Method:      "POST",
+		QueryString: "",
+		Headers: map[string]string{
+			"Host":        "example.com",
+			"Some-Header": "some-header value",
+		},
+	}
+
+	assertEqual(t, event.Request, want, "should honor the request-scoped client PII setting")
+}
+
 func TestEventProcessorsModifiesEvent(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()


### PR DESCRIPTION
## Summary
- thread the effective  decision through request construction
- build event requests from the client handling the current event instead of the global hub
- add a regression test that covers mixed-client PII settings on the same process

Resolves SDK-1188