### PR TITLE
fix: add attachments to new event path

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -491,6 +491,24 @@ func (e *Event) ToEnvelopeItem() (item *protocol.EnvelopeItem, err error) {
 	return item, nil
 }
 
+// ToEnvelope converts the Event to a Sentry envelope.
+func (e *Event) ToEnvelope(header *protocol.EnvelopeHeader) (*protocol.Envelope, error) {
+	item, err := e.ToEnvelopeItem()
+	if err != nil {
+		return nil, err
+	}
+
+	envelope := protocol.NewEnvelope(header)
+	envelope.AddItem(item)
+
+	for _, attachment := range e.Attachments {
+		attachmentItem := protocol.NewAttachmentItem(attachment.Filename, attachment.ContentType, attachment.Payload)
+		envelope.AddItem(attachmentItem)
+	}
+
+	return envelope, nil
+}
+
 // GetCategory returns the rate limit category for this event.
 func (e *Event) GetCategory() ratelimit.Category {
 	return e.toCategory()

--- a/internal/protocol/interfaces.go
+++ b/internal/protocol/interfaces.go
@@ -35,6 +35,14 @@ type EnvelopeItemConvertible interface {
 	ToEnvelopeItem() (*EnvelopeItem, error)
 }
 
+// EnvelopeConvertible represents items that can convert themselves to complete envelopes.
+type EnvelopeConvertible interface {
+	TelemetryItem
+
+	// ToEnvelope converts the item to a Sentry envelope using the provided header.
+	ToEnvelope(*EnvelopeHeader) (*Envelope, error)
+}
+
 // TelemetryTransport represents the envelope-first transport interface.
 // This interface is designed for the telemetry buffer system and provides
 // non-blocking sends with backpressure signals.

--- a/internal/telemetry/attachments_regression_test.go
+++ b/internal/telemetry/attachments_regression_test.go
@@ -1,0 +1,59 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/protocol"
+	"github.com/getsentry/sentry-go/internal/ratelimit"
+	"github.com/getsentry/sentry-go/internal/telemetry"
+	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
+	t.Parallel()
+
+	event := sentry.NewEvent()
+	event.Message = "test with attachment"
+	event.Level = sentry.LevelInfo
+
+	scope := sentry.NewScope()
+	scope.AddAttachment(&sentry.Attachment{
+		Filename:    "test.txt",
+		ContentType: "text/plain",
+		Payload:     []byte("hello world"),
+	})
+
+	event = scope.ApplyToEvent(event, nil, nil)
+
+	transport := &testutils.MockTelemetryTransport{}
+	processor := telemetry.NewProcessor(
+		map[ratelimit.Category]telemetry.Buffer[protocol.TelemetryItem]{
+			ratelimit.CategoryError: telemetry.NewRingBuffer[protocol.TelemetryItem](
+				ratelimit.CategoryError, 10, telemetry.OverflowPolicyDropOldest, 1, 0, nil,
+			),
+		},
+		transport,
+		&protocol.Dsn{},
+		func() *protocol.SdkInfo {
+			return &protocol.SdkInfo{Name: "test-sdk", Version: "1.0.0"}
+		},
+		nil,
+	)
+	t.Cleanup(func() { processor.Close(testutils.FlushTimeout()) })
+
+	require.True(t, processor.Add(event), "add failed")
+	require.True(t, processor.Flush(testutils.FlushTimeout()), "flush timed out")
+
+	envelopes := transport.GetSentEnvelopes()
+	require.Len(t, envelopes, 1, "expected a single envelope")
+	require.Len(t, envelopes[0].Items, 2, "expected event and attachment envelope items")
+
+	assert.Equal(t, protocol.EnvelopeItemTypeEvent, envelopes[0].Items[0].Header.Type)
+	assert.Equal(t, protocol.EnvelopeItemTypeAttachment, envelopes[0].Items[1].Header.Type)
+	assert.Equal(t, "test.txt", envelopes[0].Items[1].Header.Filename)
+	assert.Equal(t, "text/plain", envelopes[0].Items[1].Header.ContentType)
+	assert.Equal(t, []byte("hello world"), envelopes[0].Items[1].Payload)
+}

--- a/internal/telemetry/scheduler.go
+++ b/internal/telemetry/scheduler.go
@@ -295,14 +295,32 @@ func (s *Scheduler) sendItem(item protocol.EnvelopeItemConvertible) {
 	if header.EventID == "" {
 		header.EventID = protocol.GenerateEventID()
 	}
-	envelope := protocol.NewEnvelope(header)
-	envItem, err := item.ToEnvelopeItem()
-	if err != nil {
-		debuglog.Printf("error while converting to envelope item: %v", err)
-		s.recorder.RecordItem(report.ReasonInternalError, item)
-		return
+
+	// TODO: need to restructure the abstraction layer to actually return envelopes instead of
+	// envelope items. The problem with envelope items, is that for events and batches we might
+	// need envelopes (eg. attachments need to be added separately and splitting the `Add` path
+	// is problematic). Currently this is a workaround for adding attachments to events without
+	// adding a circular dependency on telemetry/scheduler.
+	var envelope *protocol.Envelope
+	if convertible, ok := item.(protocol.EnvelopeConvertible); ok {
+		var err error
+		envelope, err = convertible.ToEnvelope(header)
+		if err != nil {
+			debuglog.Printf("error while converting to envelope: %v", err)
+			s.recorder.RecordItem(report.ReasonInternalError, item)
+			return
+		}
+	} else {
+		envItem, err := item.ToEnvelopeItem()
+		if err != nil {
+			debuglog.Printf("error while converting to envelope item: %v", err)
+			s.recorder.RecordItem(report.ReasonInternalError, item)
+			return
+		}
+		envelope = protocol.NewEnvelope(header)
+		envelope.AddItem(envItem)
 	}
-	envelope.AddItem(envItem)
+
 	if err := s.transport.SendEnvelope(envelope); err != nil {
 		debuglog.Printf("error sending envelope: %v", err)
 	}

--- a/transport.go
+++ b/transport.go
@@ -937,20 +937,13 @@ func (a *internalAsyncTransportAdapter) SendEvent(event *Event) {
 	if header.EventID == "" {
 		header.EventID = protocol.GenerateEventID()
 	}
-	envelope := protocol.NewEnvelope(header)
-	item, err := event.ToEnvelopeItem()
+	envelope, err := event.ToEnvelope(header)
 	if err != nil {
-		debuglog.Printf("Failed to convert event to envelope item, skipping delivery. %s: %v", eventDebugContext(event), err)
+		debuglog.Printf("Failed to convert event to envelope, skipping delivery. %s: %v", eventDebugContext(event), err)
 		if a.recorder != nil {
 			recordForEvent(a.recorder, report.ReasonInternalError, event)
 		}
 		return
-	}
-	envelope.AddItem(item)
-
-	for _, attachment := range event.Attachments {
-		attachmentItem := protocol.NewAttachmentItem(attachment.Filename, attachment.ContentType, attachment.Payload)
-		envelope.AddItem(attachmentItem)
 	}
 
 	if err := a.transport.SendEnvelope(envelope); err != nil {


### PR DESCRIPTION
### Description
This PR fixes attachments for the new telemetry processor. It adds a new abstraction layer `ToEnvelope` in order to be able to encode and add the attachments to events without adding a circular dependency. In general we should move towards `ToEnvelope` instead of `ToEnvelopeItem` so will also do a follow-up to refine scheduler adds for items.

### Issues
* resolves: #1291
* resolves: GO-142

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
