### PR TITLE
fix: flaky attachment test

### DIFF
--- a/internal/telemetry/attachments_regression_test.go
+++ b/internal/telemetry/attachments_regression_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
-	t.Parallel()
-
 	event := sentry.NewEvent()
 	event.Message = "test with attachment"
 	event.Level = sentry.LevelInfo
@@ -42,10 +40,10 @@ func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
 		},
 		nil,
 	)
-	t.Cleanup(func() { processor.Close(testutils.FlushTimeout()) })
 
 	require.True(t, processor.Add(event), "add failed")
 	require.True(t, processor.Flush(testutils.FlushTimeout()), "flush timed out")
+	processor.Close(testutils.FlushTimeout())
 
 	envelopes := transport.GetSentEnvelopes()
 	require.Len(t, envelopes, 1, "expected a single envelope")


### PR DESCRIPTION
### Description
Fixing flakiness of attachment regression test. We can't run this test with t.Parallel since it create and closes a new telemetry processor and might interact with other tests.

#skip-changelog

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
