### PR TITLE
feat!: enable logs by default

### DIFF
--- a/_examples/logrus/main.go
+++ b/_examples/logrus/main.go
@@ -35,7 +35,6 @@ func main() {
 				return event
 			},
 			// need to have logs enabled
-			EnableLogs:       true,
 			Debug:            true,
 			AttachStacktrace: true,
 		})

--- a/_examples/logs/main.go
+++ b/_examples/logs/main.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:        "",
-		EnableLogs: true, // you need to have EnableLogs set to true
+		Dsn: "",
+		// Logs are enabled by default. Set DisableLogs: true to disable.
 	})
 	if err != nil {
 		panic(err)

--- a/_examples/zap/main.go
+++ b/_examples/zap/main.go
@@ -15,7 +15,6 @@ func main() {
 	// Initialize Sentry with logs enabled
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:        "your-sentry-dsn",
-		EnableLogs: true,
 	})
 	if err != nil {
 		panic(err)

--- a/client.go
+++ b/client.go
@@ -261,8 +261,9 @@ type ClientOptions struct {
 	MaxErrorDepth int
 	// Default event tags. These are overridden by tags set on a scope.
 	Tags map[string]string
-	// EnableLogs controls when logs should be emitted.
-	EnableLogs bool
+	// DisableLogs controls whether logs should be emitted.
+	// By default, logs are enabled. Set to true to disable log emission.
+	DisableLogs bool
 	// DisableMetrics controls when metrics should be emitted.
 	DisableMetrics bool
 	// DisableClientReports controls when client reports should be emitted.
@@ -429,7 +430,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		}
 		client.setupTransport()
 
-		if options.EnableLogs {
+		if !options.DisableLogs {
 			client.batchLogger = newLogBatchProcessor(&client)
 			client.batchLogger.Start()
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1162,8 +1162,8 @@ func setupMultiClientEnv(t *testing.T) *multiClientEnv {
 	mkClient := func(dsn string) (*Client, *MockTransport) {
 		tr := &MockTransport{}
 		c, err := NewClient(ClientOptions{
-			Dsn:        dsn,
-			Transport:  tr,
+			Dsn:       dsn,
+			Transport: tr,
 			Integrations: func(_ []Integration) []Integration {
 				return []Integration{}
 			},

--- a/client_test.go
+++ b/client_test.go
@@ -1164,7 +1164,6 @@ func setupMultiClientEnv(t *testing.T) *multiClientEnv {
 		c, err := NewClient(ClientOptions{
 			Dsn:        dsn,
 			Transport:  tr,
-			EnableLogs: true,
 			Integrations: func(_ []Integration) []Integration {
 				return []Integration{}
 			},

--- a/crosstest/helpers_test.go
+++ b/crosstest/helpers_test.go
@@ -39,7 +39,6 @@ func otelOpts() []sentrytest.Option {
 		sentrytest.WithClientOptions(sentry.ClientOptions{
 			EnableTracing:    true,
 			TracesSampleRate: 1.0,
-			EnableLogs:       true,
 			Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 				return append(integrations, sentryotel.NewOtelIntegration())
 			},

--- a/log.go
+++ b/log.go
@@ -60,7 +60,7 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 	}
 
 	client := hub.Client()
-	if client != nil && client.options.EnableLogs {
+	if client != nil && !client.options.DisableLogs {
 		// Build default attrs
 		serverAddr := client.options.ServerName
 		if serverAddr == "" {
@@ -91,7 +91,7 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 		}
 	}
 
-	debuglog.Println("fallback to noopLogger: enableLogs disabled")
+	debuglog.Println("fallback to noopLogger: SDK not initialized or logs disabled")
 	return &noopLogger{}
 }
 

--- a/log_context_test.go
+++ b/log_context_test.go
@@ -13,7 +13,6 @@ func TestSentryLogger_ShouldLinkToCorrectSpan(t *testing.T) {
 		Dsn:              testDsn,
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		EnableLogs:       true,
 		Transport:        transport,
 	})
 	if err != nil {

--- a/log_fallback.go
+++ b/log_fallback.go
@@ -64,7 +64,7 @@ func (n *noopLogEntry) Attributes(_ ...attribute.Builder) LogEntry {
 }
 
 func (n *noopLogEntry) Emit(args ...interface{}) {
-	debuglog.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
+	debuglog.Printf("Log with level=[%v] is being dropped. SDK not initialized or logs disabled", n.level)
 	if n.level == LogLevelFatal {
 		if n.shouldPanic {
 			panic(args)
@@ -76,7 +76,7 @@ func (n *noopLogEntry) Emit(args ...interface{}) {
 }
 
 func (n *noopLogEntry) Emitf(message string, args ...interface{}) {
-	debuglog.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", n.level)
+	debuglog.Printf("Log with level=[%v] is being dropped. SDK not initialized or logs disabled", n.level)
 	if n.level == LogLevelFatal {
 		if n.shouldPanic {
 			panic(fmt.Sprintf(message, args...))
@@ -122,9 +122,9 @@ func (*noopLogger) LFatal() LogEntry {
 }
 
 func (*noopLogger) SetAttributes(...attribute.Builder) {
-	debuglog.Printf("No attributes attached. Turn on logging via EnableLogs")
+	debuglog.Printf("No attributes attached. SDK not initialized or logs disabled")
 }
 
 func (*noopLogger) Write(_ []byte) (n int, err error) {
-	return 0, fmt.Errorf("log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+	return 0, fmt.Errorf("log with level=[%v] is being dropped. SDK not initialized or logs disabled", LogLevelInfo)
 }

--- a/log_race_test.go
+++ b/log_race_test.go
@@ -80,7 +80,6 @@ func TestLoggingRaceConditions(t *testing.T) {
 func testConcurrentLoggerSetAttributes(t *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
-		EnableLogs: true,
 		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
@@ -130,7 +129,6 @@ func testConcurrentLoggerSetAttributes(t *testing.T) {
 func testConcurrentLogEmission(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
-		EnableLogs: true,
 		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
@@ -209,7 +207,6 @@ func testConcurrentLogEntryOperations(t *testing.T) {
 
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
-		EnableLogs: true,
 		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
@@ -265,7 +262,6 @@ func testConcurrentLogEntryOperations(t *testing.T) {
 func testConcurrentLoggerCreationAndUsage(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:        testDsn,
-		EnableLogs: true,
 		Transport:  &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
@@ -316,7 +312,6 @@ func testConcurrentLoggerCreationAndUsage(_ *testing.T) {
 func testConcurrentLogWithSpanOperations(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
 		Dsn:              testDsn,
-		EnableLogs:       true,
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 		Transport:        &MockTransport{},

--- a/log_race_test.go
+++ b/log_race_test.go
@@ -79,8 +79,8 @@ func TestLoggingRaceConditions(t *testing.T) {
 
 func testConcurrentLoggerSetAttributes(t *testing.T) {
 	client, _ := NewClient(ClientOptions{
-		Dsn:        testDsn,
-		Transport:  &MockTransport{},
+		Dsn:       testDsn,
+		Transport: &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)
@@ -128,8 +128,8 @@ func testConcurrentLoggerSetAttributes(t *testing.T) {
 
 func testConcurrentLogEmission(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
-		Dsn:        testDsn,
-		Transport:  &MockTransport{},
+		Dsn:       testDsn,
+		Transport: &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)
@@ -206,8 +206,8 @@ func testConcurrentLogEntryOperations(t *testing.T) {
 	t.Skip("A single instance of a log entry should not be used concurrently")
 
 	client, _ := NewClient(ClientOptions{
-		Dsn:        testDsn,
-		Transport:  &MockTransport{},
+		Dsn:       testDsn,
+		Transport: &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 	ctx := SetHubOnContext(context.Background(), hub)
@@ -261,8 +261,8 @@ func testConcurrentLogEntryOperations(t *testing.T) {
 
 func testConcurrentLoggerCreationAndUsage(_ *testing.T) {
 	client, _ := NewClient(ClientOptions{
-		Dsn:        testDsn,
-		Transport:  &MockTransport{},
+		Dsn:       testDsn,
+		Transport: &MockTransport{},
 	})
 	hub := NewHub(client, NewScope())
 

--- a/log_test.go
+++ b/log_test.go
@@ -39,7 +39,6 @@ func setupMockTransport() (context.Context, *MockTransport) {
 		Release:       "v1.2.3",
 		Environment:   "testing",
 		ServerName:    "test-server",
-		EnableLogs:    true,
 		EnableTracing: true,
 	})
 	mockClient.sdkIdentifier = "sentry.go"
@@ -626,7 +625,6 @@ func Test_batchLogger_Shutdown(t *testing.T) {
 	mockClient, _ := NewClient(ClientOptions{
 		Dsn:                    testDsn,
 		Transport:              mockTransport,
-		EnableLogs:             true,
 		DisableTelemetryBuffer: true,
 	})
 	hub := CurrentHub()
@@ -675,7 +673,6 @@ func Test_sentryLogger_BeforeSendLog(t *testing.T) {
 		Release:       "v1.2.3",
 		Environment:   "testing",
 		ServerName:    "test-server",
-		EnableLogs:    true,
 		EnableTracing: true,
 		BeforeSendLog: func(_ *Log) *Log {
 			return nil
@@ -750,19 +747,19 @@ func Test_sentryLogger_TracePropagationWithTransaction(t *testing.T) {
 
 func TestSentryLogger_DebugLogging(t *testing.T) {
 	tests := []struct {
-		name       string
-		enableLogs bool
-		message    string
+		name        string
+		disableLogs bool
+		message     string
 	}{
 		{
-			name:       "Debug enabled",
-			enableLogs: true,
-			message:    "test message",
+			name:        "Logs enabled (default)",
+			disableLogs: false,
+			message:     "test message",
 		},
 		{
-			name:       "Debug disabled",
-			enableLogs: false,
-			message:    "test message",
+			name:        "Logs disabled",
+			disableLogs: true,
+			message:     "test message",
 		},
 	}
 
@@ -772,9 +769,9 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 
 			ctx := context.Background()
 			mockClient, _ := NewClient(ClientOptions{
-				Transport:  &MockTransport{},
-				EnableLogs: tt.enableLogs,
-				Debug:      true,
+				Transport:   &MockTransport{},
+				DisableLogs: tt.disableLogs,
+				Debug:       true,
 			})
 			hub := CurrentHub()
 			hub.BindClient(mockClient)
@@ -787,7 +784,7 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 			logger.Info().WithCtx(ctx).Emit(tt.message)
 
 			got := buf.String()
-			if tt.enableLogs {
+			if !tt.disableLogs {
 				assertEqual(t, strings.Contains(got, "test message"), true)
 			} else {
 				assertEqual(t, strings.Contains(got, "test message"), false)
@@ -805,7 +802,6 @@ func Test_sentryLogger_UserAttributes(t *testing.T) {
 		Release:       "v1.2.3",
 		Environment:   "testing",
 		ServerName:    "test-server",
-		EnableLogs:    true,
 		EnableTracing: true,
 	})
 	mockClient.sdkIdentifier = "sentry.go"

--- a/logrus/README.md
+++ b/logrus/README.md
@@ -53,7 +53,6 @@ func main() {
 				return event
 			},
 			// need to have logs enabled
-			EnableLogs:       true,
 			Debug:            true,
 			AttachStacktrace: true,
 		})

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -418,8 +418,8 @@ func (h *logHook) FlushWithContext(ctx context.Context) bool {
 // NewLogHook initializes a new Logrus hook which sends logs to a new Sentry client
 // configured according to opts.
 func NewLogHook(levels []logrus.Level, opts sentry.ClientOptions) (Hook, error) {
-	if !opts.EnableLogs {
-		return nil, errors.New("cannot create log hook, EnableLogs is set to false")
+	if opts.DisableLogs {
+		return nil, errors.New("cannot create log hook, DisableLogs is set to true")
 	}
 	client, err := sentry.NewClient(opts)
 	if err != nil {

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -24,7 +24,6 @@ func setupClientTest() (*sentry.Client, *sentry.MockTransport) {
 	mockClient, _ := sentry.NewClient(sentry.ClientOptions{
 		Dsn:        "http://whatever@example.com/1337",
 		Transport:  mockTransport,
-		EnableLogs: true,
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)
@@ -511,7 +510,6 @@ func TestNewLogHook(t *testing.T) {
 	hook, err := NewLogHook(levels, sentry.ClientOptions{
 		Dsn:         "http://whatever@example.com/1337",
 		Environment: "test",
-		EnableLogs:  true,
 	})
 
 	assert.NoError(t, err)

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -22,8 +22,8 @@ import (
 func setupClientTest() (*sentry.Client, *sentry.MockTransport) {
 	mockTransport := &sentry.MockTransport{}
 	mockClient, _ := sentry.NewClient(sentry.ClientOptions{
-		Dsn:        "http://whatever@example.com/1337",
-		Transport:  mockTransport,
+		Dsn:       "http://whatever@example.com/1337",
+		Transport: mockTransport,
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)

--- a/slog/README.MD
+++ b/slog/README.MD
@@ -37,7 +37,6 @@ func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "your-public-dsn",
 		Debug: true,
-        EnableLogs: true, 
 	})
 	if err != nil {
 		panic(err)

--- a/slog/sentryslog_test.go
+++ b/slog/sentryslog_test.go
@@ -322,7 +322,6 @@ func newMockTransport() (context.Context, *sentry.MockTransport) {
 	mockClient, _ := sentry.NewClient(sentry.ClientOptions{
 		Dsn:        "https://public@example.com/1",
 		Transport:  mockTransport,
-		EnableLogs: true,
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)

--- a/slog/sentryslog_test.go
+++ b/slog/sentryslog_test.go
@@ -320,8 +320,8 @@ func newMockTransport() (context.Context, *sentry.MockTransport) {
 	ctx := context.Background()
 	mockTransport := &sentry.MockTransport{}
 	mockClient, _ := sentry.NewClient(sentry.ClientOptions{
-		Dsn:        "https://public@example.com/1",
-		Transport:  mockTransport,
+		Dsn:       "https://public@example.com/1",
+		Transport: mockTransport,
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)

--- a/zap/README.md
+++ b/zap/README.md
@@ -27,7 +27,6 @@ func main() {
     // Initialize Sentry with logs enabled
     err := sentry.Init(sentry.ClientOptions{
         Dsn:        "your-sentry-dsn",
-        EnableLogs: true,
     })
     if err != nil {
         panic(err)
@@ -87,7 +86,6 @@ func main() {
     // Initialize Sentry
     sentry.Init(sentry.ClientOptions{
         Dsn:        "your-sentry-dsn",
-        EnableLogs: true,
     })
     defer sentry.Flush(2 * time.Second)
 
@@ -130,11 +128,11 @@ func main() {
 
 ### Option struct
 
-| Field | Type | Description | Default |
-|-------|------|-------------|---------|
-| `Level` | `[]zapcore.Level` | Zap levels to capture and send to Sentry | All levels (Debug through Fatal) |
-| `AddCaller` | `bool` | Include caller info (file, line, function) | `false` |
-| `FlushTimeout` | `time.Duration` | How long to wait when syncing/flushing | 5 seconds |
+| Field          | Type              | Description                                | Default                          |
+| -------------- | ----------------- | ------------------------------------------ | -------------------------------- |
+| `Level`        | `[]zapcore.Level` | Zap levels to capture and send to Sentry   | All levels (Debug through Fatal) |
+| `AddCaller`    | `bool`            | Include caller info (file, line, function) | `false`                          |
+| `FlushTimeout` | `time.Duration`   | How long to wait when syncing/flushing     | 5 seconds                        |
 
 ## Context and Tracing
 
@@ -182,5 +180,5 @@ scopedLogger.Info("Processing completed")
 ## Notes
 
 - This integration only sends logs to Sentry (not events/errors). For error reporting, use the main `sentry-go` package.
-- Ensure `EnableLogs: true` is set in your Sentry client options.
+- Logs are enabled by default. If you have `DisableLogs: true`, remove it to enable log emission.
 - Call `sentry.Flush()` before your application exits to ensure all logs are sent.

--- a/zap/sentryzap_test.go
+++ b/zap/sentryzap_test.go
@@ -19,7 +19,6 @@ func newMockTransport() (context.Context, *sentry.MockTransport) {
 	mockClient, _ := sentry.NewClient(sentry.ClientOptions{
 		Dsn:        "https://public@example.com/1",
 		Transport:  mockTransport,
-		EnableLogs: true,
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)

--- a/zap/sentryzap_test.go
+++ b/zap/sentryzap_test.go
@@ -17,8 +17,8 @@ func newMockTransport() (context.Context, *sentry.MockTransport) {
 	ctx := context.Background()
 	mockTransport := &sentry.MockTransport{}
 	mockClient, _ := sentry.NewClient(sentry.ClientOptions{
-		Dsn:        "https://public@example.com/1",
-		Transport:  mockTransport,
+		Dsn:       "https://public@example.com/1",
+		Transport: mockTransport,
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)


### PR DESCRIPTION
### Description
This PR enables logs by default to skip double allow behavior. Users should just use `sentry.NewLogger` or any integration to enable logs. This also shifts `EnableLogs` to `DisableLogs` for a global override switch to disable all logging.

### Issues
* resolves: #1297 
* resolves: GO-143

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>

### Changelog Entry
- Enable logs by default to skip double allow behavior. Enabling logs now happens once when setting up either `sentry.NewLogger` or any supported integration. Also the EnableLogs flag changes to DisableLogs for a global override switch
