### PR TITLE
fix(log): don't run Emit messages through fmt.Sprintf

### DIFF
--- a/log.go
+++ b/log.go
@@ -138,11 +138,13 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		attrs[k] = v
 	}
 
+	body := message
 	if len(args) > 0 {
 		attrs["sentry.message.template"] = attribute.StringValue(message)
 		for i, p := range args {
 			attrs[fmt.Sprintf("sentry.message.parameters.%d", i)] = attribute.StringValue(fmt.Sprintf("%+v", p))
 		}
+		body = fmt.Sprintf(message, args...)
 	}
 
 	log := &Log{
@@ -151,7 +153,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		SpanID:     spanID,
 		Level:      level,
 		Severity:   severity,
-		Body:       fmt.Sprintf(message, args...),
+		Body:       body,
 		Attributes: attrs,
 	}
 	log.approximateSize = computeLogSize(log)

--- a/log_test.go
+++ b/log_test.go
@@ -327,6 +327,26 @@ func Test_sentryLogger_MethodsWithoutFormat(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Emit message with literal percent sign",
+			logFunc: func(ctx context.Context, l Logger, msg any) {
+				l.Info().WithCtx(ctx).Emit(msg)
+			},
+			args: "disk 95% full",
+			wantEvents: []Event{
+				{
+					Logs: []Log{
+						{
+							TraceID:    TraceIDFromHex(LogTraceID),
+							Level:      LogLevelInfo,
+							Severity:   LogSeverityInfo,
+							Body:       "disk 95% full",
+							Attributes: attrs,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description

\`logEntry.Emit\` calls \`sentryLogger.log\` with the user message and no format args, but \`log\` unconditionally ran the message through \`fmt.Sprintf\`. A literal percent sign in an Emit'd message gets mangled by the formatter:

\`\`\`go
fmt.Sprintf(\"disk 95% full\")   // \"disk 95%!(NOVERB)full\"
fmt.Sprintf(\"100% complete\")   // \"100%!c(MISSING)omplete\"
\`\`\`

So any caller doing \`logger.Info().Emit(\"disk 95% full\")\` ends up with a garbled Body in the Sentry payload. \`Emitf\` is unaffected because the user-supplied format string was always intended to be Sprintf'd.

Only format when args were provided. Added an Emit-with-literal-percent case to \`TestLogger\`; the existing Emit and Emitf cases still pass.

### Issues

resolves: n/a