### PR TITLE
docs: add doc comment for IsRaceTest function

### DIFF
--- a/internal/testutils/notrace.go
+++ b/internal/testutils/notrace.go
@@ -2,6 +2,7 @@
 
 package testutils
 
+// IsRaceTest returns true when the test is run with the race detector enabled.
 func IsRaceTest() bool {
 	return true
 }


### PR DESCRIPTION
### 问题背景

在 Go 语言中，为了遵循[最佳实践](https://go.dev/blog/godoc)和提高代码的可读性、可维护性，所有导出的函数都应该有文档注释（Docstrings）。`IsRaceTest` 函数位于 `internal/testutils` 包中，它是一个被导出的公开函数，用于检测当前测试是否在启用了竞态检测器（`-race` 标志）的情况下运行。然而，该函数缺少必要的文档注释。

本次修改通过添加一个简洁的文档注释来修复此问题。

### 修改内容

- **为 `IsRaceTest` 函数添加了文档注释。**
  - **修改了什么**: 在函数定义上方添加了一行文档注释 `// IsRaceTest returns true when the test is run with the race detector enabled.`
  - **为什么这样改**: 遵循 Go 语言约定，提高代码清晰度。该注释清晰地说明了函数的功能和返回值，有助于其他开发者（或未来的自己）快速理解该函数的用途。
  - **对代码质量的提升**: 提高了代码的可读性和可维护性，这是高质量、生产级别代码库的重要特征。

### 验证方式

- **现有测试**: 此修改仅涉及文档注释，不改变任何代码逻辑或公共 API。因此，所有现有的测试用例无需修改即可继续通过。
- **新测试**: 不需要为纯文档性修改添加新测试。
- **手动验证**: 无需手动验证。可以观察到代码的语法高亮或 Go 的文档生成工具（如 `go doc`）会正确显示此函数的说明。

### 其他信息

- **Breaking Changes**: 无。此修改不改变任何公共 API 或行为。
- **文档更新**: 本次修改本身就是对代码内文档的更新。无需更新外部 README 或其他文档。
- **已知限制**: 无。