### PR TITLE
fix(otel): support newer semconv span attributes

### DIFF
--- a/_examples/zap/main.go
+++ b/_examples/zap/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	// Initialize Sentry with logs enabled
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:        "your-sentry-dsn",
+		Dsn: "your-sentry-dsn",
 	})
 	if err != nil {
 		panic(err)

--- a/otel/internal/utils/mapotelstatus.go
+++ b/otel/internal/utils/mapotelstatus.go
@@ -4,7 +4,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 )
 
 // // OpenTelemetry span status can be Unset, Ok, Error. HTTP and Grpc codes contained in tags can make it more detailed.
@@ -48,7 +48,7 @@ func MapOtelStatus(s trace.ReadOnlySpan) sentry.SpanStatus {
 	statusCode := s.Status().Code
 
 	for _, attribute := range s.Attributes() {
-		if attribute.Key == semconv.HTTPStatusCodeKey {
+		if isHTTPStatusCodeKey(attribute.Key) {
 			if status, ok := canonicalCodesHTTPMap[attribute.Value.Emit()]; ok {
 				return status
 			}

--- a/otel/internal/utils/mapotelstatus_test.go
+++ b/otel/internal/utils/mapotelstatus_test.go
@@ -10,7 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	oldsemconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -50,36 +51,28 @@ func TestMapOtelStatus(t *testing.T) {
 			{
 				name: "Should return SpanStatusOk if given a Ok status",
 				span: &mockReadOnlySpan{
-					status: trace.Status{
-						Code: codes.Ok,
-					},
+					status: trace.Status{Code: codes.Ok},
 				},
 				want: sentry.SpanStatusOK,
 			},
 			{
 				name: "Should return SpanStatusOk if given a Unset status",
 				span: &mockReadOnlySpan{
-					status: trace.Status{
-						Code: codes.Unset,
-					},
+					status: trace.Status{Code: codes.Unset},
 				},
 				want: sentry.SpanStatusOK,
 			},
 			{
 				name: "Should return SpanStatusError if given a Error status",
 				span: &mockReadOnlySpan{
-					status: trace.Status{
-						Code: codes.Error,
-					},
+					status: trace.Status{Code: codes.Error},
 				},
 				want: sentry.SpanStatusInternalError,
 			},
 			{
 				name: "Should return SpanStatusUnknown if given an unknown status",
 				span: &mockReadOnlySpan{
-					status: trace.Status{
-						Code: 1337,
-					},
+					status: trace.Status{Code: 1337},
 				},
 				want: sentry.SpanStatusUnknown,
 			},
@@ -101,7 +94,7 @@ func TestMapOtelStatus(t *testing.T) {
 		return key.String(strconv.Itoa(i)), "as a string attribute"
 	}
 
-	t.Run("Given a HTTP Status code", func(t *testing.T) {
+	t.Run("Given a legacy HTTP Status code", func(t *testing.T) {
 		tts := []struct {
 			code    int
 			factory func(key attribute.Key, i int) (attribute.KeyValue, string)
@@ -132,13 +125,8 @@ func TestMapOtelStatus(t *testing.T) {
 		}
 
 		for _, tt := range tts {
-			attr, how := tt.factory(semconv.HTTPStatusCodeKey, tt.code)
-			span := &mockReadOnlySpan{
-				attributes: []attribute.KeyValue{
-					attr,
-				},
-			}
-
+			attr, how := tt.factory(oldsemconv.HTTPStatusCodeKey, tt.code)
+			span := &mockReadOnlySpan{attributes: []attribute.KeyValue{attr}}
 			name := fmt.Sprintf("Should return %s given the code %d %s", tt.want, tt.code, how)
 
 			t.Run(name, func(t *testing.T) {
@@ -146,6 +134,15 @@ func TestMapOtelStatus(t *testing.T) {
 					t.Errorf("MapOtelStatus() = %v, want %v", got, tt.want)
 				}
 			})
+		}
+	})
+
+	t.Run("Given a v1.30 HTTP Status code", func(t *testing.T) {
+		attr := semconv.HTTPResponseStatusCodeKey.Int(503)
+		span := &mockReadOnlySpan{attributes: []attribute.KeyValue{attr}}
+
+		if got := utils.MapOtelStatus(span); got != sentry.SpanStatusUnavailable {
+			t.Errorf("MapOtelStatus() = %v, want %v", got, sentry.SpanStatusUnavailable)
 		}
 	})
 
@@ -191,12 +188,7 @@ func TestMapOtelStatus(t *testing.T) {
 
 		for _, tt := range tts {
 			attr, how := tt.factory(semconv.RPCGRPCStatusCodeKey, tt.code)
-			span := &mockReadOnlySpan{
-				attributes: []attribute.KeyValue{
-					attr,
-				},
-			}
-
+			span := &mockReadOnlySpan{attributes: []attribute.KeyValue{attr}}
 			name := fmt.Sprintf("Should return %s given the code %d %s", tt.want, tt.code, how)
 			t.Run(name, func(t *testing.T) {
 				if got := utils.MapOtelStatus(span); got != tt.want {

--- a/otel/internal/utils/semconv.go
+++ b/otel/internal/utils/semconv.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+)
+
+var (
+	legacyDBStatementKey    = attribute.Key("db.statement")
+	legacyDBSystemKey       = attribute.Key("db.system")
+	legacyHTTPMethodKey     = attribute.Key("http.method")
+	legacyHTTPStatusCodeKey = attribute.Key("http.status_code")
+	legacyHTTPTargetKey     = attribute.Key("http.target")
+	legacyHTTPURLKey        = attribute.Key("http.url")
+)
+
+func isKey(key attribute.Key, candidates ...attribute.Key) bool {
+	for _, candidate := range candidates {
+		if key == candidate {
+			return true
+		}
+	}
+
+	return false
+}
+
+func spanAttributeString(attributes []attribute.KeyValue, keys ...attribute.Key) string {
+	for _, attribute := range attributes {
+		if isKey(attribute.Key, keys...) {
+			return attribute.Value.AsString()
+		}
+	}
+
+	return ""
+}
+
+func isHTTPMethodKey(key attribute.Key) bool {
+	return isKey(key, legacyHTTPMethodKey, semconv.HTTPRequestMethodKey)
+}
+
+func isDBSystemKey(key attribute.Key) bool {
+	return isKey(key, legacyDBSystemKey, semconv.DBSystemNameKey)
+}
+
+func isDBStatementKey(key attribute.Key) bool {
+	return isKey(key, legacyDBStatementKey, semconv.DBQueryTextKey)
+}
+
+func isHTTPStatusCodeKey(key attribute.Key) bool {
+	return isKey(key, legacyHTTPStatusCodeKey, semconv.HTTPResponseStatusCodeKey)
+}
+
+func sentryRequestURL(attributes []attribute.KeyValue) string {
+	return spanAttributeString(attributes, legacyHTTPURLKey, semconv.URLFullKey)
+}
+
+func httpSpanData(attributes []attribute.KeyValue) (method, route, target, fullURL string) {
+	return spanAttributeString(attributes, legacyHTTPMethodKey, semconv.HTTPRequestMethodKey),
+		spanAttributeString(attributes, semconv.HTTPRouteKey),
+		spanAttributeString(attributes, legacyHTTPTargetKey, semconv.URLPathKey),
+		spanAttributeString(attributes, legacyHTTPURLKey, semconv.URLFullKey)
+}

--- a/otel/internal/utils/sentryrequest.go
+++ b/otel/internal/utils/sentryrequest.go
@@ -6,23 +6,17 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 )
 
 func IsSentryRequestSpan(ctx context.Context, s trace.ReadOnlySpan) bool {
-	attributes := s.Attributes()
-
-	// TODO(michi): can we access the attribute directly?
-	for _, attribute := range attributes {
-		if attribute.Key == semconv.HTTPURLKey {
-			return isSentryRequestURL(ctx, attribute.Value.AsString())
-		}
-	}
-
-	return false
+	return isSentryRequestURL(ctx, sentryRequestURL(s.Attributes()))
 }
 
 func isSentryRequestURL(ctx context.Context, url string) bool {
+	if url == "" {
+		return false
+	}
+
 	hub := sentry.GetHubFromContext(ctx)
 	if hub == nil {
 		hub = sentry.CurrentHub()

--- a/otel/internal/utils/spanattributes.go
+++ b/otel/internal/utils/spanattributes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	otelSdkTrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	otelTrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -18,10 +18,10 @@ type SpanAttributes struct {
 
 func ParseSpanAttributes(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 	for _, attribute := range s.Attributes() {
-		if attribute.Key == semconv.HTTPMethodKey {
+		if isHTTPMethodKey(attribute.Key) {
 			return descriptionForHTTPMethod(s)
 		}
-		if attribute.Key == semconv.DBSystemKey {
+		if isDBSystemKey(attribute.Key) {
 			return descriptionForDbSystem(s)
 		}
 		if attribute.Key == semconv.RPCSystemKey {
@@ -58,10 +58,10 @@ func ParseSpanAttributes(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 func descriptionForDbSystem(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 	description := s.Name()
 	for _, attribute := range s.Attributes() {
-		if attribute.Key == semconv.DBStatementKey {
+		if isDBStatementKey(attribute.Key) {
 			// TODO(michi)
 			// Note: The value may be sanitized to exclude sensitive information.
-			// See: https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.12.0
+			// See: https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.30.0
 			description = attribute.Value.AsString()
 			break
 		}
@@ -83,23 +83,7 @@ func descriptionForHTTPMethod(s otelSdkTrace.ReadOnlySpan) SpanAttributes {
 		op = "http.server"
 	}
 
-	var httpTarget string
-	var httpRoute string
-	var httpMethod string
-	var httpURL string
-
-	for _, attribute := range s.Attributes() {
-		switch attribute.Key {
-		case semconv.HTTPTargetKey:
-			httpTarget = attribute.Value.AsString()
-		case semconv.HTTPRouteKey:
-			httpRoute = attribute.Value.AsString()
-		case semconv.HTTPMethodKey:
-			httpMethod = attribute.Value.AsString()
-		case semconv.HTTPURLKey:
-			httpURL = attribute.Value.AsString()
-		}
-	}
+	httpMethod, httpRoute, httpTarget, httpURL := httpSpanData(s.Attributes())
 
 	var httpPath string
 

--- a/otel/internal/utils/spanattributes_test.go
+++ b/otel/internal/utils/spanattributes_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	oldsemconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/getsentry/sentry-go"
@@ -15,16 +16,16 @@ import (
 )
 
 func TestParseSpanAttributes(t *testing.T) {
-	t.Run("Handles HTTP spans", func(t *testing.T) {
+	t.Run("Handles legacy HTTP spans", func(t *testing.T) {
 		t.Run("Prefers httpRoute over httpTarget", func(t *testing.T) {
 			span := &mockReadOnlySpan{
 				name:     "<overridden>",
 				spanKind: oteltrace.SpanKindServer,
 				attributes: []attribute.KeyValue{
-					semconv.HTTPMethodKey.String(http.MethodOptions),
-					semconv.HTTPTargetKey.String("/projects/123/settings?q=proj#123"),
-					semconv.HTTPRouteKey.String("/projects/:projectID/settings"),
-					semconv.HTTPURLKey.String("https://sentry.io/projects/:projectID/settings?q=proj#123"),
+					oldsemconv.HTTPMethodKey.String(http.MethodOptions),
+					oldsemconv.HTTPTargetKey.String("/projects/123/settings?q=proj#123"),
+					oldsemconv.HTTPRouteKey.String("/projects/:projectID/settings"),
+					oldsemconv.HTTPURLKey.String("https://sentry.io/projects/:projectID/settings?q=proj#123"),
 				},
 			}
 
@@ -39,9 +40,9 @@ func TestParseSpanAttributes(t *testing.T) {
 				name:     "<overridden>",
 				spanKind: oteltrace.SpanKindClient,
 				attributes: []attribute.KeyValue{
-					semconv.HTTPMethodKey.String(http.MethodGet),
-					semconv.HTTPTargetKey.String("/users?page=2"),
-					semconv.HTTPURLKey.String("https://sentry.io/users?page=2"),
+					oldsemconv.HTTPMethodKey.String(http.MethodGet),
+					oldsemconv.HTTPTargetKey.String("/users?page=2"),
+					oldsemconv.HTTPURLKey.String("https://sentry.io/users?page=2"),
 				},
 			}
 
@@ -56,8 +57,8 @@ func TestParseSpanAttributes(t *testing.T) {
 				name:     "<overridden>",
 				spanKind: oteltrace.SpanKindClient,
 				attributes: []attribute.KeyValue{
-					semconv.HTTPMethodKey.String(http.MethodGet),
-					semconv.HTTPURLKey.String("https://sentry.io/api/v1/issues?limit=10"),
+					oldsemconv.HTTPMethodKey.String(http.MethodGet),
+					oldsemconv.HTTPURLKey.String("https://sentry.io/api/v1/issues?limit=10"),
 				},
 			}
 
@@ -66,21 +67,38 @@ func TestParseSpanAttributes(t *testing.T) {
 			assert.Equal(t, "http.client", parsed.Op)
 			assert.Equal(t, sentry.SourceURL, parsed.Source)
 		})
+	})
 
-		t.Run("Uses fallback when no URL info exists", func(t *testing.T) {
-			span := &mockReadOnlySpan{
-				name:     "Some description",
-				spanKind: oteltrace.SpanKindClient,
-				attributes: []attribute.KeyValue{
-					semconv.HTTPMethodKey.String(http.MethodGet),
-				},
-			}
+	t.Run("Handles v1.30 HTTP spans", func(t *testing.T) {
+		span := &mockReadOnlySpan{
+			name:     "<overridden>",
+			spanKind: oteltrace.SpanKindClient,
+			attributes: []attribute.KeyValue{
+				semconv.HTTPRequestMethodKey.String(http.MethodGet),
+				semconv.URLPathKey.String("/users"),
+				semconv.URLFullKey.String("https://sentry.io/users?page=2"),
+			},
+		}
 
-			parsed := utils.ParseSpanAttributes(span)
-			assert.Equal(t, "Some description", parsed.Description)
-			assert.Equal(t, "http.client", parsed.Op)
-			assert.Equal(t, sentry.SourceCustom, parsed.Source)
-		})
+		parsed := utils.ParseSpanAttributes(span)
+		assert.Equal(t, "GET /users", parsed.Description)
+		assert.Equal(t, "http.client", parsed.Op)
+		assert.Equal(t, sentry.SourceURL, parsed.Source)
+	})
+
+	t.Run("Uses fallback when no URL info exists", func(t *testing.T) {
+		span := &mockReadOnlySpan{
+			name:     "Some description",
+			spanKind: oteltrace.SpanKindClient,
+			attributes: []attribute.KeyValue{
+				oldsemconv.HTTPMethodKey.String(http.MethodGet),
+			},
+		}
+
+		parsed := utils.ParseSpanAttributes(span)
+		assert.Equal(t, "Some description", parsed.Description)
+		assert.Equal(t, "http.client", parsed.Op)
+		assert.Equal(t, sentry.SourceCustom, parsed.Source)
 	})
 
 	t.Run("Falls back to raw httpTarget when URL parsing fails", func(t *testing.T) {
@@ -89,8 +107,8 @@ func TestParseSpanAttributes(t *testing.T) {
 			name:     "<overridden>",
 			spanKind: oteltrace.SpanKindServer,
 			attributes: []attribute.KeyValue{
-				semconv.HTTPMethodKey.String(http.MethodGet),
-				semconv.HTTPTargetKey.String(invalidTarget),
+				oldsemconv.HTTPMethodKey.String(http.MethodGet),
+				oldsemconv.HTTPTargetKey.String(invalidTarget),
 			},
 		}
 
@@ -101,13 +119,29 @@ func TestParseSpanAttributes(t *testing.T) {
 	})
 
 	t.Run("Handles DB spans", func(t *testing.T) {
-		t.Run("Includes DB statement in description", func(t *testing.T) {
+		t.Run("Includes legacy DB statement in description", func(t *testing.T) {
 			stmt := "SELECT * FROM users"
 			span := &mockReadOnlySpan{
 				name: "<overridden>",
 				attributes: []attribute.KeyValue{
-					semconv.DBSystemKey.String("postgresql"),
-					semconv.DBStatementKey.String(stmt),
+					oldsemconv.DBSystemKey.String("postgresql"),
+					oldsemconv.DBStatementKey.String(stmt),
+				},
+			}
+
+			parsed := utils.ParseSpanAttributes(span)
+			assert.Equal(t, stmt, parsed.Description)
+			assert.Equal(t, "db", parsed.Op)
+			assert.Equal(t, sentry.SourceTask, parsed.Source)
+		})
+
+		t.Run("Includes v1.30 DB query text in description", func(t *testing.T) {
+			stmt := "SELECT * FROM users"
+			span := &mockReadOnlySpan{
+				name: "<overridden>",
+				attributes: []attribute.KeyValue{
+					semconv.DBSystemNameKey.String("postgresql"),
+					semconv.DBQueryTextKey.String(stmt),
 				},
 			}
 

--- a/otel/span_processor_test.go
+++ b/otel/span_processor_test.go
@@ -517,3 +517,49 @@ func TestLinkTraceContextToErrorEventWithSpanProcessor(t *testing.T) {
 		"span_id":  otelSpan.SpanContext().SpanID().String(),
 	})
 }
+
+func TestOnEndDoesNotFinishSentryRequestsWithURLFull(t *testing.T) {
+	_, tracer := setupSpanProcessorTest()
+	ctx, otelSpan := tracer.Start(
+		emptyContextWithSentry(),
+		"POST to Sentry",
+		trace.WithAttributes(attribute.String("url.full", "https://example.com/api/123/envelope/")),
+	)
+	sentrySpan, _ := sentrySpanMap.Get(otelSpan.SpanContext().TraceID(), otelSpan.SpanContext().SpanID())
+	otelSpan.End()
+
+	assertEqual(t, sentrySpanMap.Len(), 0)
+	assertTrue(t, sentrySpan.EndTime.IsZero())
+	sentryTransport := getSentryTransportFromContext(ctx)
+	assertEqual(t, len(sentryTransport.Events()), 0)
+}
+
+func TestParseSpanAttributesHttpClientWithNewSemconv(t *testing.T) {
+	_, tracer := setupSpanProcessorTest()
+	ctx, otelRootSpan := tracer.Start(
+		emptyContextWithSentry(),
+		"rootSpan",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String("http.request.method", "GET")),
+		trace.WithAttributes(attribute.String("url.full", "http://localhost:1234/api/checkout1?q1=q2#fragment")),
+	)
+	_, otelChildSpan := tracer.Start(ctx,
+		"childSpan",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String("http.request.method", "POST")),
+		trace.WithAttributes(attribute.String("url.path", "/api/checkout2")),
+		trace.WithAttributes(attribute.String("url.full", "http://localhost:2345/api/checkout2?q1=q2#fragment")),
+	)
+
+	sentryTransaction, _ := sentrySpanMap.Get(otelRootSpan.SpanContext().TraceID(), otelRootSpan.SpanContext().SpanID())
+	sentrySpan, _ := sentrySpanMap.Get(otelChildSpan.SpanContext().TraceID(), otelChildSpan.SpanContext().SpanID())
+
+	otelChildSpan.End()
+	otelRootSpan.End()
+
+	assertEqual(t, sentryTransaction.Name, "GET http://localhost:1234/api/checkout1")
+	assertEqual(t, sentryTransaction.Op, "http.client")
+	assertEqual(t, sentryTransaction.Source, sentry.TransactionSource("url"))
+	assertEqual(t, sentrySpan.Description, "POST /api/checkout2")
+	assertEqual(t, sentrySpan.Op, "http.client")
+}


### PR DESCRIPTION
## Summary
- teach the OTel span helpers to understand both legacy semconv keys and the newer v1.30 HTTP/DB/status attributes
- keep Sentry request detection working for spans that now use `url.full`
- add regression tests for the new attribute names and end-to-end span processor behavior

Closes #1303