### PR TITLE
chore: update bump-version script to also bump crosstest

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -28,3 +28,9 @@ GO_MOD_FILES=$(find . -type f -name 'go.mod' -not -path ./go.mod)
 for GO_MOD in ${GO_MOD_FILES}; do
     replace "github.com/getsentry/sentry-go v.*" "github.com/getsentry/sentry-go v${NEW_VERSION}" "${GO_MOD}"
 done
+
+# Replace sentry-go submodule versions (e.g., sentry-go/echo, sentry-go/gin)
+# in go.mod files that depend on multiple submodules (like crosstest/go.mod).
+for GO_MOD in ${GO_MOD_FILES}; do
+	perl -i -pe "s!(github\.com/getsentry/sentry-go/\S+) v[\w.\-]+!\$1 v${NEW_VERSION}!g" "${GO_MOD}"
+done


### PR DESCRIPTION
### Description
This updates the bump-version script to bump submodule versions instead of only the root module. For crosstest this doesn't really affect anything due to the replace directives, but it's good practice to keep version numbers consistent.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
