### PR TITLE
feat: add initial DataCollection struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -382,7 +382,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		options.TraceIgnoreStatusCodes = [][]int{{404}}
 	}
 
-	resolvedDataCollection := newDataCollection(options.DataCollection, options.SendDefaultPII)
+	resolvedDataCollection := snapshotDataCollection(options.DataCollection, options.SendDefaultPII)
 	options.DataCollection = cloneDataCollection(&resolvedDataCollection)
 
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar
@@ -709,7 +709,7 @@ func (client *Client) captureMetric(metric *Metric, _ *Scope) bool {
 
 // Recover captures a panic.
 // Returns EventID if successfully, or nil if there's no error to recover from.
-func (client *Client) Recover(err interface{}, hint *EventHint, scope EventModifier) *EventID {
+func (client *Client) Recover(err any, hint *EventHint, scope EventModifier) *EventID {
 	if err == nil {
 		err = recover()
 	}
@@ -726,7 +726,7 @@ func (client *Client) Recover(err interface{}, hint *EventHint, scope EventModif
 // Returns EventID if successfully, or nil if there's no error to recover from.
 func (client *Client) RecoverWithContext(
 	ctx context.Context,
-	err interface{},
+	err any,
 	hint *EventHint,
 	scope EventModifier,
 ) *EventID {

--- a/client.go
+++ b/client.go
@@ -172,9 +172,18 @@ type ClientOptions struct {
 	// List of regexp strings that will be used to match against a transaction's
 	// name.  If a match is found, then the transaction  will be dropped.
 	IgnoreTransactions []string
+	// Deprecated: Use DataCollection for granular control over what data the
+	// SDK collects. When DataCollection is configured, SendDefaultPII is
+	// ignored.
+	//
 	// If this flag is enabled, certain personally identifiable information (PII) is added by active integrations.
 	// By default, no such data is sent.
 	SendDefaultPII bool
+	// DataCollection configures what data the SDK collects automatically. All fields are optional. By default
+	// the SDK collects rich context for debugging while scrubbing sensitive values.
+	//
+	// See https://docs.sentry.io/platforms/go/configuration/options/#DataCollection
+	DataCollection *DataCollection
 	// BeforeSend is called before error events are sent to Sentry.
 	// You can use it to mutate the event or return nil to discard it.
 	BeforeSend func(event *Event, hint *EventHint) *Event
@@ -296,6 +305,7 @@ type Client struct {
 	mu                    sync.RWMutex
 	options               ClientOptions
 	dsn                   *protocol.Dsn
+	dataCollection        DataCollection
 	eventProcessors       []EventProcessor
 	integrations          []Integration
 	externalTraceResolver externalContextTraceResolver
@@ -373,6 +383,9 @@ func NewClient(options ClientOptions) (*Client, error) {
 		options.TraceIgnoreStatusCodes = [][]int{{404}}
 	}
 
+	resolvedDataCollection := newDataCollection(options.DataCollection, options.SendDefaultPII)
+	options.DataCollection = cloneDataCollection(&resolvedDataCollection)
+
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar
 	// to GODEBUG). It is not a supported feature: recognized debug options
 	// may change any time.
@@ -408,6 +421,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 	client := Client{
 		options:        options,
 		dsn:            dsn,
+		dataCollection: resolvedDataCollection,
 		sdkIdentifier:  sdkIdentifier,
 		sdkVersion:     SDKVersion,
 		reportRecorder: report.NoopRecorder(),
@@ -586,6 +600,16 @@ func (client *Client) externalTraceContextFromContext(ctx context.Context) (Trac
 func (client *Client) Options() ClientOptions {
 	// Note: internally, consider using `client.options` instead of `client.Options()` to avoid copying the object each time.
 	return client.options
+}
+
+// GetDataCollection returns a copy of the resolved data collection
+// configuration used by the client.
+func (client *Client) GetDataCollection() DataCollection {
+	cloned := cloneDataCollection(&client.dataCollection)
+	if cloned == nil {
+		return DataCollection{}
+	}
+	return *cloned
 }
 
 // CaptureMessage captures an arbitrary message.

--- a/client.go
+++ b/client.go
@@ -305,7 +305,6 @@ type Client struct {
 	mu                    sync.RWMutex
 	options               ClientOptions
 	dsn                   *protocol.Dsn
-	dataCollection        DataCollection
 	eventProcessors       []EventProcessor
 	integrations          []Integration
 	externalTraceResolver externalContextTraceResolver
@@ -384,7 +383,6 @@ func NewClient(options ClientOptions) (*Client, error) {
 	}
 
 	resolvedDataCollection := newDataCollection(options.DataCollection, options.SendDefaultPII)
-	// replace options.DataCollection with a snapshot of current settings.
 	options.DataCollection = cloneDataCollection(&resolvedDataCollection)
 
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar
@@ -422,7 +420,6 @@ func NewClient(options ClientOptions) (*Client, error) {
 	client := Client{
 		options:        options,
 		dsn:            dsn,
-		dataCollection: resolvedDataCollection,
 		sdkIdentifier:  sdkIdentifier,
 		sdkVersion:     SDKVersion,
 		reportRecorder: report.NoopRecorder(),
@@ -605,26 +602,13 @@ func (client *Client) Options() ClientOptions {
 	return opts
 }
 
-// CollectUserInfo reports whether automatic user-info collection is enabled.
-// After NewClient, UserInfo is always resolved.
-func (client *Client) CollectUserInfo() bool {
-	if client == nil {
-		return false
-	}
-	return client.dataCollection.UserInfo.Value
-}
-
 // GetDataCollection returns a copy of the resolved data collection
 // configuration used by the client.
 func (client *Client) GetDataCollection() DataCollection {
-	if client == nil {
+	if client == nil || client.options.DataCollection == nil {
 		return DataCollection{}
 	}
-	cloned := cloneDataCollection(&client.dataCollection)
-	if cloned == nil {
-		return DataCollection{}
-	}
-	return *cloned
+	return *cloneDataCollection(client.options.DataCollection)
 }
 
 // CaptureMessage captures an arbitrary message.

--- a/client.go
+++ b/client.go
@@ -384,6 +384,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 	}
 
 	resolvedDataCollection := newDataCollection(options.DataCollection, options.SendDefaultPII)
+	// replace options.DataCollection with a snapshot of current settings.
 	options.DataCollection = cloneDataCollection(&resolvedDataCollection)
 
 	// SENTRYGODEBUG is a comma-separated list of key=value pairs (similar
@@ -599,12 +600,26 @@ func (client *Client) externalTraceContextFromContext(ctx context.Context) (Trac
 // Options return ClientOptions for the current Client.
 func (client *Client) Options() ClientOptions {
 	// Note: internally, consider using `client.options` instead of `client.Options()` to avoid copying the object each time.
-	return client.options
+	opts := client.options
+	opts.DataCollection = cloneDataCollection(client.options.DataCollection)
+	return opts
+}
+
+// CollectUserInfo reports whether automatic user-info collection is enabled.
+// After NewClient, UserInfo is always resolved.
+func (client *Client) CollectUserInfo() bool {
+	if client == nil {
+		return false
+	}
+	return client.dataCollection.UserInfo.Value
 }
 
 // GetDataCollection returns a copy of the resolved data collection
 // configuration used by the client.
 func (client *Client) GetDataCollection() DataCollection {
+	if client == nil {
+		return DataCollection{}
+	}
 	cloned := cloneDataCollection(&client.dataCollection)
 	if cloned == nil {
 		return DataCollection{}

--- a/data_collection.go
+++ b/data_collection.go
@@ -86,18 +86,6 @@ type DataCollection struct {
 	//
 	// Defaults to using the built-in DenyList.
 	QueryParams *KeyValueCollectionBehavior
-
-	// StackFrameVariables controls whether local variable values captured
-	// within stack frames are included.
-	//
-	// Defaults to true.
-	StackFrameVariables Option[bool]
-
-	// FrameContextLines controls how many source code lines to include above
-	// and below each stack frame.
-	//
-	// Defaults to 5.
-	FrameContextLines Option[int]
 }
 
 // cloneKeyValueCollectionBehavior returns a deep copy of b.
@@ -129,12 +117,10 @@ func cloneDataCollection(dc *DataCollection) *DataCollection {
 		return nil
 	}
 	cloned := &DataCollection{
-		UserInfo:            dc.UserInfo,
-		Cookies:             cloneKeyValueCollectionBehavior(dc.Cookies),
-		HTTPHeaders:         cloneHeaderCollectionConfig(dc.HTTPHeaders),
-		QueryParams:         cloneKeyValueCollectionBehavior(dc.QueryParams),
-		StackFrameVariables: dc.StackFrameVariables,
-		FrameContextLines:   dc.FrameContextLines,
+		UserInfo:    dc.UserInfo,
+		Cookies:     cloneKeyValueCollectionBehavior(dc.Cookies),
+		HTTPHeaders: cloneHeaderCollectionConfig(dc.HTTPHeaders),
+		QueryParams: cloneKeyValueCollectionBehavior(dc.QueryParams),
 	}
 	if dc.HTTPBodies != nil {
 		cloned.HTTPBodies = append([]BodyType{}, dc.HTTPBodies...)
@@ -146,9 +132,6 @@ func cloneDataCollection(dc *DataCollection) *DataCollection {
 func defaultKeyValueBehavior() *KeyValueCollectionBehavior {
 	return &KeyValueCollectionBehavior{Mode: CollectionDenyList}
 }
-
-// defaultFrameContextLines is the default number of source context lines.
-const defaultFrameContextLines = 5
 
 // allBodyTypes returns all valid body types.
 func allBodyTypes() []BodyType {
@@ -173,9 +156,7 @@ func newDataCollection(dc *DataCollection, sendDefaultPII bool) DataCollection {
 		resolved.Cookies == nil &&
 		resolved.HTTPHeaders == nil &&
 		resolved.HTTPBodies == nil &&
-		resolved.QueryParams == nil &&
-		!resolved.StackFrameVariables.IsSet &&
-		!resolved.FrameContextLines.IsSet)
+		resolved.QueryParams == nil)
 
 	// TODO: should consider sendDefaultPII on how to apply and use DataCollection for
 	// backward compatibility. Will be used in a next step.
@@ -202,13 +183,6 @@ func newDataCollection(dc *DataCollection, sendDefaultPII bool) DataCollection {
 	if resolved.QueryParams == nil {
 		resolved.QueryParams = defaultKeyValueBehavior()
 	}
-	if !resolved.StackFrameVariables.IsSet {
-		resolved.StackFrameVariables = Set(true)
-	}
-	if !resolved.FrameContextLines.IsSet {
-		resolved.FrameContextLines = Set(defaultFrameContextLines)
-	}
-
 	return resolved
 }
 

--- a/data_collection.go
+++ b/data_collection.go
@@ -64,7 +64,7 @@ type DataCollection struct {
 	//
 	// This does NOT gate data explicitly set via Scope.SetUser(); that is
 	// always attached. Defaults to true.
-	UserInfo *bool
+	UserInfo Option[bool]
 
 	// Cookies configures collection of HTTP cookies.
 	//
@@ -91,29 +91,13 @@ type DataCollection struct {
 	// within stack frames are included.
 	//
 	// Defaults to true.
-	StackFrameVariables *bool
+	StackFrameVariables Option[bool]
 
 	// FrameContextLines controls how many source code lines to include above
 	// and below each stack frame.
 	//
 	// Defaults to 5.
-	FrameContextLines *int
-}
-
-// cloneBool returns a copy of b.
-func cloneBool(b *bool) *bool {
-	if b == nil {
-		return nil
-	}
-	return Pointer(*b)
-}
-
-// cloneInt returns a copy of n.
-func cloneInt(n *int) *int {
-	if n == nil {
-		return nil
-	}
-	return Pointer(*n)
+	FrameContextLines Option[int]
 }
 
 // cloneKeyValueCollectionBehavior returns a deep copy of b.
@@ -145,12 +129,12 @@ func cloneDataCollection(dc *DataCollection) *DataCollection {
 		return nil
 	}
 	cloned := &DataCollection{
-		UserInfo:            cloneBool(dc.UserInfo),
+		UserInfo:            dc.UserInfo,
 		Cookies:             cloneKeyValueCollectionBehavior(dc.Cookies),
 		HTTPHeaders:         cloneHeaderCollectionConfig(dc.HTTPHeaders),
 		QueryParams:         cloneKeyValueCollectionBehavior(dc.QueryParams),
-		StackFrameVariables: cloneBool(dc.StackFrameVariables),
-		FrameContextLines:   cloneInt(dc.FrameContextLines),
+		StackFrameVariables: dc.StackFrameVariables,
+		FrameContextLines:   dc.FrameContextLines,
 	}
 	if dc.HTTPBodies != nil {
 		cloned.HTTPBodies = append([]BodyType{}, dc.HTTPBodies...)
@@ -185,20 +169,20 @@ func newDataCollection(dc *DataCollection, sendDefaultPII bool) DataCollection {
 		resolved = *cloned
 	}
 
-	isZero := dc == nil || (resolved.UserInfo == nil &&
+	isZero := dc == nil || (!resolved.UserInfo.IsSet &&
 		resolved.Cookies == nil &&
 		resolved.HTTPHeaders == nil &&
 		resolved.HTTPBodies == nil &&
 		resolved.QueryParams == nil &&
-		resolved.StackFrameVariables == nil &&
-		resolved.FrameContextLines == nil)
+		!resolved.StackFrameVariables.IsSet &&
+		!resolved.FrameContextLines.IsSet)
 
 	// TODO: should consider sendDefaultPII on how to apply and use DataCollection for
 	// backward compatibility. Will be used in a next step.
 	_ = isZero && sendDefaultPII
 
-	if resolved.UserInfo == nil {
-		resolved.UserInfo = Pointer(true)
+	if !resolved.UserInfo.IsSet {
+		resolved.UserInfo = Set(true)
 	}
 	if resolved.Cookies == nil {
 		resolved.Cookies = defaultKeyValueBehavior()
@@ -218,11 +202,11 @@ func newDataCollection(dc *DataCollection, sendDefaultPII bool) DataCollection {
 	if resolved.QueryParams == nil {
 		resolved.QueryParams = defaultKeyValueBehavior()
 	}
-	if resolved.StackFrameVariables == nil {
-		resolved.StackFrameVariables = Pointer(true)
+	if !resolved.StackFrameVariables.IsSet {
+		resolved.StackFrameVariables = Set(true)
 	}
-	if resolved.FrameContextLines == nil {
-		resolved.FrameContextLines = Pointer(defaultFrameContextLines)
+	if !resolved.FrameContextLines.IsSet {
+		resolved.FrameContextLines = Set(defaultFrameContextLines)
 	}
 
 	return resolved

--- a/data_collection.go
+++ b/data_collection.go
@@ -98,7 +98,7 @@ func cloneKeyValueCollectionBehavior(b *KeyValueCollectionBehavior) *KeyValueCol
 	}
 	cloned := &KeyValueCollectionBehavior{Mode: b.Mode}
 	if b.Terms != nil {
-		cloned.Terms = append([]string(nil), b.Terms...)
+		cloned.Terms = slices.Clone(b.Terms)
 	}
 	return cloned
 }
@@ -126,7 +126,7 @@ func cloneDataCollection(dc *DataCollection) *DataCollection {
 		QueryParams: cloneKeyValueCollectionBehavior(dc.QueryParams),
 	}
 	if dc.HTTPBodies != nil {
-		cloned.HTTPBodies = append([]BodyType{}, dc.HTTPBodies...)
+		cloned.HTTPBodies = slices.Clone(dc.HTTPBodies)
 	}
 	return cloned
 }

--- a/data_collection.go
+++ b/data_collection.go
@@ -1,0 +1,243 @@
+package sentry
+
+// CollectionMode controls how key-value data (headers, cookies, query params) is collected.
+type CollectionMode string
+
+const (
+	// CollectionOff disables collection of the category entirely.
+	CollectionOff CollectionMode = "off"
+
+	// CollectionDenyList keeps all keys and filters denied values.
+	CollectionDenyList CollectionMode = "denyList"
+
+	// CollectionAllowList keeps all keys and sends real values only for allowed
+	// keys; all other values are filtered.
+	CollectionAllowList CollectionMode = "allowList"
+)
+
+// KeyValueCollectionBehavior configures how key-value data is collected and filtered.
+type KeyValueCollectionBehavior struct {
+	// Mode controls the collection strategy. Default: CollectionDenyList.
+	Mode CollectionMode
+	// Terms is a list of additional terms used by the active mode.
+	Terms []string
+}
+
+// HeaderCollectionConfig configures how HTTP headers are collected for
+// requests and responses independently.
+type HeaderCollectionConfig struct {
+	// Request configures collection of HTTP request headers. Defaults to DenyList.
+	Request *KeyValueCollectionBehavior
+	// Response configures collection of HTTP response headers. Defaults to DenyList.
+	Response *KeyValueCollectionBehavior
+}
+
+// BodyType identifies a category of HTTP body to collect.
+type BodyType string
+
+const (
+	// BodyIncomingRequest collects bodies from incoming HTTP requests
+	// (server-side).
+	BodyIncomingRequest BodyType = "incomingRequest"
+
+	// BodyOutgoingRequest collects bodies from outgoing HTTP requests
+	// (client-side).
+	BodyOutgoingRequest BodyType = "outgoingRequest"
+
+	// BodyIncomingResponse collects bodies from incoming HTTP responses
+	// (client-side).
+	BodyIncomingResponse BodyType = "incomingResponse"
+
+	// BodyOutgoingResponse collects bodies from outgoing HTTP responses
+	// (server-side).
+	BodyOutgoingResponse BodyType = "outgoingResponse"
+)
+
+// DataCollection configures what data the SDK collects automatically.
+// All fields are optional. nil or zero-value fields use the documented
+// defaults, which collect rich context for debugging while scrubbing sensitive
+// values via a built-in denylist.
+//
+// See https://docs.sentry.io/platforms/go/configuration/options/#DataCollection
+type DataCollection struct {
+	// UserInfo controls automatic population of user.* fields from auto-instrumentation.
+	//
+	// This does NOT gate data explicitly set via Scope.SetUser(); that is
+	// always attached. Defaults to true.
+	UserInfo *bool
+
+	// Cookies configures collection of HTTP cookies.
+	//
+	// Defaults to using the built-in DenyList.
+	Cookies *KeyValueCollectionBehavior
+
+	// HTTPHeaders configures collection of HTTP request and response headers
+	// independently.
+	//
+	// Defaults to both request and response using the built-in DenyList.
+	HTTPHeaders *HeaderCollectionConfig
+
+	// HTTPBodies controls which HTTP body types are collected.
+	//
+	// Defaults to collecting all valid body types.
+	HTTPBodies []BodyType
+
+	// QueryParams configures collection of URL query parameters.
+	//
+	// Defaults to using the built-in DenyList.
+	QueryParams *KeyValueCollectionBehavior
+
+	// StackFrameVariables controls whether local variable values captured
+	// within stack frames are included.
+	//
+	// Defaults to true.
+	StackFrameVariables *bool
+
+	// FrameContextLines controls how many source code lines to include above
+	// and below each stack frame.
+	//
+	// Defaults to 5.
+	FrameContextLines *int
+}
+
+// cloneBool returns a copy of b.
+func cloneBool(b *bool) *bool {
+	if b == nil {
+		return nil
+	}
+	return Pointer(*b)
+}
+
+// cloneInt returns a copy of n.
+func cloneInt(n *int) *int {
+	if n == nil {
+		return nil
+	}
+	return Pointer(*n)
+}
+
+// cloneKeyValueCollectionBehavior returns a deep copy of b.
+func cloneKeyValueCollectionBehavior(b *KeyValueCollectionBehavior) *KeyValueCollectionBehavior {
+	if b == nil {
+		return nil
+	}
+	cloned := &KeyValueCollectionBehavior{Mode: b.Mode}
+	if b.Terms != nil {
+		cloned.Terms = append([]string(nil), b.Terms...)
+	}
+	return cloned
+}
+
+// cloneHeaderCollectionConfig returns a deep copy of c.
+func cloneHeaderCollectionConfig(c *HeaderCollectionConfig) *HeaderCollectionConfig {
+	if c == nil {
+		return nil
+	}
+	return &HeaderCollectionConfig{
+		Request:  cloneKeyValueCollectionBehavior(c.Request),
+		Response: cloneKeyValueCollectionBehavior(c.Response),
+	}
+}
+
+// cloneDataCollection returns a deep copy of dc.
+func cloneDataCollection(dc *DataCollection) *DataCollection {
+	if dc == nil {
+		return nil
+	}
+	cloned := &DataCollection{
+		UserInfo:            cloneBool(dc.UserInfo),
+		Cookies:             cloneKeyValueCollectionBehavior(dc.Cookies),
+		HTTPHeaders:         cloneHeaderCollectionConfig(dc.HTTPHeaders),
+		QueryParams:         cloneKeyValueCollectionBehavior(dc.QueryParams),
+		StackFrameVariables: cloneBool(dc.StackFrameVariables),
+		FrameContextLines:   cloneInt(dc.FrameContextLines),
+	}
+	if dc.HTTPBodies != nil {
+		cloned.HTTPBodies = append([]BodyType{}, dc.HTTPBodies...)
+	}
+	return cloned
+}
+
+// defaultKeyValueBehavior returns the default key-value collection behavior.
+func defaultKeyValueBehavior() *KeyValueCollectionBehavior {
+	return &KeyValueCollectionBehavior{Mode: CollectionDenyList}
+}
+
+// defaultFrameContextLines is the default number of source context lines.
+const defaultFrameContextLines = 5
+
+// allBodyTypes returns all valid body types.
+func allBodyTypes() []BodyType {
+	return []BodyType{
+		BodyIncomingRequest,
+		BodyOutgoingRequest,
+		BodyIncomingResponse,
+		BodyOutgoingResponse,
+	}
+}
+
+// newDataCollection builds a fully-populated DataCollection by applying
+// defaults to any nil fields. It also handles backward compatibility with the
+// legacy SendDefaultPII option.
+func newDataCollection(dc *DataCollection, sendDefaultPII bool) DataCollection {
+	var resolved DataCollection
+	if cloned := cloneDataCollection(dc); cloned != nil {
+		resolved = *cloned
+	}
+
+	isZero := dc == nil || (resolved.UserInfo == nil &&
+		resolved.Cookies == nil &&
+		resolved.HTTPHeaders == nil &&
+		resolved.HTTPBodies == nil &&
+		resolved.QueryParams == nil &&
+		resolved.StackFrameVariables == nil &&
+		resolved.FrameContextLines == nil)
+
+	// TODO: should consider sendDefaultPII on how to apply and use DataCollection for
+	// backward compatibility. Will be used in a next step.
+	_ = isZero && sendDefaultPII
+
+	if resolved.UserInfo == nil {
+		resolved.UserInfo = Pointer(true)
+	}
+	if resolved.Cookies == nil {
+		resolved.Cookies = defaultKeyValueBehavior()
+	}
+	if resolved.HTTPHeaders == nil {
+		resolved.HTTPHeaders = &HeaderCollectionConfig{}
+	}
+	if resolved.HTTPHeaders.Request == nil {
+		resolved.HTTPHeaders.Request = defaultKeyValueBehavior()
+	}
+	if resolved.HTTPHeaders.Response == nil {
+		resolved.HTTPHeaders.Response = defaultKeyValueBehavior()
+	}
+	if resolved.HTTPBodies == nil {
+		resolved.HTTPBodies = allBodyTypes()
+	}
+	if resolved.QueryParams == nil {
+		resolved.QueryParams = defaultKeyValueBehavior()
+	}
+	if resolved.StackFrameVariables == nil {
+		resolved.StackFrameVariables = Pointer(true)
+	}
+	if resolved.FrameContextLines == nil {
+		resolved.FrameContextLines = Pointer(defaultFrameContextLines)
+	}
+
+	return resolved
+}
+
+// isHTTPBodyCollected reports whether the given body type should be collected
+// according to the DataCollection configuration.
+func (dc *DataCollection) isHTTPBodyCollected(bt BodyType) bool {
+	if dc == nil || dc.HTTPBodies == nil {
+		return true
+	}
+	for _, t := range dc.HTTPBodies {
+		if t == bt {
+			return true
+		}
+	}
+	return false
+}

--- a/data_collection.go
+++ b/data_collection.go
@@ -1,23 +1,26 @@
 package sentry
 
+import "slices"
+
 // CollectionMode controls how key-value data (headers, cookies, query params) is collected.
-type CollectionMode string
+//
+// Defaults to CollectionDenyList.
+type CollectionMode int
 
 const (
-	// CollectionOff disables collection of the category entirely.
-	CollectionOff CollectionMode = "off"
-
 	// CollectionDenyList keeps all keys and filters denied values.
-	CollectionDenyList CollectionMode = "denyList"
+	CollectionDenyList CollectionMode = iota
 
-	// CollectionAllowList keeps all keys and sends real values only for allowed
-	// keys; all other values are filtered.
-	CollectionAllowList CollectionMode = "allowList"
+	// CollectionOff disables collection of the category entirely.
+	CollectionOff
+
+	// CollectionAllowList keeps all keys and sends real values only for allowed keys.
+	CollectionAllowList
 )
 
 // KeyValueCollectionBehavior configures how key-value data is collected and filtered.
 type KeyValueCollectionBehavior struct {
-	// Mode controls the collection strategy. Default: CollectionDenyList.
+	// Mode controls the collection strategy.
 	Mode CollectionMode
 	// Terms is a list of additional terms used by the active mode.
 	Terms []string
@@ -26,9 +29,9 @@ type KeyValueCollectionBehavior struct {
 // HeaderCollectionConfig configures how HTTP headers are collected for
 // requests and responses independently.
 type HeaderCollectionConfig struct {
-	// Request configures collection of HTTP request headers. Defaults to DenyList.
+	// Request configures collection of HTTP request headers.
 	Request *KeyValueCollectionBehavior
-	// Response configures collection of HTTP response headers. Defaults to DenyList.
+	// Response configures collection of HTTP response headers.
 	Response *KeyValueCollectionBehavior
 }
 
@@ -128,11 +131,6 @@ func cloneDataCollection(dc *DataCollection) *DataCollection {
 	return cloned
 }
 
-// defaultKeyValueBehavior returns the default key-value collection behavior.
-func defaultKeyValueBehavior() *KeyValueCollectionBehavior {
-	return &KeyValueCollectionBehavior{Mode: CollectionDenyList}
-}
-
 // allBodyTypes returns all valid body types.
 func allBodyTypes() []BodyType {
 	return []BodyType{
@@ -143,59 +141,87 @@ func allBodyTypes() []BodyType {
 	}
 }
 
-// newDataCollection builds a fully-populated DataCollection by applying
-// defaults to any nil fields. It also handles backward compatibility with the
-// legacy SendDefaultPII option.
-func newDataCollection(dc *DataCollection, sendDefaultPII bool) DataCollection {
+// snapshotDataCollection builds a fully-populated DataCollection based on given options.
+// It handles any unspecified values by applying the defaults. If the given opts are nil, this
+// provides a best-effort snapshot to align with sendDefaultPII for backwards compatibility.
+func snapshotDataCollection(opts *DataCollection, sendDefaultPII bool) DataCollection {
+	if opts == nil {
+		return legacyDataCollection(sendDefaultPII)
+	}
+	return resolveDataCollection(opts)
+}
+
+func resolveDataCollection(dc *DataCollection) DataCollection {
 	var resolved DataCollection
 	if cloned := cloneDataCollection(dc); cloned != nil {
 		resolved = *cloned
 	}
 
-	isZero := dc == nil || (!resolved.UserInfo.IsSet &&
-		resolved.Cookies == nil &&
-		resolved.HTTPHeaders == nil &&
-		resolved.HTTPBodies == nil &&
-		resolved.QueryParams == nil)
-
-	// TODO: should consider sendDefaultPII on how to apply and use DataCollection for
-	// backward compatibility. Will be used in a next step.
-	_ = isZero && sendDefaultPII
-
 	if !resolved.UserInfo.IsSet {
 		resolved.UserInfo = Set(true)
 	}
 	if resolved.Cookies == nil {
-		resolved.Cookies = defaultKeyValueBehavior()
+		resolved.Cookies = &KeyValueCollectionBehavior{}
 	}
 	if resolved.HTTPHeaders == nil {
 		resolved.HTTPHeaders = &HeaderCollectionConfig{}
 	}
 	if resolved.HTTPHeaders.Request == nil {
-		resolved.HTTPHeaders.Request = defaultKeyValueBehavior()
+		resolved.HTTPHeaders.Request = &KeyValueCollectionBehavior{}
 	}
 	if resolved.HTTPHeaders.Response == nil {
-		resolved.HTTPHeaders.Response = defaultKeyValueBehavior()
+		resolved.HTTPHeaders.Response = &KeyValueCollectionBehavior{}
 	}
 	if resolved.HTTPBodies == nil {
 		resolved.HTTPBodies = allBodyTypes()
 	}
 	if resolved.QueryParams == nil {
-		resolved.QueryParams = defaultKeyValueBehavior()
+		resolved.QueryParams = &KeyValueCollectionBehavior{}
 	}
 	return resolved
 }
 
-// isHTTPBodyCollected reports whether the given body type should be collected
-// according to the DataCollection configuration.
-func (dc *DataCollection) isHTTPBodyCollected(bt BodyType) bool {
-	if dc == nil || dc.HTTPBodies == nil {
-		return true
-	}
-	for _, t := range dc.HTTPBodies {
-		if t == bt {
-			return true
+func legacyDataCollection(sendDefaultPII bool) DataCollection {
+	if sendDefaultPII {
+		return DataCollection{
+			UserInfo:    Set(true),
+			Cookies:     &KeyValueCollectionBehavior{},
+			HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{}, Response: &KeyValueCollectionBehavior{}},
+			HTTPBodies:  allBodyTypes(),
+			QueryParams: &KeyValueCollectionBehavior{},
 		}
 	}
-	return false
+
+	terms := PrivacyDenyTerms()
+	return resolveDataCollection(&DataCollection{
+		UserInfo:   Set(false),
+		HTTPBodies: []BodyType{},
+		Cookies:    &KeyValueCollectionBehavior{Mode: CollectionOff},
+		HTTPHeaders: &HeaderCollectionConfig{
+			Request:  &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: slices.Clone(terms)},
+			Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: slices.Clone(terms)},
+		},
+		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: slices.Clone(terms)},
+	})
+}
+
+// extendedDenyTerms are optional privacy terms documented by the dataCollection
+// spec. They are not part of the built-in sensitive denylist.
+var extendedDenyTerms = []string{
+	"forwarded",
+	"-ip",
+	"remote-",
+	"via",
+	"-user",
+}
+
+// PrivacyDenyTerms returns the optional privacy deny terms documented by the
+// dataCollection spec.
+//
+// These terms cover user-identifying data such as IP forwarding headers and
+// user IDs. They are not part of the built-in sensitive denylist. Pass them as
+// custom denyList terms for cookies, HTTP headers, or query params when you
+// need stricter privacy filtering.
+func PrivacyDenyTerms() []string {
+	return slices.Clone(extendedDenyTerms)
 }

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -13,8 +13,6 @@ func defaultResolvedDataCollection() DataCollection {
 		HTTPHeaders:         &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
 		HTTPBodies:          allBodyTypes(),
 		QueryParams:         &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		StackFrameVariables: Set(true),
-		FrameContextLines:   Set(defaultFrameContextLines),
 	}
 }
 
@@ -243,8 +241,6 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 		got.Cookies.Mode = CollectionOff
 		got.HTTPHeaders.Request.Mode = CollectionAllowList
 		got.QueryParams.Mode = CollectionOff
-		got.StackFrameVariables = Set(false)
-		got.FrameContextLines = Set(0)
 
 		if diff := cmp.Diff(defaultResolvedDataCollection(), client.GetDataCollection()); diff != "" {
 			t.Errorf("returned config mutation should not affect client (-want +got):\n%s", diff)

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -6,143 +6,23 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func defaultResolvedDataCollection() DataCollection {
-	return DataCollection{
+func TestNewClientDataCollection(t *testing.T) {
+	t.Parallel()
+
+	specDefaults := DataCollection{
 		UserInfo:    Set(true),
 		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
 		HTTPBodies:  allBodyTypes(),
 		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 	}
-}
-
-func TestNewDataCollection(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		input          *DataCollection
-		sendDefaultPII bool
-		want           DataCollection
-	}{
-		{
-			name: "defaults",
-			want: defaultResolvedDataCollection(),
-		},
-		{
-			name: "explicit overrides",
-			input: &DataCollection{
-				UserInfo: Set(false),
-				Cookies: &KeyValueCollectionBehavior{
-					Mode:  CollectionAllowList,
-					Terms: []string{"session_id"},
-				},
-				HTTPBodies: []BodyType{BodyIncomingRequest},
-			},
-			want: func() DataCollection {
-				want := defaultResolvedDataCollection()
-				want.UserInfo = Set(false)
-				want.Cookies = &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}}
-				want.HTTPBodies = []BodyType{BodyIncomingRequest}
-				return want
-			}(),
-		},
-		{
-			name: "empty HTTPBodies is explicit off",
-			input: &DataCollection{
-				HTTPBodies: []BodyType{},
-			},
-			want: func() DataCollection {
-				want := defaultResolvedDataCollection()
-				want.HTTPBodies = []BodyType{}
-				return want
-			}(),
-		},
-		{
-			name:           "legacy SendDefaultPII still resolves to defaults",
-			sendDefaultPII: true,
-			want:           defaultResolvedDataCollection(),
-		},
-		{
-			name: "explicit overrides take precedence over SendDefaultPII",
-			input: &DataCollection{
-				UserInfo: Set(false),
-			},
-			sendDefaultPII: true,
-			want: func() DataCollection {
-				want := defaultResolvedDataCollection()
-				want.UserInfo = Set(false)
-				return want
-			}(),
-		},
-		{
-			name: "partial header config defaults missing direction",
-			input: &DataCollection{
-				HTTPHeaders: &HeaderCollectionConfig{
-					Request: &KeyValueCollectionBehavior{
-						Mode:  CollectionAllowList,
-						Terms: []string{"x-request-id"},
-					},
-				},
-			},
-			want: func() DataCollection {
-				want := defaultResolvedDataCollection()
-				want.HTTPHeaders = &HeaderCollectionConfig{
-					Request:  &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}},
-					Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-				}
-				return want
-			}(),
-		},
+	legacyPrivacyDefaults := DataCollection{
+		UserInfo:    Set(false),
+		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionOff},
+		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()}},
+		HTTPBodies:  []BodyType{},
+		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := newDataCollection(tt.input, tt.sendDefaultPII)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("resolved data collection mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestIsHTTPBodyCollected(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		dc   *DataCollection
-		want []BodyType
-	}{
-		{name: "nil DataCollection collects all", dc: nil, want: allBodyTypes()},
-		{name: "nil HTTPBodies collects all", dc: &DataCollection{}, want: allBodyTypes()},
-		{name: "empty HTTPBodies collects none", dc: &DataCollection{HTTPBodies: []BodyType{}}, want: []BodyType{}},
-		{name: "specific types included", dc: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}}, want: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}},
-		{name: "single specific type included", dc: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest}}, want: []BodyType{BodyIncomingRequest}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := make([]BodyType, 0)
-			for _, bt := range allBodyTypes() {
-				if tt.dc.isHTTPBodyCollected(bt) {
-					got = append(got, bt)
-				}
-			}
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("collected body types mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestNewClientDataCollection(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -150,27 +30,59 @@ func TestNewClientDataCollection(t *testing.T) {
 		want    DataCollection
 	}{
 		{
-			name: "defaults applied",
+			name: "empty explicit config applies spec defaults",
+			options: ClientOptions{
+				Dsn:            "https://key@sentry.io/1",
+				DataCollection: &DataCollection{},
+			},
+			want: specDefaults,
+		},
+		{
+			name: "nil config with SendDefaultPII true applies spec defaults",
+			options: ClientOptions{
+				Dsn:            "https://key@sentry.io/1",
+				SendDefaultPII: true,
+			},
+			want: specDefaults,
+		},
+		{
+			name: "nil config with SendDefaultPII false applies legacy privacy compatibility",
 			options: ClientOptions{
 				Dsn: "https://key@sentry.io/1",
 			},
-			want: defaultResolvedDataCollection(),
+			want: legacyPrivacyDefaults,
 		},
 		{
-			name: "explicit config resolved",
+			name: "zero-value key-value behaviors use default deny list",
 			options: ClientOptions{
 				Dsn: "https://key@sentry.io/1",
 				DataCollection: &DataCollection{
-					UserInfo:   Set(false),
-					HTTPBodies: []BodyType{},
+					Cookies:     &KeyValueCollectionBehavior{},
+					HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{}, Response: &KeyValueCollectionBehavior{}},
+					QueryParams: &KeyValueCollectionBehavior{},
 				},
 			},
-			want: func() DataCollection {
-				want := defaultResolvedDataCollection()
-				want.UserInfo = Set(false)
-				want.HTTPBodies = []BodyType{}
-				return want
-			}(),
+			want: specDefaults,
+		},
+		{
+			name: "explicit overrides are preserved and missing fields default",
+			options: ClientOptions{
+				Dsn: "https://key@sentry.io/1",
+				DataCollection: &DataCollection{
+					UserInfo:    Set(false),
+					Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+					HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}}},
+					HTTPBodies:  []BodyType{},
+				},
+				SendDefaultPII: true,
+			},
+			want: DataCollection{
+				UserInfo:    Set(false),
+				Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+				HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+				HTTPBodies:  []BodyType{},
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+			},
 		},
 	}
 
@@ -193,79 +105,60 @@ func TestNewClientDataCollection(t *testing.T) {
 func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 	t.Parallel()
 
-	t.Run("input mutation after NewClient does not affect client", func(t *testing.T) {
-		t.Parallel()
-
-		input := &DataCollection{
-			UserInfo:   Set(false),
-			HTTPBodies: []BodyType{BodyIncomingRequest},
-			Cookies: &KeyValueCollectionBehavior{
-				Mode:  CollectionAllowList,
-				Terms: []string{"session_id"},
-			},
-		}
-		client, err := NewClient(ClientOptions{
-			Dsn:            "https://key@sentry.io/1",
-			DataCollection: input,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		input.UserInfo = Set(true)
-		input.HTTPBodies[0] = BodyOutgoingResponse
-		input.Cookies.Mode = CollectionOff
-		input.Cookies.Terms[0] = "changed"
-
-		want := defaultResolvedDataCollection()
-		want.UserInfo = Set(false)
-		want.Cookies = &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}}
-		want.HTTPBodies = []BodyType{BodyIncomingRequest}
-
-		if diff := cmp.Diff(want, client.GetDataCollection()); diff != "" {
-			t.Errorf("snapshot should not track caller mutations (-want +got):\n%s", diff)
-		}
+	input := &DataCollection{
+		UserInfo:   Set(false),
+		Cookies:    &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+		HTTPBodies: []BodyType{BodyIncomingRequest},
+	}
+	client, err := NewClient(ClientOptions{
+		Dsn:            "https://key@sentry.io/1",
+		DataCollection: input,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	t.Run("returned config mutation does not affect client", func(t *testing.T) {
-		t.Parallel()
+	input.UserInfo = Set(true)
+	input.Cookies.Mode = CollectionOff
+	input.Cookies.Terms[0] = "changed"
+	input.HTTPBodies[0] = BodyOutgoingResponse
 
-		client, err := NewClient(ClientOptions{Dsn: "https://key@sentry.io/1"})
-		if err != nil {
-			t.Fatal(err)
-		}
+	returned := client.GetDataCollection()
+	returned.UserInfo = Set(true)
+	returned.Cookies.Mode = CollectionOff
+	returned.Cookies.Terms[0] = "changed"
+	returned.HTTPHeaders.Request.Mode = CollectionAllowList
+	returned.HTTPBodies[0] = BodyOutgoingResponse
+	returned.QueryParams.Mode = CollectionOff
 
-		got := client.GetDataCollection()
-		got.UserInfo = Set(false)
-		got.HTTPBodies[0] = BodyOutgoingResponse
-		got.Cookies.Mode = CollectionOff
-		got.HTTPHeaders.Request.Mode = CollectionAllowList
-		got.QueryParams.Mode = CollectionOff
+	want := DataCollection{
+		UserInfo:    Set(false),
+		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:  []BodyType{BodyIncomingRequest},
+		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+	}
 
-		if diff := cmp.Diff(defaultResolvedDataCollection(), client.GetDataCollection()); diff != "" {
-			t.Errorf("returned config mutation should not affect client (-want +got):\n%s", diff)
-		}
-	})
-}
-
-func TestCollectionModeConstants(t *testing.T) {
-	t.Parallel()
-
-	got := []CollectionMode{CollectionOff, CollectionDenyList, CollectionAllowList}
-	want := []CollectionMode{"off", "denyList", "allowList"}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("collection mode constants mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(want, client.GetDataCollection()); diff != "" {
+		t.Errorf("client data collection should be snapshotted (-want +got):\n%s", diff)
 	}
 }
 
-func TestBodyTypeConstants(t *testing.T) {
+func TestNewClientLegacyDataCollectionPrivacyTermsAreNotShared(t *testing.T) {
 	t.Parallel()
 
-	got := []BodyType{BodyIncomingRequest, BodyOutgoingRequest, BodyIncomingResponse, BodyOutgoingResponse}
-	want := []BodyType{"incomingRequest", "outgoingRequest", "incomingResponse", "outgoingResponse"}
+	client, err := NewClient(ClientOptions{Dsn: "https://key@sentry.io/1"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("body type constants mismatch (-want +got):\n%s", diff)
+	got := client.GetDataCollection()
+	got.HTTPHeaders.Request.Terms[0] = "changed"
+
+	if diff := cmp.Diff(PrivacyDenyTerms(), got.HTTPHeaders.Response.Terms); diff != "" {
+		t.Errorf("response header terms should not share request header terms (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(PrivacyDenyTerms(), got.QueryParams.Terms); diff != "" {
+		t.Errorf("query param terms should not share request header terms (-want +got):\n%s", diff)
 	}
 }

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -8,13 +8,13 @@ import (
 
 func defaultResolvedDataCollection() DataCollection {
 	return DataCollection{
-		UserInfo:            Pointer(true),
+		UserInfo:            Set(true),
 		Cookies:             &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 		HTTPHeaders:         &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
 		HTTPBodies:          allBodyTypes(),
 		QueryParams:         &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		StackFrameVariables: Pointer(true),
-		FrameContextLines:   Pointer(defaultFrameContextLines),
+		StackFrameVariables: Set(true),
+		FrameContextLines:   Set(defaultFrameContextLines),
 	}
 }
 
@@ -34,7 +34,7 @@ func TestNewDataCollection(t *testing.T) {
 		{
 			name: "explicit overrides",
 			input: &DataCollection{
-				UserInfo: Pointer(false),
+				UserInfo: Set(false),
 				Cookies: &KeyValueCollectionBehavior{
 					Mode:  CollectionAllowList,
 					Terms: []string{"session_id"},
@@ -43,7 +43,7 @@ func TestNewDataCollection(t *testing.T) {
 			},
 			want: func() DataCollection {
 				want := defaultResolvedDataCollection()
-				want.UserInfo = Pointer(false)
+				want.UserInfo = Set(false)
 				want.Cookies = &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}}
 				want.HTTPBodies = []BodyType{BodyIncomingRequest}
 				return want
@@ -68,12 +68,12 @@ func TestNewDataCollection(t *testing.T) {
 		{
 			name: "explicit overrides take precedence over SendDefaultPII",
 			input: &DataCollection{
-				UserInfo: Pointer(false),
+				UserInfo: Set(false),
 			},
 			sendDefaultPII: true,
 			want: func() DataCollection {
 				want := defaultResolvedDataCollection()
-				want.UserInfo = Pointer(false)
+				want.UserInfo = Set(false)
 				return want
 			}(),
 		},
@@ -163,13 +163,13 @@ func TestNewClientDataCollection(t *testing.T) {
 			options: ClientOptions{
 				Dsn: "https://key@sentry.io/1",
 				DataCollection: &DataCollection{
-					UserInfo:   Pointer(false),
+					UserInfo:   Set(false),
 					HTTPBodies: []BodyType{},
 				},
 			},
 			want: func() DataCollection {
 				want := defaultResolvedDataCollection()
-				want.UserInfo = Pointer(false)
+				want.UserInfo = Set(false)
 				want.HTTPBodies = []BodyType{}
 				return want
 			}(),
@@ -199,7 +199,7 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 		t.Parallel()
 
 		input := &DataCollection{
-			UserInfo:   Pointer(false),
+			UserInfo:   Set(false),
 			HTTPBodies: []BodyType{BodyIncomingRequest},
 			Cookies: &KeyValueCollectionBehavior{
 				Mode:  CollectionAllowList,
@@ -214,13 +214,13 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		*input.UserInfo = true
+		input.UserInfo = Set(true)
 		input.HTTPBodies[0] = BodyOutgoingResponse
 		input.Cookies.Mode = CollectionOff
 		input.Cookies.Terms[0] = "changed"
 
 		want := defaultResolvedDataCollection()
-		want.UserInfo = Pointer(false)
+		want.UserInfo = Set(false)
 		want.Cookies = &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}}
 		want.HTTPBodies = []BodyType{BodyIncomingRequest}
 
@@ -238,13 +238,13 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 		}
 
 		got := client.GetDataCollection()
-		*got.UserInfo = false
+		got.UserInfo = Set(false)
 		got.HTTPBodies[0] = BodyOutgoingResponse
 		got.Cookies.Mode = CollectionOff
 		got.HTTPHeaders.Request.Mode = CollectionAllowList
 		got.QueryParams.Mode = CollectionOff
-		*got.StackFrameVariables = false
-		*got.FrameContextLines = 0
+		got.StackFrameVariables = Set(false)
+		got.FrameContextLines = Set(0)
 
 		if diff := cmp.Diff(defaultResolvedDataCollection(), client.GetDataCollection()); diff != "" {
 			t.Errorf("returned config mutation should not affect client (-want +got):\n%s", diff)

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -8,11 +8,11 @@ import (
 
 func defaultResolvedDataCollection() DataCollection {
 	return DataCollection{
-		UserInfo:            Set(true),
-		Cookies:             &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		HTTPHeaders:         &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-		HTTPBodies:          allBodyTypes(),
-		QueryParams:         &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		UserInfo:    Set(true),
+		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:  allBodyTypes(),
+		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 	}
 }
 

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -1,0 +1,275 @@
+package sentry
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func defaultResolvedDataCollection() DataCollection {
+	return DataCollection{
+		UserInfo:            Pointer(true),
+		Cookies:             &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		HTTPHeaders:         &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:          allBodyTypes(),
+		QueryParams:         &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		StackFrameVariables: Pointer(true),
+		FrameContextLines:   Pointer(defaultFrameContextLines),
+	}
+}
+
+func TestNewDataCollection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		input          *DataCollection
+		sendDefaultPII bool
+		want           DataCollection
+	}{
+		{
+			name: "defaults",
+			want: defaultResolvedDataCollection(),
+		},
+		{
+			name: "explicit overrides",
+			input: &DataCollection{
+				UserInfo: Pointer(false),
+				Cookies: &KeyValueCollectionBehavior{
+					Mode:  CollectionAllowList,
+					Terms: []string{"session_id"},
+				},
+				HTTPBodies: []BodyType{BodyIncomingRequest},
+			},
+			want: func() DataCollection {
+				want := defaultResolvedDataCollection()
+				want.UserInfo = Pointer(false)
+				want.Cookies = &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}}
+				want.HTTPBodies = []BodyType{BodyIncomingRequest}
+				return want
+			}(),
+		},
+		{
+			name: "empty HTTPBodies is explicit off",
+			input: &DataCollection{
+				HTTPBodies: []BodyType{},
+			},
+			want: func() DataCollection {
+				want := defaultResolvedDataCollection()
+				want.HTTPBodies = []BodyType{}
+				return want
+			}(),
+		},
+		{
+			name:           "legacy SendDefaultPII still resolves to defaults",
+			sendDefaultPII: true,
+			want:           defaultResolvedDataCollection(),
+		},
+		{
+			name: "explicit overrides take precedence over SendDefaultPII",
+			input: &DataCollection{
+				UserInfo: Pointer(false),
+			},
+			sendDefaultPII: true,
+			want: func() DataCollection {
+				want := defaultResolvedDataCollection()
+				want.UserInfo = Pointer(false)
+				return want
+			}(),
+		},
+		{
+			name: "partial header config defaults missing direction",
+			input: &DataCollection{
+				HTTPHeaders: &HeaderCollectionConfig{
+					Request: &KeyValueCollectionBehavior{
+						Mode:  CollectionAllowList,
+						Terms: []string{"x-request-id"},
+					},
+				},
+			},
+			want: func() DataCollection {
+				want := defaultResolvedDataCollection()
+				want.HTTPHeaders = &HeaderCollectionConfig{
+					Request:  &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}},
+					Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+				}
+				return want
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := newDataCollection(tt.input, tt.sendDefaultPII)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("resolved data collection mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsHTTPBodyCollected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dc   *DataCollection
+		want []BodyType
+	}{
+		{name: "nil DataCollection collects all", dc: nil, want: allBodyTypes()},
+		{name: "nil HTTPBodies collects all", dc: &DataCollection{}, want: allBodyTypes()},
+		{name: "empty HTTPBodies collects none", dc: &DataCollection{HTTPBodies: []BodyType{}}, want: []BodyType{}},
+		{name: "specific types included", dc: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}}, want: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}},
+		{name: "single specific type included", dc: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest}}, want: []BodyType{BodyIncomingRequest}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make([]BodyType, 0)
+			for _, bt := range allBodyTypes() {
+				if tt.dc.isHTTPBodyCollected(bt) {
+					got = append(got, bt)
+				}
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("collected body types mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewClientDataCollection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options ClientOptions
+		want    DataCollection
+	}{
+		{
+			name: "defaults applied",
+			options: ClientOptions{
+				Dsn: "https://key@sentry.io/1",
+			},
+			want: defaultResolvedDataCollection(),
+		},
+		{
+			name: "explicit config resolved",
+			options: ClientOptions{
+				Dsn: "https://key@sentry.io/1",
+				DataCollection: &DataCollection{
+					UserInfo:   Pointer(false),
+					HTTPBodies: []BodyType{},
+				},
+			},
+			want: func() DataCollection {
+				want := defaultResolvedDataCollection()
+				want.UserInfo = Pointer(false)
+				want.HTTPBodies = []BodyType{}
+				return want
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := NewClient(tt.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tt.want, client.GetDataCollection()); diff != "" {
+				t.Errorf("client data collection mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewClientDataCollectionSnapshotting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("input mutation after NewClient does not affect client", func(t *testing.T) {
+		t.Parallel()
+
+		input := &DataCollection{
+			UserInfo:   Pointer(false),
+			HTTPBodies: []BodyType{BodyIncomingRequest},
+			Cookies: &KeyValueCollectionBehavior{
+				Mode:  CollectionAllowList,
+				Terms: []string{"session_id"},
+			},
+		}
+		client, err := NewClient(ClientOptions{
+			Dsn:            "https://key@sentry.io/1",
+			DataCollection: input,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		*input.UserInfo = true
+		input.HTTPBodies[0] = BodyOutgoingResponse
+		input.Cookies.Mode = CollectionOff
+		input.Cookies.Terms[0] = "changed"
+
+		want := defaultResolvedDataCollection()
+		want.UserInfo = Pointer(false)
+		want.Cookies = &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}}
+		want.HTTPBodies = []BodyType{BodyIncomingRequest}
+
+		if diff := cmp.Diff(want, client.GetDataCollection()); diff != "" {
+			t.Errorf("snapshot should not track caller mutations (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("returned config mutation does not affect client", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := NewClient(ClientOptions{Dsn: "https://key@sentry.io/1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := client.GetDataCollection()
+		*got.UserInfo = false
+		got.HTTPBodies[0] = BodyOutgoingResponse
+		got.Cookies.Mode = CollectionOff
+		got.HTTPHeaders.Request.Mode = CollectionAllowList
+		got.QueryParams.Mode = CollectionOff
+		*got.StackFrameVariables = false
+		*got.FrameContextLines = 0
+
+		if diff := cmp.Diff(defaultResolvedDataCollection(), client.GetDataCollection()); diff != "" {
+			t.Errorf("returned config mutation should not affect client (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestCollectionModeConstants(t *testing.T) {
+	t.Parallel()
+
+	got := []CollectionMode{CollectionOff, CollectionDenyList, CollectionAllowList}
+	want := []CollectionMode{"off", "denyList", "allowList"}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("collection mode constants mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBodyTypeConstants(t *testing.T) {
+	t.Parallel()
+
+	got := []BodyType{BodyIncomingRequest, BodyOutgoingRequest, BodyIncomingResponse, BodyOutgoingResponse}
+	want := []BodyType{"incomingRequest", "outgoingRequest", "incomingResponse", "outgoingResponse"}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("body type constants mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -182,7 +182,7 @@ func metadataToContext(md metadata.MD) map[string]any {
 
 	ctx := make(map[string]any, len(md))
 	for key, values := range md {
-		if sentry.IsSensitiveHeader(key) {
+		if sentry.IsSensitiveHeader(key) { // nolint: staticcheck // TODO: remove this later.
 			continue
 		}
 

--- a/option.go
+++ b/option.go
@@ -1,0 +1,23 @@
+package sentry
+
+// Option represents an optional configuration value.
+//
+// The zero value is unset. Use Set to distinguish an explicitly configured
+// zero value, such as false, 0, or "", from an unset option.
+type Option[T any] struct {
+	Value T
+	IsSet bool
+}
+
+// Set returns an Option containing v.
+func Set[T any](v T) Option[T] {
+	return Option[T]{Value: v, IsSet: true}
+}
+
+// Or returns the option value when set, or defaultValue otherwise.
+func (o Option[T]) Or(defaultValue T) T {
+	if o.IsSet {
+		return o.Value
+	}
+	return defaultValue
+}

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,30 @@
+package sentry
+
+import "testing"
+
+func TestOptionZeroValueIsUnset(t *testing.T) {
+	t.Parallel()
+
+	var option Option[bool]
+	if option.IsSet {
+		t.Fatal("zero-value option should be unset")
+	}
+	if got := option.Or(true); got != true {
+		t.Errorf("unset option should return default, got %v", got)
+	}
+}
+
+func TestSetReturnsSetOption(t *testing.T) {
+	t.Parallel()
+
+	option := Set(false)
+	if !option.IsSet {
+		t.Fatal("Set should mark option as set")
+	}
+	if option.Value {
+		t.Fatal("Set should preserve explicitly configured false")
+	}
+	if got := option.Or(true); got != false {
+		t.Errorf("set option should return explicit value, got %v", got)
+	}
+}

--- a/sql/span.go
+++ b/sql/span.go
@@ -102,7 +102,7 @@ func sendDefaultPII(ctx context.Context) bool {
 	if client == nil {
 		return false
 	}
-	return client.Options().SendDefaultPII
+	return client.Options().SendDefaultPII // nolint: staticcheck // TODO: remove this later in favor of DataCollection
 }
 
 func finishSpan(span *sentry.Span, err error) {


### PR DESCRIPTION
### Description
This adds the initial datastructures and logic for implementing the https://develop.sentry.dev/sdk/foundations/client/data-collection/#overview spec.

#skip-changelog

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
