### PR TITLE
feat: add sensitive data filtering methods

### DIFF
--- a/data_collection.go
+++ b/data_collection.go
@@ -89,6 +89,10 @@ type DataCollection struct {
 	//
 	// Defaults to using the built-in DenyList.
 	QueryParams *KeyValueCollectionBehavior
+
+	// sensitiveTerms is the deny-list used for built-in sensitive-key
+	// scrubbing.
+	sensitiveTerms []string
 }
 
 // cloneKeyValueCollectionBehavior returns a deep copy of b.
@@ -120,10 +124,11 @@ func cloneDataCollection(dc *DataCollection) *DataCollection {
 		return nil
 	}
 	cloned := &DataCollection{
-		UserInfo:    dc.UserInfo,
-		Cookies:     cloneKeyValueCollectionBehavior(dc.Cookies),
-		HTTPHeaders: cloneHeaderCollectionConfig(dc.HTTPHeaders),
-		QueryParams: cloneKeyValueCollectionBehavior(dc.QueryParams),
+		UserInfo:       dc.UserInfo,
+		Cookies:        cloneKeyValueCollectionBehavior(dc.Cookies),
+		HTTPHeaders:    cloneHeaderCollectionConfig(dc.HTTPHeaders),
+		QueryParams:    cloneKeyValueCollectionBehavior(dc.QueryParams),
+		sensitiveTerms: dc.sensitiveTerms,
 	}
 	if dc.HTTPBodies != nil {
 		cloned.HTTPBodies = slices.Clone(dc.HTTPBodies)
@@ -178,50 +183,68 @@ func resolveDataCollection(dc *DataCollection) DataCollection {
 	if resolved.QueryParams == nil {
 		resolved.QueryParams = &KeyValueCollectionBehavior{}
 	}
+	if resolved.sensitiveTerms == nil {
+		resolved.sensitiveTerms = defaultSensitiveTerms
+	}
 	return resolved
 }
 
 func legacyDataCollection(sendDefaultPII bool) DataCollection {
 	if sendDefaultPII {
-		return DataCollection{
+		return resolveDataCollection(&DataCollection{
 			UserInfo:    Set(true),
 			Cookies:     &KeyValueCollectionBehavior{},
 			HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{}, Response: &KeyValueCollectionBehavior{}},
 			HTTPBodies:  allBodyTypes(),
 			QueryParams: &KeyValueCollectionBehavior{},
-		}
+		})
 	}
 
-	terms := PrivacyDenyTerms()
 	return resolveDataCollection(&DataCollection{
 		UserInfo:   Set(false),
 		HTTPBodies: []BodyType{},
 		Cookies:    &KeyValueCollectionBehavior{Mode: CollectionOff},
 		HTTPHeaders: &HeaderCollectionConfig{
-			Request:  &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: slices.Clone(terms)},
-			Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: slices.Clone(terms)},
+			Request:  &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+			Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 		},
-		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: slices.Clone(terms)},
+		QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		sensitiveTerms: extendedSensitiveTerms,
 	})
 }
 
-// extendedDenyTerms are optional privacy terms documented by the dataCollection
-// spec. They are not part of the built-in sensitive denylist.
-var extendedDenyTerms = []string{
+// defaultSensitiveTerms is the canonical list of case-insensitive,
+// partial-match terms used for scrubbing.
+//
+// See https://develop.sentry.dev/sdk/foundations/client/data-collection/#sensitive-denylist
+var defaultSensitiveTerms = []string{
+	"auth",
+	"bearer",
+	"credentials",
+	"csrf",
+	"identity",
+	"jwt",
+	"key",
+	"passwd",
+	"password",
+	"pwd",
+	"saml",
+	"secret",
+	"session",
+	"sid",
+	"sso",
+	"token",
+	"xsrf",
+}
+
+// extendedSensitiveTerms is defaultSensitiveTerms plus additional privacy
+// terms that cover user-identifying data such as IP forwarding headers and
+// user IDs. Used for backwards compatibility with SendDefaultPII=false.
+var extendedSensitiveTerms = append(
+	slices.Clone(defaultSensitiveTerms),
 	"forwarded",
 	"-ip",
 	"remote-",
 	"via",
 	"-user",
-}
-
-// PrivacyDenyTerms returns the optional privacy deny terms documented by the
-// dataCollection spec.
-//
-// These terms cover user-identifying data such as IP forwarding headers and
-// user IDs. They are not part of the built-in sensitive denylist. Pass them as
-// custom denyList terms for cookies, HTTP headers, or query params when you
-// need stricter privacy filtering.
-func PrivacyDenyTerms() []string {
-	return slices.Clone(extendedDenyTerms)
-}
+)

--- a/data_collection.go
+++ b/data_collection.go
@@ -183,9 +183,6 @@ func resolveDataCollection(dc *DataCollection) DataCollection {
 	if resolved.QueryParams == nil {
 		resolved.QueryParams = &KeyValueCollectionBehavior{}
 	}
-	if resolved.sensitiveTerms == nil {
-		resolved.sensitiveTerms = defaultSensitiveTerms
-	}
 	return resolved
 }
 
@@ -213,38 +210,13 @@ func legacyDataCollection(sendDefaultPII bool) DataCollection {
 	})
 }
 
-// defaultSensitiveTerms is the canonical list of case-insensitive,
-// partial-match terms used for scrubbing.
-//
-// See https://develop.sentry.dev/sdk/foundations/client/data-collection/#sensitive-denylist
-var defaultSensitiveTerms = []string{
-	"auth",
-	"bearer",
-	"credentials",
-	"csrf",
-	"identity",
-	"jwt",
-	"key",
-	"passwd",
-	"password",
-	"pwd",
-	"saml",
-	"secret",
-	"session",
-	"sid",
-	"sso",
-	"token",
-	"xsrf",
-}
-
-// extendedSensitiveTerms is defaultSensitiveTerms plus additional privacy
-// terms that cover user-identifying data such as IP forwarding headers and
-// user IDs. Used for backwards compatibility with SendDefaultPII=false.
-var extendedSensitiveTerms = append(
-	slices.Clone(defaultSensitiveTerms),
+// extendedSensitiveTerms are additional privacy terms that cover
+// user-identifying data such as IP forwarding headers and user IDs. Used for
+// backwards compatibility with SendDefaultPII=false.
+var extendedSensitiveTerms = []string{
 	"forwarded",
 	"-ip",
 	"remote-",
 	"via",
 	"-user",
-)
+}

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -6,29 +6,6 @@ import (
 	"strings"
 )
 
-// sensitiveDenyList is the canonical list of case-insensitive, partial-match terms used for scrubbing.
-//
-// See https://develop.sentry.dev/sdk/foundations/client/data-collection/#sensitive-denylist
-var sensitiveDenyList = []string{
-	"auth",
-	"bearer",
-	"credentials",
-	"csrf",
-	"identity",
-	"jwt",
-	"key",
-	"passwd",
-	"password",
-	"pwd",
-	"saml",
-	"secret",
-	"session",
-	"sid",
-	"sso",
-	"token",
-	"xsrf",
-}
-
 // filteredValue is the replacement for sensitive values.
 const filteredValue = "[Filtered]"
 
@@ -36,37 +13,22 @@ const filteredValue = "[Filtered]"
 // pairs. Keys are always preserved and values are replaced with "[Filtered]".
 //
 // Returns nil when the mode is CollectionOff.
-func filterKeyValues(data map[string]string, behavior *KeyValueCollectionBehavior) map[string]string {
+func (dc DataCollection) filterKeyValues(data map[string]string, behavior *KeyValueCollectionBehavior) map[string]string {
 	if behavior == nil {
 		behavior = &KeyValueCollectionBehavior{}
 	}
-
-	switch behavior.Mode {
-	case CollectionOff:
+	if behavior.Mode == CollectionOff {
 		return nil
-
-	case CollectionAllowList:
-		result := make(map[string]string, len(data))
-		for k, v := range data {
-			if isSensitiveAllowList(k, behavior.Terms) {
-				result[k] = filteredValue
-			} else {
-				result[k] = v
-			}
-		}
-		return result
-
-	default: // CollectionDenyList (also handles zero value)
-		result := make(map[string]string, len(data))
-		for k, v := range data {
-			if isSensitiveDenyList(k, behavior.Terms) {
-				result[k] = filteredValue
-			} else {
-				result[k] = v
-			}
-		}
-		return result
 	}
+	result := make(map[string]string, len(data))
+	for k, v := range data {
+		if dc.shouldFilterKey(k, behavior) {
+			result[k] = filteredValue
+		} else {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 // FilterRequestHeaders applies the configured request-header collection behavior.
@@ -75,7 +37,7 @@ func (dc DataCollection) FilterRequestHeaders(headers map[string]string) map[str
 	if dc.HTTPHeaders != nil {
 		behavior = dc.HTTPHeaders.Request
 	}
-	return filterKeyValues(headers, behavior)
+	return dc.filterKeyValues(headers, behavior)
 }
 
 // FilterResponseHeaders applies the configured response-header collection behavior.
@@ -84,7 +46,7 @@ func (dc DataCollection) FilterResponseHeaders(headers map[string]string) map[st
 	if dc.HTTPHeaders != nil {
 		behavior = dc.HTTPHeaders.Response
 	}
-	return filterKeyValues(headers, behavior)
+	return dc.filterKeyValues(headers, behavior)
 }
 
 // CollectHTTPBody reports whether the given body type should be collected.
@@ -114,7 +76,7 @@ func (dc DataCollection) FilterQueryString(rawQuery string) string {
 	if err != nil {
 		return filteredValue
 	}
-	filtered := filterKeyValues(parsed, dc.QueryParams)
+	filtered := dc.filterKeyValues(parsed, dc.QueryParams)
 	if filtered == nil {
 		return ""
 	}
@@ -130,7 +92,7 @@ func (dc DataCollection) FilterCookies(rawCookies string) string {
 	if parsed == nil {
 		return filteredValue
 	}
-	filtered := filterKeyValues(parsed, dc.Cookies)
+	filtered := dc.filterKeyValues(parsed, dc.Cookies)
 	if filtered == nil {
 		return ""
 	}
@@ -147,10 +109,7 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 	if strings.Contains(strings.ToLower(contentType), "application/json") || looksLikeJSON(body) {
 		var value any
 		if err := json.Unmarshal(body, &value); err == nil {
-			filteredValue := filterJSONValue(value, dc.QueryParams)
-			if filteredValue == nil {
-				return ""
-			}
+			filteredValue := dc.filterJSONValue(value, nil)
 			filtered, err := json.Marshal(filteredValue)
 			if err == nil {
 				return string(filtered)
@@ -160,10 +119,7 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 
 	if strings.Contains(strings.ToLower(contentType), "application/x-www-form-urlencoded") {
 		if values, err := url.ParseQuery(string(body)); err == nil {
-			filtered := filterKeyValues(flattenValues(values), dc.QueryParams)
-			if filtered == nil {
-				return ""
-			}
+			filtered := dc.filterKeyValues(flattenValues(values), nil)
 			return joinKeyValuePairs(filtered, "&", "=")
 		}
 	}
@@ -176,7 +132,7 @@ func looksLikeJSON(body []byte) bool {
 	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
 }
 
-func filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
+func (dc DataCollection) filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
 	if behavior != nil && behavior.Mode == CollectionOff {
 		return nil
 	}
@@ -185,17 +141,17 @@ func filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
 	case map[string]any:
 		filtered := make(map[string]any, len(value))
 		for key, child := range value {
-			if shouldFilterKey(key, behavior) {
+			if dc.shouldFilterKey(key, behavior) {
 				filtered[key] = filteredValue
 			} else {
-				filtered[key] = filterJSONValue(child, behavior)
+				filtered[key] = dc.filterJSONValue(child, behavior)
 			}
 		}
 		return filtered
 	case []any:
 		filtered := make([]any, len(value))
 		for i, child := range value {
-			filtered[i] = filterJSONValue(child, behavior)
+			filtered[i] = dc.filterJSONValue(child, behavior)
 		}
 		return filtered
 	default:
@@ -203,7 +159,10 @@ func filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
 	}
 }
 
-func shouldFilterKey(key string, behavior *KeyValueCollectionBehavior) bool {
+// shouldFilterKey reports whether a key's value should be redacted under the
+// given behavior. It combines the built-in sensitive terms with the behavior's
+// user-provided terms.
+func (dc DataCollection) shouldFilterKey(key string, behavior *KeyValueCollectionBehavior) bool {
 	if behavior == nil {
 		behavior = &KeyValueCollectionBehavior{}
 	}
@@ -212,9 +171,9 @@ func shouldFilterKey(key string, behavior *KeyValueCollectionBehavior) bool {
 	case CollectionOff:
 		return true
 	case CollectionAllowList:
-		return isSensitiveAllowList(key, behavior.Terms)
+		return matchesDenyTerms(key, dc.sensitiveTerms) || !matchesDenyTerms(key, behavior.Terms)
 	default:
-		return isSensitiveDenyList(key, behavior.Terms)
+		return matchesDenyTerms(key, dc.sensitiveTerms) || matchesDenyTerms(key, behavior.Terms)
 	}
 }
 
@@ -228,24 +187,6 @@ func matchesDenyTerms(key string, terms []string) bool {
 		}
 	}
 	return false
-}
-
-// isSensitiveAllowList reports whether key's value must be redacted under
-// allow-list collection.
-//
-// The built-in sensitive denylist always wins, even if the user allow-lists a
-// matching term.
-func isSensitiveAllowList(key string, terms []string) bool {
-	return matchesDenyTerms(key, sensitiveDenyList) || !matchesDenyTerms(key, terms)
-}
-
-// isSensitiveDenyList reports whether key's value should be filtered when
-// deny-list collection is active.
-//
-// A key is filtered if it matches either the built-in sensitive denylist or any
-// user-provided deny-list term.
-func isSensitiveDenyList(key string, terms []string) bool {
-	return matchesDenyTerms(key, sensitiveDenyList) || matchesDenyTerms(key, terms)
 }
 
 func parseQueryString(s string) (map[string]string, error) {

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -32,11 +32,6 @@ var sensitiveDenyList = []string{
 // filteredValue is the replacement for sensitive values.
 const filteredValue = "[Filtered]"
 
-// isSensitiveKey reports whether a key name matches the built-in sensitive denylist.
-func isSensitiveKey(key string) bool {
-	return matchesDenyTerms(key, sensitiveDenyList)
-}
-
 // filterKeyValues applies a KeyValueCollectionBehavior to a map of key-value
 // pairs. Keys are always preserved and values are replaced with "[Filtered]".
 //
@@ -53,7 +48,7 @@ func filterKeyValues(data map[string]string, behavior *KeyValueCollectionBehavio
 	case CollectionAllowList:
 		result := make(map[string]string, len(data))
 		for k, v := range data {
-			if isSensitiveKey(k) || !matchesDenyTerms(k, behavior.Terms) {
+			if isSensitiveAllowList(k, behavior.Terms) {
 				result[k] = filteredValue
 			} else {
 				result[k] = v
@@ -64,7 +59,7 @@ func filterKeyValues(data map[string]string, behavior *KeyValueCollectionBehavio
 	default: // CollectionDenyList (also handles zero value)
 		result := make(map[string]string, len(data))
 		for k, v := range data {
-			if isSensitiveKey(k) || matchesDenyTerms(k, behavior.Terms) {
+			if isSensitiveDenyList(k, behavior.Terms) {
 				result[k] = filteredValue
 			} else {
 				result[k] = v
@@ -217,9 +212,9 @@ func shouldFilterKey(key string, behavior *KeyValueCollectionBehavior) bool {
 	case CollectionOff:
 		return true
 	case CollectionAllowList:
-		return isSensitiveKey(key) || !matchesDenyTerms(key, behavior.Terms)
+		return isSensitiveAllowList(key, behavior.Terms)
 	default:
-		return isSensitiveKey(key) || matchesDenyTerms(key, behavior.Terms)
+		return isSensitiveDenyList(key, behavior.Terms)
 	}
 }
 
@@ -233,6 +228,24 @@ func matchesDenyTerms(key string, terms []string) bool {
 		}
 	}
 	return false
+}
+
+// isSensitiveAllowList reports whether key's value must be redacted under
+// allow-list collection.
+//
+// The built-in sensitive denylist always wins, even if the user allow-lists a
+// matching term.
+func isSensitiveAllowList(key string, terms []string) bool {
+	return matchesDenyTerms(key, sensitiveDenyList) || !matchesDenyTerms(key, terms)
+}
+
+// isSensitiveDenyList reports whether key's value should be filtered when
+// deny-list collection is active.
+//
+// A key is filtered if it matches either the built-in sensitive denylist or any
+// user-provided deny-list term.
+func isSensitiveDenyList(key string, terms []string) bool {
+	return matchesDenyTerms(key, sensitiveDenyList) || matchesDenyTerms(key, terms)
 }
 
 func parseQueryString(s string) (map[string]string, error) {

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -72,15 +72,11 @@ func (dc DataCollection) FilterQueryString(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
 	}
-	parsed, err := parseQueryString(rawQuery)
+	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
 		return filteredValue
 	}
-	filtered := dc.filterKeyValues(parsed, dc.QueryParams)
-	if filtered == nil {
-		return ""
-	}
-	return joinKeyValuePairs(filtered, "&", "=")
+	return dc.filterURLValues(values, dc.QueryParams)
 }
 
 // FilterCookies applies the configured cookie collection behavior.
@@ -93,10 +89,15 @@ func (dc DataCollection) FilterCookies(rawCookies string) string {
 		return filteredValue
 	}
 	filtered := dc.filterKeyValues(parsed, dc.Cookies)
-	if filtered == nil {
+	if filtered == nil || len(filtered) == 0 {
 		return ""
 	}
-	return joinKeyValuePairs(filtered, "; ", "=")
+
+	parts := make([]string, 0, len(filtered))
+	for key, value := range filtered {
+		parts = append(parts, key+"="+value)
+	}
+	return strings.Join(parts, "; ")
 }
 
 // FilterHTTPBody applies sensitive-key filtering to parseable HTTP body data.
@@ -109,8 +110,8 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 	if strings.Contains(strings.ToLower(contentType), "application/json") || looksLikeJSON(body) {
 		var value any
 		if err := json.Unmarshal(body, &value); err == nil {
-			filteredValue := dc.filterJSONValue(value, nil)
-			filtered, err := json.Marshal(filteredValue)
+			filteredJSON := dc.filterJSONValue(value, nil)
+			filtered, err := json.Marshal(filteredJSON)
 			if err == nil {
 				return string(filtered)
 			}
@@ -119,8 +120,7 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 
 	if strings.Contains(strings.ToLower(contentType), "application/x-www-form-urlencoded") {
 		if values, err := url.ParseQuery(string(body)); err == nil {
-			filtered := dc.filterKeyValues(flattenValues(values), nil)
-			return joinKeyValuePairs(filtered, "&", "=")
+			return dc.filterURLValues(values, nil)
 		}
 	}
 
@@ -130,6 +130,21 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 func looksLikeJSON(body []byte) bool {
 	trimmed := strings.TrimSpace(string(body))
 	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
+}
+
+func (dc DataCollection) filterURLValues(values url.Values, behavior *KeyValueCollectionBehavior) string {
+	if behavior == nil {
+		behavior = &KeyValueCollectionBehavior{}
+	}
+	if behavior.Mode == CollectionOff {
+		return ""
+	}
+	for key := range values {
+		if dc.shouldFilterKey(key, behavior) {
+			values.Set(key, filteredValue)
+		}
+	}
+	return values.Encode()
 }
 
 func (dc DataCollection) filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
@@ -189,16 +204,8 @@ func matchesDenyTerms(key string, terms []string) bool {
 	return false
 }
 
-func parseQueryString(s string) (map[string]string, error) {
-	values, err := url.ParseQuery(s)
-	if err != nil {
-		return nil, err
-	}
-	return flattenValues(values), nil
-}
-
-// parseKeyValueString splits a string like "a=1&b=2" or "a=1; b=2" into a
-// map. Parts without '=' are treated as keys with empty values.
+// parseKeyValueString splits a string like "a=1; b=2" into a map.
+// Malformed parts without '=' and parts with empty keys are skipped.
 func parseKeyValueString(s string, separator rune) map[string]string {
 	result := make(map[string]string)
 	for _, part := range strings.Split(s, string(separator)) {
@@ -207,30 +214,10 @@ func parseKeyValueString(s string, separator rune) map[string]string {
 			continue
 		}
 		key, value, ok := strings.Cut(part, "=")
-		if !ok {
-			key = part
+		if !ok || strings.TrimSpace(key) == "" {
+			continue
 		}
 		result[key] = value
 	}
 	return result
-}
-
-func flattenValues(values url.Values) map[string]string {
-	result := make(map[string]string, len(values))
-	for key, value := range values {
-		result[key] = strings.Join(value, ",")
-	}
-	return result
-}
-
-// joinKeyValuePairs reassembles a map into a string.
-func joinKeyValuePairs(values map[string]string, separator, assignment string) string {
-	if len(values) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, len(values))
-	for k, v := range values {
-		parts = append(parts, k+assignment+v)
-	}
-	return strings.Join(parts, separator)
 }

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -89,7 +89,7 @@ func (dc DataCollection) FilterCookies(rawCookies string) string {
 		return filteredValue
 	}
 	filtered := dc.filterKeyValues(parsed, dc.Cookies)
-	if filtered == nil || len(filtered) == 0 {
+	if len(filtered) == 0 {
 		return ""
 	}
 

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -1,0 +1,243 @@
+package sentry
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// sensitiveDenyList is the canonical list of case-insensitive, partial-match terms used for scrubbing.
+//
+// See https://develop.sentry.dev/sdk/foundations/client/data-collection/#sensitive-denylist
+var sensitiveDenyList = []string{
+	"auth",
+	"bearer",
+	"credentials",
+	"csrf",
+	"identity",
+	"jwt",
+	"key",
+	"passwd",
+	"password",
+	"pwd",
+	"saml",
+	"secret",
+	"session",
+	"sid",
+	"sso",
+	"token",
+	"xsrf",
+}
+
+// filteredValue is the replacement for sensitive values.
+const filteredValue = "[Filtered]"
+
+// isSensitiveKey reports whether a key name matches the built-in sensitive denylist.
+func isSensitiveKey(key string) bool {
+	return matchesDenyTerms(key, sensitiveDenyList)
+}
+
+// filterKeyValues applies a KeyValueCollectionBehavior to a map of key-value
+// pairs. Keys are always preserved and values are replaced with "[Filtered]".
+//
+// Returns nil when the mode is CollectionOff.
+func filterKeyValues(data map[string]string, behavior *KeyValueCollectionBehavior) map[string]string {
+	if behavior == nil {
+		behavior = &KeyValueCollectionBehavior{}
+	}
+
+	switch behavior.Mode {
+	case CollectionOff:
+		return nil
+
+	case CollectionAllowList:
+		result := make(map[string]string, len(data))
+		for k, v := range data {
+			if isSensitiveKey(k) || !matchesDenyTerms(k, behavior.Terms) {
+				result[k] = filteredValue
+			} else {
+				result[k] = v
+			}
+		}
+		return result
+
+	default: // CollectionDenyList (also handles zero value)
+		result := make(map[string]string, len(data))
+		for k, v := range data {
+			if isSensitiveKey(k) || matchesDenyTerms(k, behavior.Terms) {
+				result[k] = filteredValue
+			} else {
+				result[k] = v
+			}
+		}
+		return result
+	}
+}
+
+// FilterRequestHeaders applies the configured request-header collection behavior.
+func (dc DataCollection) FilterRequestHeaders(headers map[string]string) map[string]string {
+	var behavior *KeyValueCollectionBehavior
+	if dc.HTTPHeaders != nil {
+		behavior = dc.HTTPHeaders.Request
+	}
+	return filterKeyValues(headers, behavior)
+}
+
+// FilterResponseHeaders applies the configured response-header collection behavior.
+func (dc DataCollection) FilterResponseHeaders(headers map[string]string) map[string]string {
+	var behavior *KeyValueCollectionBehavior
+	if dc.HTTPHeaders != nil {
+		behavior = dc.HTTPHeaders.Response
+	}
+	return filterKeyValues(headers, behavior)
+}
+
+// CollectHTTPBody reports whether the given body type should be collected.
+func (dc *DataCollection) CollectHTTPBody(bt BodyType) bool {
+	if dc == nil || dc.HTTPBodies == nil {
+		return true
+	}
+	for _, t := range dc.HTTPBodies {
+		if t == bt {
+			return true
+		}
+	}
+	return false
+}
+
+// CollectCookies reports whether cookies should be collected.
+func (dc *DataCollection) CollectCookies() bool {
+	return dc == nil || dc.Cookies == nil || dc.Cookies.Mode != CollectionOff
+}
+
+// FilterQueryString applies the configured query-parameter collection behavior.
+func (dc DataCollection) FilterQueryString(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	parsed := parseKeyValueString(rawQuery, '&')
+	if parsed == nil {
+		return filteredValue
+	}
+	filtered := filterKeyValues(parsed, dc.QueryParams)
+	if filtered == nil {
+		return ""
+	}
+	return joinKeyValuePairs(filtered, "&", "=")
+}
+
+// FilterCookies applies the configured cookie collection behavior.
+func (dc DataCollection) FilterCookies(rawCookies string) string {
+	if rawCookies == "" {
+		return ""
+	}
+	parsed := parseKeyValueString(rawCookies, ';')
+	if parsed == nil {
+		return filteredValue
+	}
+	filtered := filterKeyValues(parsed, dc.Cookies)
+	if filtered == nil {
+		return ""
+	}
+	return joinKeyValuePairs(filtered, "; ", "=")
+}
+
+// FilterHTTPBody applies sensitive-key filtering to parseable HTTP body data.
+// Opaque raw bodies are replaced entirely.
+func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	if strings.Contains(strings.ToLower(contentType), "application/json") || looksLikeJSON(body) {
+		var value any
+		if err := json.Unmarshal(body, &value); err == nil {
+			filtered, err := json.Marshal(filterJSONValue(value))
+			if err == nil {
+				return string(filtered)
+			}
+		}
+	}
+
+	if strings.Contains(strings.ToLower(contentType), "application/x-www-form-urlencoded") {
+		if values, err := url.ParseQuery(string(body)); err == nil {
+			filtered := make(map[string]string, len(values))
+			for key, value := range values {
+				filtered[key] = strings.Join(value, ",")
+			}
+			return joinKeyValuePairs(filterKeyValues(filtered, &KeyValueCollectionBehavior{}), "&", "=")
+		}
+	}
+
+	return filteredValue
+}
+
+func looksLikeJSON(body []byte) bool {
+	trimmed := strings.TrimSpace(string(body))
+	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
+}
+
+func filterJSONValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		filtered := make(map[string]any, len(value))
+		for key, child := range value {
+			if isSensitiveKey(key) {
+				filtered[key] = filteredValue
+			} else {
+				filtered[key] = filterJSONValue(child)
+			}
+		}
+		return filtered
+	case []any:
+		filtered := make([]any, len(value))
+		for i, child := range value {
+			filtered[i] = filterJSONValue(child)
+		}
+		return filtered
+	default:
+		return value
+	}
+}
+
+// matchesDenyTerms reports whether the key (case-insensitive) contains any of
+// the given terms as a substring.
+func matchesDenyTerms(key string, terms []string) bool {
+	lower := strings.ToLower(key)
+	for _, term := range terms {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseKeyValueString splits a string like "a=1&b=2" or "a=1; b=2" into a
+// map. It returns nil when any part cannot be split on '='.
+func parseKeyValueString(s string, separator rune) map[string]string {
+	result := make(map[string]string)
+	for _, part := range strings.Split(s, string(separator)) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return nil
+		}
+		result[key] = value
+	}
+	return result
+}
+
+// joinKeyValuePairs reassembles a map into a string.
+func joinKeyValuePairs(values map[string]string, separator, assignment string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for k, v := range values {
+		parts = append(parts, k+assignment+v)
+	}
+	return strings.Join(parts, separator)
+}

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -115,8 +115,8 @@ func (dc DataCollection) FilterQueryString(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
 	}
-	parsed := parseKeyValueString(rawQuery, '&')
-	if parsed == nil {
+	parsed, err := parseQueryString(rawQuery)
+	if err != nil {
 		return filteredValue
 	}
 	filtered := filterKeyValues(parsed, dc.QueryParams)
@@ -152,7 +152,11 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 	if strings.Contains(strings.ToLower(contentType), "application/json") || looksLikeJSON(body) {
 		var value any
 		if err := json.Unmarshal(body, &value); err == nil {
-			filtered, err := json.Marshal(filterJSONValue(value))
+			filteredValue := filterJSONValue(value, dc.QueryParams)
+			if filteredValue == nil {
+				return ""
+			}
+			filtered, err := json.Marshal(filteredValue)
 			if err == nil {
 				return string(filtered)
 			}
@@ -161,11 +165,11 @@ func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string 
 
 	if strings.Contains(strings.ToLower(contentType), "application/x-www-form-urlencoded") {
 		if values, err := url.ParseQuery(string(body)); err == nil {
-			filtered := make(map[string]string, len(values))
-			for key, value := range values {
-				filtered[key] = strings.Join(value, ",")
+			filtered := filterKeyValues(flattenValues(values), dc.QueryParams)
+			if filtered == nil {
+				return ""
 			}
-			return joinKeyValuePairs(filterKeyValues(filtered, &KeyValueCollectionBehavior{}), "&", "=")
+			return joinKeyValuePairs(filtered, "&", "=")
 		}
 	}
 
@@ -177,26 +181,45 @@ func looksLikeJSON(body []byte) bool {
 	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
 }
 
-func filterJSONValue(value any) any {
+func filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
+	if behavior != nil && behavior.Mode == CollectionOff {
+		return nil
+	}
+
 	switch value := value.(type) {
 	case map[string]any:
 		filtered := make(map[string]any, len(value))
 		for key, child := range value {
-			if isSensitiveKey(key) {
+			if shouldFilterKey(key, behavior) {
 				filtered[key] = filteredValue
 			} else {
-				filtered[key] = filterJSONValue(child)
+				filtered[key] = filterJSONValue(child, behavior)
 			}
 		}
 		return filtered
 	case []any:
 		filtered := make([]any, len(value))
 		for i, child := range value {
-			filtered[i] = filterJSONValue(child)
+			filtered[i] = filterJSONValue(child, behavior)
 		}
 		return filtered
 	default:
 		return value
+	}
+}
+
+func shouldFilterKey(key string, behavior *KeyValueCollectionBehavior) bool {
+	if behavior == nil {
+		behavior = &KeyValueCollectionBehavior{}
+	}
+
+	switch behavior.Mode {
+	case CollectionOff:
+		return true
+	case CollectionAllowList:
+		return isSensitiveKey(key) || !matchesDenyTerms(key, behavior.Terms)
+	default:
+		return isSensitiveKey(key) || matchesDenyTerms(key, behavior.Terms)
 	}
 }
 
@@ -205,15 +228,23 @@ func filterJSONValue(value any) any {
 func matchesDenyTerms(key string, terms []string) bool {
 	lower := strings.ToLower(key)
 	for _, term := range terms {
-		if strings.Contains(lower, term) {
+		if strings.Contains(lower, strings.ToLower(term)) {
 			return true
 		}
 	}
 	return false
 }
 
+func parseQueryString(s string) (map[string]string, error) {
+	values, err := url.ParseQuery(s)
+	if err != nil {
+		return nil, err
+	}
+	return flattenValues(values), nil
+}
+
 // parseKeyValueString splits a string like "a=1&b=2" or "a=1; b=2" into a
-// map. It returns nil when any part cannot be split on '='.
+// map. Parts without '=' are treated as keys with empty values.
 func parseKeyValueString(s string, separator rune) map[string]string {
 	result := make(map[string]string)
 	for _, part := range strings.Split(s, string(separator)) {
@@ -223,9 +254,17 @@ func parseKeyValueString(s string, separator rune) map[string]string {
 		}
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
-			return nil
+			key = part
 		}
 		result[key] = value
+	}
+	return result
+}
+
+func flattenValues(values url.Values) map[string]string {
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = strings.Join(value, ",")
 	}
 	return result
 }

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -6,6 +6,30 @@ import (
 	"strings"
 )
 
+// defaultSensitiveTerms is the canonical list of case-insensitive,
+// partial-match terms used for scrubbing.
+//
+// See https://develop.sentry.dev/sdk/foundations/client/data-collection/#sensitive-denylist
+var defaultSensitiveTerms = []string{
+	"auth",
+	"bearer",
+	"credentials",
+	"csrf",
+	"identity",
+	"jwt",
+	"key",
+	"passwd",
+	"password",
+	"pwd",
+	"saml",
+	"secret",
+	"session",
+	"sid",
+	"sso",
+	"token",
+	"xsrf",
+}
+
 // filteredValue is the replacement for sensitive values.
 const filteredValue = "[Filtered]"
 
@@ -74,7 +98,7 @@ func (dc DataCollection) FilterQueryString(rawQuery string) string {
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return filteredValue
+		return ""
 	}
 	return dc.filterURLValues(values, dc.QueryParams)
 }
@@ -85,8 +109,8 @@ func (dc DataCollection) FilterCookies(rawCookies string) string {
 		return ""
 	}
 	parsed := parseKeyValueString(rawCookies, ';')
-	if parsed == nil {
-		return filteredValue
+	if len(parsed) == 0 {
+		return ""
 	}
 	filtered := dc.filterKeyValues(parsed, dc.Cookies)
 	if len(filtered) == 0 {
@@ -144,7 +168,7 @@ func (dc DataCollection) filterURLValues(values url.Values, behavior *KeyValueCo
 			values.Set(key, filteredValue)
 		}
 	}
-	return values.Encode()
+	return strings.ReplaceAll(values.Encode(), url.QueryEscape(filteredValue), filteredValue)
 }
 
 func (dc DataCollection) filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
@@ -182,13 +206,15 @@ func (dc DataCollection) shouldFilterKey(key string, behavior *KeyValueCollectio
 		behavior = &KeyValueCollectionBehavior{}
 	}
 
+	sensitive := matchesDenyTerms(key, defaultSensitiveTerms) || matchesDenyTerms(key, dc.sensitiveTerms)
+
 	switch behavior.Mode {
 	case CollectionOff:
 		return true
 	case CollectionAllowList:
-		return matchesDenyTerms(key, dc.sensitiveTerms) || !matchesDenyTerms(key, behavior.Terms)
+		return sensitive || !matchesDenyTerms(key, behavior.Terms)
 	default:
-		return matchesDenyTerms(key, dc.sensitiveTerms) || matchesDenyTerms(key, behavior.Terms)
+		return sensitive || matchesDenyTerms(key, behavior.Terms)
 	}
 }
 

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestIsSensitiveKey(t *testing.T) {
+func TestSensitiveDenyListTerms(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -42,8 +42,8 @@ func TestIsSensitiveKey(t *testing.T) {
 		t.Run(tt.key, func(t *testing.T) {
 			t.Parallel()
 
-			if got := isSensitiveKey(tt.key); got != tt.want {
-				t.Errorf("isSensitiveKey(%q) = %v, want %v", tt.key, got, tt.want)
+			if got := isSensitiveDenyList(tt.key, nil); got != tt.want {
+				t.Errorf("isSensitiveDenyList(%q, nil) = %v, want %v", tt.key, got, tt.want)
 			}
 		})
 	}

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -40,7 +40,7 @@ func TestSensitiveDenyListTerms(t *testing.T) {
 		{"X-Request-Id", false},
 	}
 
-	dc := DataCollection{sensitiveTerms: defaultSensitiveTerms}
+	dc := DataCollection{}
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
 			t.Parallel()

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -38,12 +38,13 @@ func TestSensitiveDenyListTerms(t *testing.T) {
 		{"X-Request-Id", false},
 	}
 
+	dc := DataCollection{sensitiveTerms: defaultSensitiveTerms}
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
 			t.Parallel()
 
-			if got := isSensitiveDenyList(tt.key, nil); got != tt.want {
-				t.Errorf("isSensitiveDenyList(%q, nil) = %v, want %v", tt.key, got, tt.want)
+			if got := dc.shouldFilterKey(tt.key, nil); got != tt.want {
+				t.Errorf("shouldFilterKey(%q, nil) = %v, want %v", tt.key, got, tt.want)
 			}
 		})
 	}
@@ -173,52 +174,49 @@ func TestNewClientDataCollectionHTTPBodyFilters(t *testing.T) {
 		want           map[string]any
 	}{
 		{
-			name: "JSON uses custom deny terms",
-			dataCollection: &DataCollection{
-				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"internal"}},
-			},
+			name:        "JSON uses built-in sensitive denylist",
 			body:        []byte(`{"internal_id":"123","name":"Jane","password":"secret"}`),
 			contentType: "application/json",
 			want: map[string]any{
-				"internal_id": filteredValue,
+				"internal_id": "123",
 				"name":        "Jane",
 				"password":    filteredValue,
 			},
 		},
 		{
-			name: "JSON uses allow list but sensitive keys still scrub",
+			name: "JSON ignores query param allow list",
 			dataCollection: &DataCollection{
 				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"name", "password"}},
 			},
 			body:        []byte(`{"id":"123","name":"Jane","password":"secret"}`),
 			contentType: "application/json",
 			want: map[string]any{
-				"id":       filteredValue,
+				"id":       "123",
 				"name":     "Jane",
 				"password": filteredValue,
 			},
 		},
 		{
-			name: "form body uses custom deny terms",
-			dataCollection: &DataCollection{
-				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"internal"}},
-			},
+			name:        "form body uses built-in sensitive denylist",
 			body:        []byte("internal_id=123&name=Jane&password=secret"),
 			contentType: "application/x-www-form-urlencoded",
 			want: map[string]any{
-				"internal_id": filteredValue,
+				"internal_id": "123",
 				"name":        "Jane",
 				"password":    filteredValue,
 			},
 		},
 		{
-			name: "off mode omits parseable body data",
+			name: "query params off does not omit parseable body data",
 			dataCollection: &DataCollection{
 				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionOff},
 			},
-			body:        []byte(`{"name":"Jane"}`),
+			body:        []byte(`{"name":"Jane","password":"secret"}`),
 			contentType: "application/json",
-			want:        map[string]any{},
+			want: map[string]any{
+				"name":     "Jane",
+				"password": filteredValue,
+			},
 		},
 	}
 
@@ -268,7 +266,7 @@ func TestNewClientDataCollectionCollectHTTPBody(t *testing.T) {
 	}
 }
 
-func TestPrivacyDenyTermsAreOptIn(t *testing.T) {
+func TestExtendedSensitiveTermsAreOptIn(t *testing.T) {
 	t.Parallel()
 
 	data := map[string]string{
@@ -278,6 +276,7 @@ func TestPrivacyDenyTermsAreOptIn(t *testing.T) {
 		"x-user-id":       "user-123",
 	}
 
+	// Default config uses only defaultSensitiveTerms — extended terms are not applied.
 	defaultFiltered := newClientDataCollection(t, &DataCollection{}).FilterRequestHeaders(data)
 	for key, value := range data {
 		if defaultFiltered[key] != value {
@@ -285,14 +284,17 @@ func TestPrivacyDenyTermsAreOptIn(t *testing.T) {
 		}
 	}
 
-	strictFiltered := newClientDataCollection(t, &DataCollection{
+	// Extended terms are applied when sensitiveTerms includes them (legacy path).
+	strictDC := newClientDataCollection(t, &DataCollection{
 		HTTPHeaders: &HeaderCollectionConfig{
-			Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()},
+			Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 		},
-	}).FilterRequestHeaders(data)
+	})
+	strictDC.sensitiveTerms = extendedSensitiveTerms
+	strictFiltered := strictDC.FilterRequestHeaders(data)
 	for key := range data {
 		if strictFiltered[key] != filteredValue {
-			t.Errorf("%s should be filtered with privacy deny terms, got %q", key, strictFiltered[key])
+			t.Errorf("%s should be filtered with extended sensitive terms, got %q", key, strictFiltered[key])
 		}
 	}
 }

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -1,0 +1,248 @@
+package sentry
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIsSensitiveKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		// Exact terms
+		{"auth", true},
+		{"token", true},
+		{"secret", true},
+		{"password", true},
+		{"passwd", true},
+		{"pwd", true},
+		{"key", true},
+		{"jwt", true},
+		{"bearer", true},
+		{"sso", true},
+		{"saml", true},
+		{"csrf", true},
+		{"xsrf", true},
+		{"credentials", true},
+		{"session", true},
+		{"sid", true},
+		{"identity", true},
+
+		// Substring matches (case-insensitive)
+		{"Authorization", true},
+		{"X-Auth-Token", true},
+		{"X-API-Key", true},
+		{"x-csrf-token", true},
+		{"XSRF-TOKEN", true},
+		{"session-id", true},
+		{"user-session", true},
+		{"Proxy-Authorization", true},
+		{"x-api-key", true},
+		{"private-key", true},
+		{"JWT-Token", true},
+		{"Bearer-Auth", true},
+
+		// Non-sensitive
+		{"Content-Type", false},
+		{"Accept", false},
+		{"Host", false},
+		{"User-Agent", false},
+		{"X-Request-Id", false},
+		{"Cache-Control", false},
+		{"Content-Length", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			got := isSensitiveKey(tt.key)
+			if got != tt.want {
+				t.Errorf("isSensitiveKey(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterKeyValues(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{
+		"Authorization": "Bearer abc123",
+		"Content-Type":  "application/json",
+		"X-Request-Id":  "req-456",
+		"X-Api-Key":     "secret-key",
+	}
+
+	t.Run("nil behavior uses DenyList default", func(t *testing.T) {
+		t.Parallel()
+		result := filterKeyValues(data, nil)
+		if result["Authorization"] != filteredValue {
+			t.Error("Authorization should be filtered")
+		}
+		if result["Content-Type"] != "application/json" {
+			t.Error("Content-Type should not be filtered")
+		}
+		if result["X-Api-Key"] != filteredValue {
+			t.Error("X-Api-Key should be filtered")
+		}
+		if result["X-Request-Id"] != "req-456" {
+			t.Error("X-Request-Id should not be filtered")
+		}
+	})
+
+	t.Run("DenyList mode", func(t *testing.T) {
+		t.Parallel()
+		result := filterKeyValues(data, &KeyValueCollectionBehavior{Mode: CollectionDenyList})
+		if result["Authorization"] != filteredValue {
+			t.Error("Authorization should be filtered")
+		}
+		if result["Content-Type"] != "application/json" {
+			t.Error("Content-Type should not be filtered")
+		}
+	})
+
+	t.Run("DenyList with extra terms", func(t *testing.T) {
+		t.Parallel()
+		result := filterKeyValues(data, &KeyValueCollectionBehavior{
+			Mode:  CollectionDenyList,
+			Terms: []string{"request-id"},
+		})
+		if result["X-Request-Id"] != filteredValue {
+			t.Error("X-Request-Id should be filtered by extra term")
+		}
+		if result["Content-Type"] != "application/json" {
+			t.Error("Content-Type should not be filtered")
+		}
+	})
+
+	t.Run("AllowList mode", func(t *testing.T) {
+		t.Parallel()
+		result := filterKeyValues(data, &KeyValueCollectionBehavior{
+			Mode:  CollectionAllowList,
+			Terms: []string{"content-type", "x-request-id"},
+		})
+		if result["Content-Type"] != "application/json" {
+			t.Error("Content-Type should pass through allow list")
+		}
+		if result["X-Request-Id"] != "req-456" {
+			t.Error("X-Request-Id should pass through allow list")
+		}
+		if result["Authorization"] != filteredValue {
+			t.Error("Authorization should be filtered (not in allow list + sensitive)")
+		}
+		if result["X-Api-Key"] != filteredValue {
+			t.Error("X-Api-Key should be filtered (not in allow list + sensitive)")
+		}
+	})
+
+	t.Run("AllowList sensitive keys still scrubbed", func(t *testing.T) {
+		t.Parallel()
+		// Even if "authorization" is in the allow list, it matches the
+		// sensitive denylist and MUST be scrubbed.
+		result := filterKeyValues(data, &KeyValueCollectionBehavior{
+			Mode:  CollectionAllowList,
+			Terms: []string{"authorization"},
+		})
+		if result["Authorization"] != filteredValue {
+			t.Error("Authorization should be filtered even when in allow list")
+		}
+	})
+
+	t.Run("Off mode", func(t *testing.T) {
+		t.Parallel()
+		result := filterKeyValues(data, &KeyValueCollectionBehavior{Mode: CollectionOff})
+		if result != nil {
+			t.Errorf("Off mode should return nil, got %v", result)
+		}
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		t.Parallel()
+		result := filterKeyValues(map[string]string{}, &KeyValueCollectionBehavior{Mode: CollectionDenyList})
+		if result == nil {
+			t.Error("should return non-nil empty map")
+		}
+		if len(result) != 0 {
+			t.Errorf("should return empty map, got %v", result)
+		}
+	})
+}
+
+func TestCollectHTTPBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dc   *DataCollection
+		want []BodyType
+	}{
+		{name: "nil DataCollection collects all", dc: nil, want: allBodyTypes()},
+		{name: "nil HTTPBodies collects all", dc: &DataCollection{}, want: allBodyTypes()},
+		{name: "empty HTTPBodies collects none", dc: &DataCollection{HTTPBodies: []BodyType{}}, want: []BodyType{}},
+		{name: "specific types included", dc: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}}, want: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make([]BodyType, 0)
+			for _, bt := range allBodyTypes() {
+				if tt.dc.CollectHTTPBody(bt) {
+					got = append(got, bt)
+				}
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("collected body types mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPrivacyDenyTerms(t *testing.T) {
+	t.Parallel()
+
+	got := PrivacyDenyTerms()
+	want := []string{"forwarded", "-ip", "remote-", "via", "-user"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("privacy deny terms mismatch (-want +got):\n%s", diff)
+	}
+
+	got[0] = "changed"
+	if diff := cmp.Diff(want, PrivacyDenyTerms()); diff != "" {
+		t.Errorf("privacy deny terms should return a copy (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrivacyDenyTermsAreOptIn(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{
+		"x-forwarded-for": "192.0.2.1",
+		"x-real-ip":       "192.0.2.2",
+		"remote-addr":     "192.0.2.3",
+		"x-user-id":       "user-123",
+	}
+
+	defaultFiltered := filterKeyValues(data, nil)
+	for key, value := range data {
+		if defaultFiltered[key] != value {
+			t.Errorf("%s should not be filtered by default, got %q", key, defaultFiltered[key])
+		}
+	}
+
+	strictFiltered := filterKeyValues(data, &KeyValueCollectionBehavior{
+		Mode:  CollectionDenyList,
+		Terms: PrivacyDenyTerms(),
+	})
+	for key := range data {
+		if strictFiltered[key] != filteredValue {
+			t.Errorf("%s should be filtered with privacy deny terms, got %q", key, strictFiltered[key])
+		}
+	}
+}

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -2,6 +2,8 @@ package sentry
 
 import (
 	"encoding/json"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -81,7 +83,7 @@ func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 			},
 			filter: func(t *testing.T, dc DataCollection) map[string]string {
 				t.Helper()
-				got, err := parseQueryString(dc.FilterQueryString("x-request-id=req-456&page=1"))
+				got, err := parseQueryString(t, dc.FilterQueryString("x-request-id=req-456&page=1"))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -99,7 +101,7 @@ func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 			},
 			filter: func(t *testing.T, dc DataCollection) map[string]string {
 				t.Helper()
-				got, err := parseQueryString(dc.FilterQueryString("debug=true&page=1&password=secret"))
+				got, err := parseQueryString(t, dc.FilterQueryString("debug=true&page=1&password=secret"))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -115,7 +117,7 @@ func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 			name: "flag-style and encoded query keys are filtered per key",
 			filter: func(t *testing.T, dc DataCollection) map[string]string {
 				t.Helper()
-				got, err := parseQueryString(dc.FilterQueryString("debug&pa%73sword=secret&page=1"))
+				got, err := parseQueryString(t, dc.FilterQueryString("debug&pa%73sword=secret&page=1"))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -128,12 +130,27 @@ func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "cookies are parsed and filtered per cookie name",
-			filter: func(_ *testing.T, dc DataCollection) map[string]string {
-				return parseKeyValueString(dc.FilterCookies("debug; user_session=secret; theme=dark"), ';')
+			name: "encoded query delimiters in values cannot inject sensitive parameters",
+			filter: func(t *testing.T, dc DataCollection) map[string]string {
+				t.Helper()
+				got, err := parseQueryString(t, dc.FilterQueryString("safe=hello%26password%3Dhunter2&page=1"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return got
 			},
 			want: map[string]string{
-				"debug":        "",
+				"safe": "hello&password=hunter2",
+				"page": "1",
+			},
+		},
+		{
+			name: "cookies are parsed and filtered per cookie name",
+			filter: func(_ *testing.T, dc DataCollection) map[string]string {
+				return parseKeyValueString(dc.FilterCookies("debug; =bad; empty=; user_session=secret; theme=dark"), ';')
+			},
+			want: map[string]string{
+				"empty":        "",
 				"user_session": filteredValue,
 				"theme":        "dark",
 			},
@@ -204,6 +221,15 @@ func TestNewClientDataCollectionHTTPBodyFilters(t *testing.T) {
 				"internal_id": "123",
 				"name":        "Jane",
 				"password":    filteredValue,
+			},
+		},
+		{
+			name:        "encoded form delimiters in values cannot inject sensitive parameters",
+			body:        []byte("safe=hello%26password%3Dhunter2&page=1"),
+			contentType: "application/x-www-form-urlencoded",
+			want: map[string]any{
+				"safe": "hello&password=hunter2",
+				"page": "1",
 			},
 		},
 		{
@@ -329,7 +355,7 @@ func parseFilteredBody(t *testing.T, body, contentType string) map[string]any {
 		return parsed
 	}
 
-	form, err := parseQueryString(body)
+	form, err := parseQueryString(t, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,4 +364,18 @@ func parseFilteredBody(t *testing.T, body, contentType string) map[string]any {
 		parsed[key] = value
 	}
 	return parsed
+}
+
+func parseQueryString(t *testing.T, s string) (map[string]string, error) {
+	t.Helper()
+
+	values, err := url.ParseQuery(s)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = strings.Join(value, ",")
+	}
+	return result, nil
 }

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,7 +14,6 @@ func TestIsSensitiveKey(t *testing.T) {
 		key  string
 		want bool
 	}{
-		// Exact terms
 		{"auth", true},
 		{"token", true},
 		{"secret", true},
@@ -31,168 +31,232 @@ func TestIsSensitiveKey(t *testing.T) {
 		{"session", true},
 		{"sid", true},
 		{"identity", true},
-
-		// Substring matches (case-insensitive)
 		{"Authorization", true},
 		{"X-Auth-Token", true},
 		{"X-API-Key", true},
-		{"x-csrf-token", true},
-		{"XSRF-TOKEN", true},
-		{"session-id", true},
-		{"user-session", true},
-		{"Proxy-Authorization", true},
-		{"x-api-key", true},
-		{"private-key", true},
-		{"JWT-Token", true},
-		{"Bearer-Auth", true},
-
-		// Non-sensitive
 		{"Content-Type", false},
-		{"Accept", false},
-		{"Host", false},
-		{"User-Agent", false},
 		{"X-Request-Id", false},
-		{"Cache-Control", false},
-		{"Content-Length", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
 			t.Parallel()
-			got := isSensitiveKey(tt.key)
-			if got != tt.want {
+
+			if got := isSensitiveKey(tt.key); got != tt.want {
 				t.Errorf("isSensitiveKey(%q) = %v, want %v", tt.key, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestFilterKeyValues(t *testing.T) {
-	t.Parallel()
-
-	data := map[string]string{
-		"Authorization": "Bearer abc123",
-		"Content-Type":  "application/json",
-		"X-Request-Id":  "req-456",
-		"X-Api-Key":     "secret-key",
-	}
-
-	t.Run("nil behavior uses DenyList default", func(t *testing.T) {
-		t.Parallel()
-		result := filterKeyValues(data, nil)
-		if result["Authorization"] != filteredValue {
-			t.Error("Authorization should be filtered")
-		}
-		if result["Content-Type"] != "application/json" {
-			t.Error("Content-Type should not be filtered")
-		}
-		if result["X-Api-Key"] != filteredValue {
-			t.Error("X-Api-Key should be filtered")
-		}
-		if result["X-Request-Id"] != "req-456" {
-			t.Error("X-Request-Id should not be filtered")
-		}
-	})
-
-	t.Run("DenyList mode", func(t *testing.T) {
-		t.Parallel()
-		result := filterKeyValues(data, &KeyValueCollectionBehavior{Mode: CollectionDenyList})
-		if result["Authorization"] != filteredValue {
-			t.Error("Authorization should be filtered")
-		}
-		if result["Content-Type"] != "application/json" {
-			t.Error("Content-Type should not be filtered")
-		}
-	})
-
-	t.Run("DenyList with extra terms", func(t *testing.T) {
-		t.Parallel()
-		result := filterKeyValues(data, &KeyValueCollectionBehavior{
-			Mode:  CollectionDenyList,
-			Terms: []string{"request-id"},
-		})
-		if result["X-Request-Id"] != filteredValue {
-			t.Error("X-Request-Id should be filtered by extra term")
-		}
-		if result["Content-Type"] != "application/json" {
-			t.Error("Content-Type should not be filtered")
-		}
-	})
-
-	t.Run("AllowList mode", func(t *testing.T) {
-		t.Parallel()
-		result := filterKeyValues(data, &KeyValueCollectionBehavior{
-			Mode:  CollectionAllowList,
-			Terms: []string{"content-type", "x-request-id"},
-		})
-		if result["Content-Type"] != "application/json" {
-			t.Error("Content-Type should pass through allow list")
-		}
-		if result["X-Request-Id"] != "req-456" {
-			t.Error("X-Request-Id should pass through allow list")
-		}
-		if result["Authorization"] != filteredValue {
-			t.Error("Authorization should be filtered (not in allow list + sensitive)")
-		}
-		if result["X-Api-Key"] != filteredValue {
-			t.Error("X-Api-Key should be filtered (not in allow list + sensitive)")
-		}
-	})
-
-	t.Run("AllowList sensitive keys still scrubbed", func(t *testing.T) {
-		t.Parallel()
-		// Even if "authorization" is in the allow list, it matches the
-		// sensitive denylist and MUST be scrubbed.
-		result := filterKeyValues(data, &KeyValueCollectionBehavior{
-			Mode:  CollectionAllowList,
-			Terms: []string{"authorization"},
-		})
-		if result["Authorization"] != filteredValue {
-			t.Error("Authorization should be filtered even when in allow list")
-		}
-	})
-
-	t.Run("Off mode", func(t *testing.T) {
-		t.Parallel()
-		result := filterKeyValues(data, &KeyValueCollectionBehavior{Mode: CollectionOff})
-		if result != nil {
-			t.Errorf("Off mode should return nil, got %v", result)
-		}
-	})
-
-	t.Run("empty data", func(t *testing.T) {
-		t.Parallel()
-		result := filterKeyValues(map[string]string{}, &KeyValueCollectionBehavior{Mode: CollectionDenyList})
-		if result == nil {
-			t.Error("should return non-nil empty map")
-		}
-		if len(result) != 0 {
-			t.Errorf("should return empty map, got %v", result)
-		}
-	})
-}
-
-func TestCollectHTTPBody(t *testing.T) {
+func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		dc   *DataCollection
-		want []BodyType
+		name           string
+		dataCollection *DataCollection
+		filter         func(*testing.T, DataCollection) map[string]string
+		want           map[string]string
 	}{
-		{name: "nil DataCollection collects all", dc: nil, want: allBodyTypes()},
-		{name: "nil HTTPBodies collects all", dc: &DataCollection{}, want: allBodyTypes()},
-		{name: "empty HTTPBodies collects none", dc: &DataCollection{HTTPBodies: []BodyType{}}, want: []BodyType{}},
-		{name: "specific types included", dc: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}}, want: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}},
+		{
+			name: "default headers scrub built-in sensitive keys",
+			filter: func(_ *testing.T, dc DataCollection) map[string]string {
+				return dc.FilterRequestHeaders(map[string]string{
+					"Authorization": "Bearer abc123",
+					"Content-Type":  "application/json",
+					"X-Request-Id":  "req-456",
+				})
+			},
+			want: map[string]string{
+				"Authorization": filteredValue,
+				"Content-Type":  "application/json",
+				"X-Request-Id":  "req-456",
+			},
+		},
+		{
+			name: "custom deny terms are case-insensitive",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"REQUEST-ID"}},
+			},
+			filter: func(t *testing.T, dc DataCollection) map[string]string {
+				t.Helper()
+				got, err := parseQueryString(dc.FilterQueryString("x-request-id=req-456&page=1"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return got
+			},
+			want: map[string]string{
+				"x-request-id": filteredValue,
+				"page":         "1",
+			},
+		},
+		{
+			name: "allow list is case-insensitive and built-in sensitive keys still scrub",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"PAGE", "PASSWORD"}},
+			},
+			filter: func(t *testing.T, dc DataCollection) map[string]string {
+				t.Helper()
+				got, err := parseQueryString(dc.FilterQueryString("debug=true&page=1&password=secret"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return got
+			},
+			want: map[string]string{
+				"debug":    filteredValue,
+				"page":     "1",
+				"password": filteredValue,
+			},
+		},
+		{
+			name: "flag-style and encoded query keys are filtered per key",
+			filter: func(t *testing.T, dc DataCollection) map[string]string {
+				t.Helper()
+				got, err := parseQueryString(dc.FilterQueryString("debug&pa%73sword=secret&page=1"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return got
+			},
+			want: map[string]string{
+				"debug":    "",
+				"password": filteredValue,
+				"page":     "1",
+			},
+		},
+		{
+			name: "cookies are parsed and filtered per cookie name",
+			filter: func(_ *testing.T, dc DataCollection) map[string]string {
+				return parseKeyValueString(dc.FilterCookies("debug; user_session=secret; theme=dark"), ';')
+			},
+			want: map[string]string{
+				"debug":        "",
+				"user_session": filteredValue,
+				"theme":        "dark",
+			},
+		},
+		{
+			name: "off mode omits collection",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionOff},
+			},
+			filter: func(_ *testing.T, dc DataCollection) map[string]string {
+				return map[string]string{"query": dc.FilterQueryString("page=1")}
+			},
+			want: map[string]string{"query": ""},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			dc := newClientDataCollection(t, tt.dataCollection)
+			got := tt.filter(t, dc)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("filtered values mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewClientDataCollectionHTTPBodyFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		dataCollection *DataCollection
+		body           []byte
+		contentType    string
+		want           map[string]any
+	}{
+		{
+			name: "JSON uses custom deny terms",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"internal"}},
+			},
+			body:        []byte(`{"internal_id":"123","name":"Jane","password":"secret"}`),
+			contentType: "application/json",
+			want: map[string]any{
+				"internal_id": filteredValue,
+				"name":        "Jane",
+				"password":    filteredValue,
+			},
+		},
+		{
+			name: "JSON uses allow list but sensitive keys still scrub",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"name", "password"}},
+			},
+			body:        []byte(`{"id":"123","name":"Jane","password":"secret"}`),
+			contentType: "application/json",
+			want: map[string]any{
+				"id":       filteredValue,
+				"name":     "Jane",
+				"password": filteredValue,
+			},
+		},
+		{
+			name: "form body uses custom deny terms",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"internal"}},
+			},
+			body:        []byte("internal_id=123&name=Jane&password=secret"),
+			contentType: "application/x-www-form-urlencoded",
+			want: map[string]any{
+				"internal_id": filteredValue,
+				"name":        "Jane",
+				"password":    filteredValue,
+			},
+		},
+		{
+			name: "off mode omits parseable body data",
+			dataCollection: &DataCollection{
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionOff},
+			},
+			body:        []byte(`{"name":"Jane"}`),
+			contentType: "application/json",
+			want:        map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dc := newClientDataCollection(t, tt.dataCollection)
+			got := dc.FilterHTTPBody(tt.body, tt.contentType)
+			parsed := parseFilteredBody(t, got, tt.contentType)
+			if diff := cmp.Diff(tt.want, parsed); diff != "" {
+				t.Errorf("filtered body mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewClientDataCollectionCollectHTTPBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		dataCollection *DataCollection
+		want           []BodyType
+	}{
+		{name: "nil HTTPBodies collects all", dataCollection: &DataCollection{}, want: allBodyTypes()},
+		{name: "empty HTTPBodies collects none", dataCollection: &DataCollection{HTTPBodies: []BodyType{}}, want: []BodyType{}},
+		{name: "specific body types", dataCollection: &DataCollection{HTTPBodies: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}}, want: []BodyType{BodyIncomingRequest, BodyOutgoingRequest}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dc := newClientDataCollection(t, tt.dataCollection)
 			got := make([]BodyType, 0)
 			for _, bt := range allBodyTypes() {
-				if tt.dc.CollectHTTPBody(bt) {
+				if (&dc).CollectHTTPBody(bt) {
 					got = append(got, bt)
 				}
 			}
@@ -201,21 +265,6 @@ func TestCollectHTTPBody(t *testing.T) {
 				t.Errorf("collected body types mismatch (-want +got):\n%s", diff)
 			}
 		})
-	}
-}
-
-func TestPrivacyDenyTerms(t *testing.T) {
-	t.Parallel()
-
-	got := PrivacyDenyTerms()
-	want := []string{"forwarded", "-ip", "remote-", "via", "-user"}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("privacy deny terms mismatch (-want +got):\n%s", diff)
-	}
-
-	got[0] = "changed"
-	if diff := cmp.Diff(want, PrivacyDenyTerms()); diff != "" {
-		t.Errorf("privacy deny terms should return a copy (-want +got):\n%s", diff)
 	}
 }
 
@@ -229,20 +278,62 @@ func TestPrivacyDenyTermsAreOptIn(t *testing.T) {
 		"x-user-id":       "user-123",
 	}
 
-	defaultFiltered := filterKeyValues(data, nil)
+	defaultFiltered := newClientDataCollection(t, &DataCollection{}).FilterRequestHeaders(data)
 	for key, value := range data {
 		if defaultFiltered[key] != value {
 			t.Errorf("%s should not be filtered by default, got %q", key, defaultFiltered[key])
 		}
 	}
 
-	strictFiltered := filterKeyValues(data, &KeyValueCollectionBehavior{
-		Mode:  CollectionDenyList,
-		Terms: PrivacyDenyTerms(),
-	})
+	strictFiltered := newClientDataCollection(t, &DataCollection{
+		HTTPHeaders: &HeaderCollectionConfig{
+			Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()},
+		},
+	}).FilterRequestHeaders(data)
 	for key := range data {
 		if strictFiltered[key] != filteredValue {
 			t.Errorf("%s should be filtered with privacy deny terms, got %q", key, strictFiltered[key])
 		}
 	}
+}
+
+func newClientDataCollection(t *testing.T, dc *DataCollection) DataCollection {
+	t.Helper()
+
+	if dc == nil {
+		dc = &DataCollection{}
+	}
+	client, err := NewClient(ClientOptions{
+		Dsn:            "https://key@sentry.io/1",
+		DataCollection: dc,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client.GetDataCollection()
+}
+
+func parseFilteredBody(t *testing.T, body, contentType string) map[string]any {
+	t.Helper()
+
+	if body == "" {
+		return map[string]any{}
+	}
+	if contentType == "application/json" {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+			t.Fatal(err)
+		}
+		return parsed
+	}
+
+	form, err := parseQueryString(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed := make(map[string]any, len(form))
+	for key, value := range form {
+		parsed[key] = value
+	}
+	return parsed
 }

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -10,18 +10,20 @@ func TestNewClientDataCollection(t *testing.T) {
 	t.Parallel()
 
 	specDefaults := DataCollection{
-		UserInfo:    Set(true),
-		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-		HTTPBodies:  allBodyTypes(),
-		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		UserInfo:       Set(true),
+		Cookies:        &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:     allBodyTypes(),
+		QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		sensitiveTerms: defaultSensitiveTerms,
 	}
 	legacyPrivacyDefaults := DataCollection{
-		UserInfo:    Set(false),
-		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionOff},
-		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()}},
-		HTTPBodies:  []BodyType{},
-		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: PrivacyDenyTerms()},
+		UserInfo:       Set(false),
+		Cookies:        &KeyValueCollectionBehavior{Mode: CollectionOff},
+		HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:     []BodyType{},
+		QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		sensitiveTerms: extendedSensitiveTerms,
 	}
 
 	tests := []struct {
@@ -77,11 +79,12 @@ func TestNewClientDataCollection(t *testing.T) {
 				SendDefaultPII: true,
 			},
 			want: DataCollection{
-				UserInfo:    Set(false),
-				Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
-				HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-				HTTPBodies:  []BodyType{},
-				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+				UserInfo:       Set(false),
+				Cookies:        &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+				HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+				HTTPBodies:     []BodyType{},
+				QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+				sensitiveTerms: defaultSensitiveTerms,
 			},
 		},
 	}
@@ -95,7 +98,7 @@ func TestNewClientDataCollection(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(tt.want, client.GetDataCollection()); diff != "" {
+			if diff := cmp.Diff(tt.want, client.GetDataCollection(), cmp.AllowUnexported(DataCollection{})); diff != "" {
 				t.Errorf("client data collection mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -132,19 +135,20 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 	returned.QueryParams.Mode = CollectionOff
 
 	want := DataCollection{
-		UserInfo:    Set(false),
-		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
-		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-		HTTPBodies:  []BodyType{BodyIncomingRequest},
-		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		UserInfo:       Set(false),
+		Cookies:        &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+		HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:     []BodyType{BodyIncomingRequest},
+		QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		sensitiveTerms: defaultSensitiveTerms,
 	}
 
-	if diff := cmp.Diff(want, client.GetDataCollection()); diff != "" {
+	if diff := cmp.Diff(want, client.GetDataCollection(), cmp.AllowUnexported(DataCollection{})); diff != "" {
 		t.Errorf("client data collection should be snapshotted (-want +got):\n%s", diff)
 	}
 }
 
-func TestNewClientLegacyDataCollectionPrivacyTermsAreNotShared(t *testing.T) {
+func TestNewClientLegacyDataCollectionSensitiveTerms(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(ClientOptions{Dsn: "https://key@sentry.io/1"})
@@ -153,12 +157,7 @@ func TestNewClientLegacyDataCollectionPrivacyTermsAreNotShared(t *testing.T) {
 	}
 
 	got := client.GetDataCollection()
-	got.HTTPHeaders.Request.Terms[0] = "changed"
-
-	if diff := cmp.Diff(PrivacyDenyTerms(), got.HTTPHeaders.Response.Terms); diff != "" {
-		t.Errorf("response header terms should not share request header terms (-want +got):\n%s", diff)
-	}
-	if diff := cmp.Diff(PrivacyDenyTerms(), got.QueryParams.Terms); diff != "" {
-		t.Errorf("query param terms should not share request header terms (-want +got):\n%s", diff)
+	if diff := cmp.Diff(extendedSensitiveTerms, got.sensitiveTerms); diff != "" {
+		t.Errorf("sensitiveTerms mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -10,12 +10,11 @@ func TestNewClientDataCollection(t *testing.T) {
 	t.Parallel()
 
 	specDefaults := DataCollection{
-		UserInfo:       Set(true),
-		Cookies:        &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-		HTTPBodies:     allBodyTypes(),
-		QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		sensitiveTerms: defaultSensitiveTerms,
+		UserInfo:    Set(true),
+		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionDenyList},
+		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:  allBodyTypes(),
+		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 	}
 	legacyPrivacyDefaults := DataCollection{
 		UserInfo:       Set(false),
@@ -79,12 +78,11 @@ func TestNewClientDataCollection(t *testing.T) {
 				SendDefaultPII: true,
 			},
 			want: DataCollection{
-				UserInfo:       Set(false),
-				Cookies:        &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
-				HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-				HTTPBodies:     []BodyType{},
-				QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-				sensitiveTerms: defaultSensitiveTerms,
+				UserInfo:    Set(false),
+				Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+				HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"x-request-id"}}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+				HTTPBodies:  []BodyType{},
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 			},
 		},
 	}
@@ -135,12 +133,11 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 	returned.QueryParams.Mode = CollectionOff
 
 	want := DataCollection{
-		UserInfo:       Set(false),
-		Cookies:        &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
-		HTTPHeaders:    &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
-		HTTPBodies:     []BodyType{BodyIncomingRequest},
-		QueryParams:    &KeyValueCollectionBehavior{Mode: CollectionDenyList},
-		sensitiveTerms: defaultSensitiveTerms,
+		UserInfo:    Set(false),
+		Cookies:     &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"session_id"}},
+		HTTPHeaders: &HeaderCollectionConfig{Request: &KeyValueCollectionBehavior{Mode: CollectionDenyList}, Response: &KeyValueCollectionBehavior{Mode: CollectionDenyList}},
+		HTTPBodies:  []BodyType{BodyIncomingRequest},
+		QueryParams: &KeyValueCollectionBehavior{Mode: CollectionDenyList},
 	}
 
 	if diff := cmp.Diff(want, client.GetDataCollection(), cmp.AllowUnexported(DataCollection{})); diff != "" {


### PR DESCRIPTION
### Description
This PR adds the filtering methods for sensitive data. Using the new methods means that the SDK now will properly apply scrubbing to collected headers, cookies, query parameters and request bodies (the SDK previously collected raw bodies and query strings. The followup PR will take care of the plumbing and fixing all failing tests). `SendDefaultPII` also remains supported for backwards compatibility along with the fixes on raw sensitive data.

#skip-changelog

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
