### PR TITLE
feat: apply sensitive data filters to http

### DIFF
--- a/data_collection.go
+++ b/data_collection.go
@@ -50,10 +50,6 @@ const (
 	// BodyIncomingResponse collects bodies from incoming HTTP responses
 	// (client-side).
 	BodyIncomingResponse BodyType = "incomingResponse"
-
-	// BodyOutgoingResponse collects bodies from outgoing HTTP responses
-	// (server-side).
-	BodyOutgoingResponse BodyType = "outgoingResponse"
 )
 
 // DataCollection configures what data the SDK collects automatically.
@@ -142,7 +138,6 @@ func allBodyTypes() []BodyType {
 		BodyIncomingRequest,
 		BodyOutgoingRequest,
 		BodyIncomingResponse,
-		BodyOutgoingResponse,
 	}
 }
 

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -91,6 +91,11 @@ func (dc *DataCollection) CollectCookies() bool {
 	return dc == nil || dc.Cookies == nil || dc.Cookies.Mode != CollectionOff
 }
 
+// CollectQueryParams reports whether query parameters should be collected.
+func (dc DataCollection) CollectQueryParams() bool {
+	return dc.QueryParams == nil || dc.QueryParams.Mode != CollectionOff
+}
+
 // FilterQueryString applies the configured query-parameter collection behavior.
 func (dc DataCollection) FilterQueryString(rawQuery string) string {
 	if rawQuery == "" {
@@ -101,6 +106,16 @@ func (dc DataCollection) FilterQueryString(rawQuery string) string {
 		return ""
 	}
 	return dc.filterURLValues(values, dc.QueryParams)
+}
+
+// FilterURL applies query-parameter filtering to u and returns its redacted string form.
+func (dc DataCollection) FilterURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	filtered := *u
+	filtered.RawQuery = dc.FilterQueryString(u.RawQuery)
+	return filtered.Redacted()
 }
 
 // FilterCookies applies the configured cookie collection behavior.

--- a/data_collection_test.go
+++ b/data_collection_test.go
@@ -122,14 +122,14 @@ func TestNewClientDataCollectionSnapshotting(t *testing.T) {
 	input.UserInfo = Set(true)
 	input.Cookies.Mode = CollectionOff
 	input.Cookies.Terms[0] = "changed"
-	input.HTTPBodies[0] = BodyOutgoingResponse
+	input.HTTPBodies[0] = BodyIncomingResponse
 
 	returned := client.GetDataCollection()
 	returned.UserInfo = Set(true)
 	returned.Cookies.Mode = CollectionOff
 	returned.Cookies.Terms[0] = "changed"
 	returned.HTTPHeaders.Request.Mode = CollectionAllowList
-	returned.HTTPBodies[0] = BodyOutgoingResponse
+	returned.HTTPBodies[0] = BodyIncomingResponse
 	returned.QueryParams.Mode = CollectionOff
 
 	want := DataCollection{

--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -27,6 +27,7 @@ func TestIntegration(t *testing.T) {
 		Method      string
 		WantStatus  int
 		Body        string
+		ContentType string
 		Handler     echo.HandlerFunc
 
 		WantEvent       *sentry.Event
@@ -113,7 +114,8 @@ func TestIntegration(t *testing.T) {
 			RoutePath:   "/post",
 			Method:      "POST",
 			WantStatus:  200,
-			Body:        "payload",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
 			Handler: func(c *echo.Context) error {
 				hub := sentryecho.GetHubFromContext(c)
 				body, err := io.ReadAll(c.Request().Body)
@@ -125,14 +127,15 @@ func TestIntegration(t *testing.T) {
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -144,9 +147,10 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"Accept-Encoding": "gzip",
 						"User-Agent":      "Go-http-client/1.1",
 					},
@@ -358,6 +362,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:          true,
 		TracesSampleRate:       1.0,
+		DataCollection:         &sentry.DataCollection{},
 		TraceIgnoreStatusCodes: make([][]int, 0), // don't ignore any status codes
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
@@ -414,6 +419,9 @@ func TestIntegration(t *testing.T) {
 		req, err := http.NewRequest(tt.Method, srv.URL+tt.RequestPath, strings.NewReader(tt.Body))
 		if err != nil {
 			t.Fatal(err)
+		}
+		if tt.ContentType != "" {
+			req.Header.Set("Content-Type", tt.ContentType)
 		}
 		res, err := c.Do(req)
 		if err != nil {

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -28,6 +28,7 @@ func TestIntegration(t *testing.T) {
 		Path            string
 		Method          string
 		Body            string
+		ContentType     string
 		WantStatus      int
 		Handler         fasthttp.RequestHandler
 		WantEvent       *sentry.Event
@@ -77,24 +78,26 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:       "/post",
-			Method:     http.MethodPost,
-			WantStatus: 200,
-			Body:       "payload",
+			Path:        "/post",
+			Method:      http.MethodPost,
+			WantStatus:  200,
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
 			Handler: func(ctx *fasthttp.RequestCtx) {
 				hub := sentryfasthttp.GetHubFromContext(ctx)
 				hub.CaptureMessage("post: " + string(ctx.Request.Body()))
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "http://example.com/post",
 					Method: http.MethodPost,
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Host":       "example.com",
-						"User-Agent": "fasthttp",
+						"Content-Type": "application/json",
+						"Host":         "example.com",
+						"User-Agent":   "fasthttp",
 					},
 				},
 			},
@@ -105,10 +108,11 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "http://example.com/post",
 					Method: http.MethodPost,
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Host":       "example.com",
-						"User-Agent": "fasthttp",
+						"Content-Type": "application/json",
+						"Host":         "example.com",
+						"User-Agent":   "fasthttp",
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
@@ -218,10 +222,11 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:       "/post/body-ignored",
-			Method:     http.MethodPost,
-			Body:       "client sends, fasthttp always reads, SDK reports",
-			WantStatus: 200,
+			Path:        "/post/body-ignored",
+			Method:      http.MethodPost,
+			Body:        `{"safe":"body ignored"}`,
+			ContentType: "application/json",
+			WantStatus:  200,
 			Handler: func(ctx *fasthttp.RequestCtx) {
 				hub := sentryfasthttp.GetHubFromContext(ctx)
 				hub.CaptureMessage("body ignored")
@@ -234,10 +239,11 @@ func TestIntegration(t *testing.T) {
 					Method: http.MethodPost,
 					// Actual request body included because fasthttp always
 					// reads full request body.
-					Data: "client sends, fasthttp always reads, SDK reports",
+					Data: `{"safe":"body ignored"}`,
 					Headers: map[string]string{
-						"Host":       "example.com",
-						"User-Agent": "fasthttp",
+						"Content-Type": "application/json",
+						"Host":         "example.com",
+						"User-Agent":   "fasthttp",
 					},
 				},
 			},
@@ -248,10 +254,11 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "http://example.com/post/body-ignored",
 					Method: http.MethodPost,
-					Data:   "client sends, fasthttp always reads, SDK reports",
+					Data:   `{"safe":"body ignored"}`,
 					Headers: map[string]string{
-						"Host":       "example.com",
-						"User-Agent": "fasthttp",
+						"Content-Type": "application/json",
+						"Host":         "example.com",
+						"User-Agent":   "fasthttp",
 					},
 				},
 				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
@@ -326,6 +333,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
@@ -378,6 +386,9 @@ func TestIntegration(t *testing.T) {
 		req.URI().SetPath(tt.Path)
 		req.Header.SetMethod(tt.Method)
 		req.SetBodyString(tt.Body)
+		if tt.ContentType != "" {
+			req.Header.SetContentType(tt.ContentType)
+		}
 		if err := c.Do(req, res); err != nil {
 			t.Fatalf("Request %q failed: %s", tt.Path, err)
 		}

--- a/fiber/sentryfiber_test.go
+++ b/fiber/sentryfiber_test.go
@@ -27,6 +27,9 @@ func wantFiberTransaction(routePath, requestURL, method, body string, status int
 	if body != "" || method == http.MethodPost {
 		headers["Content-Length"] = fmt.Sprintf("%d", len(body))
 	}
+	if strings.HasPrefix(body, "{") {
+		headers["Content-Type"] = "application/json"
+	}
 
 	return &sentry.Event{
 		Level:       sentry.LevelInfo,
@@ -106,6 +109,7 @@ func TestIntegration(t *testing.T) {
 		Path            string
 		Method          string
 		Body            string
+		ContentType     string
 		WantStatus      int
 		WantEvent       *sentry.Event
 		WantTransaction *sentry.Event
@@ -152,25 +156,27 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:       "/post",
-			Method:     "POST",
-			Body:       "payload",
-			WantStatus: 200,
+			Path:        "/post",
+			Method:      "POST",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
+			WantStatus:  200,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "http://example.com/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Content-Length": "7",
+						"Content-Length": "16",
+						"Content-Type":   "application/json",
 						"Host":           "example.com",
 						"User-Agent":     "fiber",
 					},
 				},
 			},
-			WantTransaction: wantFiberTransaction("/post", "/post", http.MethodPost, "payload", http.StatusOK),
+			WantTransaction: wantFiberTransaction("/post", "/post", http.MethodPost, `{"safe":"value"}`, http.StatusOK),
 		},
 		{
 			Path:       "/get",
@@ -303,10 +309,11 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:       "/post/body-ignored",
-			WantStatus: 200,
-			Method:     "POST",
-			Body:       "client sends, fiber always reads, SDK reports",
+			Path:        "/post/body-ignored",
+			WantStatus:  200,
+			Method:      "POST",
+			Body:        `{"safe":"body ignored"}`,
+			ContentType: "application/json",
 
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
@@ -314,15 +321,16 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "http://example.com/post/body-ignored",
 					Method: "POST",
-					Data:   "client sends, fiber always reads, SDK reports",
+					Data:   `{"safe":"body ignored"}`,
 					Headers: map[string]string{
-						"Content-Length": "45",
+						"Content-Length": "23",
+						"Content-Type":   "application/json",
 						"Host":           "example.com",
 						"User-Agent":     "fiber",
 					},
 				},
 			},
-			WantTransaction: wantFiberTransaction("/post/body-ignored", "/post/body-ignored", http.MethodPost, "client sends, fiber always reads, SDK reports", http.StatusOK),
+			WantTransaction: wantFiberTransaction("/post/body-ignored", "/post/body-ignored", http.MethodPost, `{"safe":"body ignored"}`, http.StatusOK),
 		},
 		{
 			Path:       "/post/error-handler",
@@ -380,6 +388,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
@@ -403,6 +412,9 @@ func TestIntegration(t *testing.T) {
 		req, err := http.NewRequest(tt.Method, "http://example.com"+tt.Path, strings.NewReader(tt.Body))
 		if err != nil {
 			t.Fatal(err)
+		}
+		if tt.ContentType != "" {
+			req.Header.Set("Content-Type", tt.ContentType)
 		}
 		req.Header.Set("User-Agent", "fiber")
 		resp, err := app.Test(req)

--- a/fiberv3/sentryfiber_test.go
+++ b/fiberv3/sentryfiber_test.go
@@ -27,6 +27,9 @@ func wantFiberTransaction(routePath, requestURL, method, body string, status int
 	if body != "" || method == http.MethodPost {
 		headers["Content-Length"] = fmt.Sprintf("%d", len(body))
 	}
+	if strings.HasPrefix(body, "{") {
+		headers["Content-Type"] = "application/json"
+	}
 
 	return &sentry.Event{
 		Level:       sentry.LevelInfo,
@@ -106,6 +109,7 @@ func TestIntegration(t *testing.T) {
 		Path            string
 		Method          string
 		Body            string
+		ContentType     string
 		WantStatus      int
 		WantEvent       *sentry.Event
 		WantTransaction *sentry.Event
@@ -152,25 +156,27 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:       "/post",
-			Method:     "POST",
-			Body:       "payload",
-			WantStatus: 200,
+			Path:        "/post",
+			Method:      "POST",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
+			WantStatus:  200,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "http://example.com/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Content-Length": "7",
+						"Content-Length": "16",
+						"Content-Type":   "application/json",
 						"Host":           "example.com",
 						"User-Agent":     "fiber",
 					},
 				},
 			},
-			WantTransaction: wantFiberTransaction("/post", "/post", http.MethodPost, "payload", http.StatusOK),
+			WantTransaction: wantFiberTransaction("/post", "/post", http.MethodPost, `{"safe":"value"}`, http.StatusOK),
 		},
 		{
 			Path:       "/get",
@@ -302,10 +308,11 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:       "/post/body-ignored",
-			WantStatus: 200,
-			Method:     "POST",
-			Body:       "client sends, fiber always reads, SDK reports",
+			Path:        "/post/body-ignored",
+			WantStatus:  200,
+			Method:      "POST",
+			Body:        `{"safe":"body ignored"}`,
+			ContentType: "application/json",
 
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
@@ -313,15 +320,16 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "http://example.com/post/body-ignored",
 					Method: "POST",
-					Data:   "client sends, fiber always reads, SDK reports",
+					Data:   `{"safe":"body ignored"}`,
 					Headers: map[string]string{
-						"Content-Length": "45",
+						"Content-Length": "23",
+						"Content-Type":   "application/json",
 						"Host":           "example.com",
 						"User-Agent":     "fiber",
 					},
 				},
 			},
-			WantTransaction: wantFiberTransaction("/post/body-ignored", "/post/body-ignored", http.MethodPost, "client sends, fiber always reads, SDK reports", http.StatusOK),
+			WantTransaction: wantFiberTransaction("/post/body-ignored", "/post/body-ignored", http.MethodPost, `{"safe":"body ignored"}`, http.StatusOK),
 		},
 		{
 			Path:       "/post/error-handler",
@@ -379,6 +387,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
@@ -402,6 +411,9 @@ func TestIntegration(t *testing.T) {
 		req, err := http.NewRequest(tt.Method, "http://example.com"+tt.Path, strings.NewReader(tt.Body))
 		if err != nil {
 			t.Fatal(err)
+		}
+		if tt.ContentType != "" {
+			req.Header.Set("Content-Type", tt.ContentType)
 		}
 		req.Header.Set("User-Agent", "fiber")
 		resp, err := app.Test(req)

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -28,6 +28,7 @@ func TestIntegration(t *testing.T) {
 		Method      string
 		WantStatus  int
 		Body        string
+		ContentType string
 		Handler     gin.HandlerFunc
 
 		WantEvent       *sentry.Event
@@ -114,7 +115,8 @@ func TestIntegration(t *testing.T) {
 			RoutePath:   "/post",
 			Method:      "POST",
 			WantStatus:  200,
-			Body:        "payload",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
 			Handler: func(c *gin.Context) {
 				hub := sentry.GetHubFromContext(c.Request.Context())
 				body, err := io.ReadAll(c.Request.Body)
@@ -131,9 +133,10 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"Accept-Encoding": "gzip",
 						"User-Agent":      "Go-http-client/1.1",
 					},
@@ -151,14 +154,15 @@ func TestIntegration(t *testing.T) {
 				}},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -356,6 +360,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:          true,
 		TracesSampleRate:       1.0,
+		DataCollection:         &sentry.DataCollection{},
 		TraceIgnoreStatusCodes: make([][]int, 0), // don't ignore any status codes
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
@@ -403,6 +408,9 @@ func TestIntegration(t *testing.T) {
 		req, err := http.NewRequest(tt.Method, srv.URL+tt.RequestPath, strings.NewReader(tt.Body))
 		if err != nil {
 			t.Fatal(err)
+		}
+		if tt.ContentType != "" {
+			req.Header.Set("Content-Type", tt.ContentType)
 		}
 		res, err := c.Do(req)
 		if err != nil {

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -20,10 +20,11 @@ func TestIntegration(t *testing.T) {
 	largePayload := strings.Repeat("Large", 3*1024) // 15 KB
 
 	tests := []struct {
-		Path    string
-		Method  string
-		Body    string
-		Handler http.Handler
+		Path        string
+		Method      string
+		Body        string
+		ContentType string
+		Handler     http.Handler
 
 		WantStatus      int
 		WantEvent       *sentry.Event
@@ -74,9 +75,10 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:   "/post",
-			Method: "POST",
-			Body:   "payload",
+			Path:        "/post",
+			Method:      "POST",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
 			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				body, err := io.ReadAll(r.Body)
@@ -89,14 +91,15 @@ func TestIntegration(t *testing.T) {
 			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -108,10 +111,11 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -289,6 +293,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
@@ -337,6 +342,9 @@ func TestIntegration(t *testing.T) {
 		req, err := http.NewRequest(tt.Method, srv.URL+tt.Path, strings.NewReader(tt.Body))
 		if err != nil {
 			t.Fatal(err)
+		}
+		if tt.ContentType != "" {
+			req.Header.Set("Content-Type", tt.ContentType)
 		}
 		res, err := c.Do(req)
 		if err != nil {
@@ -388,6 +396,10 @@ func TestIntegration(t *testing.T) {
 			"StartTime", "Spans",
 		),
 		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
+		cmpopts.IgnoreFields(
+			sentry.Request{},
+			"Env",
+		),
 		cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 			ignoredCtxEntries := []string{"span_id", "trace_id", "device", "os", "runtime"}
 			for _, e := range ignoredCtxEntries {

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -79,6 +79,20 @@ type SentryRoundTripper struct {
 	tracePropagationTargets []string
 }
 
+func dataCollectionFromRequest(request *http.Request) sentry.DataCollection {
+	if hub := sentry.GetHubFromContext(request.Context()); hub != nil {
+		if client := hub.Client(); client != nil {
+			return client.GetDataCollection()
+		}
+	}
+	if hub := sentry.CurrentHub(); hub != nil {
+		if client := hub.Client(); client != nil {
+			return client.GetDataCollection()
+		}
+	}
+	return sentry.DataCollection{}
+}
+
 func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	// Respect trace propagation targets
 	if len(s.tracePropagationTargets) > 0 {
@@ -111,12 +125,15 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 		return s.originalRoundTripper.RoundTrip(request)
 	}
 
-	cleanRequestURL := request.URL.Redacted()
+	dc := dataCollectionFromRequest(request)
+	cleanRequestURL := dc.FilterURL(request.URL)
 
 	span := parentSpan.StartChild("http.client", sentry.WithDescription(fmt.Sprintf("%s %s", request.Method, cleanRequestURL)))
 	defer span.Finish()
 
-	span.SetData("http.query", request.URL.Query().Encode())
+	if dc.CollectQueryParams() {
+		span.SetData("http.query", dc.FilterQueryString(request.URL.RawQuery))
+	}
 	span.SetData("http.fragment", request.URL.Fragment)
 	span.SetData("http.request.method", request.Method)
 	span.SetData("server.address", request.URL.Hostname())

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -130,7 +130,7 @@ func TestIntegration(t *testing.T) {
 			WantSpan: &sentry.Span{
 				Data: map[string]interface{}{
 					"http.fragment":                string(""),
-					"http.query":                   string("abc=def&bar=123"),
+					"http.query":                   string("bar=123&abc=def"),
 					"http.request.method":          string("HEAD"),
 					"http.response.status_code":    int(400),
 					"http.response_content_length": int64(0),
@@ -302,6 +302,7 @@ func TestIntegration(t *testing.T) {
 			"mu", "parent", "sampleRate", "ctx", "dynamicSamplingContext", "recorder", "finishOnce", "contexts",
 			"explicitSampled", "serializedTags", "serializedData", "serializationSafe",
 		),
+		testutils.EquateKeyValueStrings(),
 	}
 	for i, tt := range tests {
 		gotSpans := got[i]
@@ -619,4 +620,104 @@ func traceparentFromSentryTraceHeader(t *testing.T, sentryTrace string) string {
 	}
 
 	return fmt.Sprintf("00-%s-%s-%s", traceParentContext.TraceID.String(), traceParentContext.ParentSpanID.String(), traceFlags)
+}
+
+func TestDataCollectionFiltersQuerySpanData(t *testing.T) {
+	tests := []struct {
+		name           string
+		dataCollection *sentry.DataCollection
+		requestURL     string
+		wantData       map[string]interface{}
+		wantDesc       string
+	}{
+		{
+			name:       "filters sensitive query values",
+			requestURL: "https://example.com/foo?page=1&token=secret#readme",
+			wantData: map[string]interface{}{
+				"http.fragment":                "readme",
+				"http.query":                   "page=1&token=[Filtered]",
+				"http.request.method":          "GET",
+				"http.response.status_code":    200,
+				"http.response_content_length": int64(0),
+				"server.address":               "example.com",
+				"server.port":                  "",
+			},
+			wantDesc: "GET https://example.com/foo?page=1&token=[Filtered]#readme",
+		},
+		{
+			name: "omits query values when disabled",
+			dataCollection: &sentry.DataCollection{
+				QueryParams: &sentry.KeyValueCollectionBehavior{Mode: sentry.CollectionOff},
+			},
+			requestURL: "https://example.com/foo?page=1&token=secret#readme",
+			wantData: map[string]interface{}{
+				"http.fragment":                "readme",
+				"http.request.method":          "GET",
+				"http.response.status_code":    200,
+				"http.response_content_length": int64(0),
+				"server.address":               "example.com",
+				"server.port":                  "",
+			},
+			wantDesc: "GET https://example.com/foo#readme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spansCh := make(chan []*sentry.Span, 1)
+			sentryClient, err := sentry.NewClient(sentry.ClientOptions{
+				EnableTracing:    true,
+				TracesSampleRate: 1.0,
+				DataCollection:   tt.dataCollection,
+				BeforeSendTransaction: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+					spansCh <- event.Spans
+					return event
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hub := sentry.NewHub(sentryClient, sentry.NewScope())
+			ctx := sentry.SetHubOnContext(context.Background(), hub)
+			span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
+			ctx = span.Context()
+
+			request, err := http.NewRequestWithContext(ctx, http.MethodGet, tt.requestURL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := &http.Client{Transport: sentryhttpclient.NewSentryRoundTripper(&noopRoundTripper{ExpectResponseStatus: http.StatusOK})}
+			response, err := client.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.Body.Close()
+			span.Finish()
+
+			if ok := sentryClient.Flush(testutils.FlushTimeout()); !ok {
+				t.Fatal("sentry.Flush timed out")
+			}
+			close(spansCh)
+
+			var got *sentry.Span
+			for spans := range spansCh {
+				for _, candidate := range spans {
+					if candidate.Op == "http.client" {
+						got = candidate
+						break
+					}
+				}
+			}
+			if got == nil {
+				t.Fatal("missing http.client span")
+			}
+			if diff := cmp.Diff(tt.wantData, got.Data, testutils.EquateKeyValueStrings()); diff != "" {
+				t.Fatalf("span data mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantDesc, got.Description, testutils.EquateKeyValueStrings()); diff != "" {
+				t.Fatalf("span description mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -254,17 +254,8 @@ func newRequest(r *http.Request, client *Client) *Request {
 	}
 	url := fmt.Sprintf("%s://%s%s", prot, r.Host, r.URL.Path)
 
-	legacyPII := false
-	if client != nil {
-		legacyPII = client.options.SendDefaultPII // nolint: staticcheck // intended use for backwards compatibility
-	}
+	dc := client.GetDataCollection()
 
-	var dc DataCollection
-	if client != nil && client.options.DataCollection != nil {
-		dc = *client.options.DataCollection
-	} else {
-		dc = snapshotDataCollection(nil, legacyPII)
-	}
 	var cookies string
 	headers := make(map[string]string, len(r.Header)+1)
 	if dc.CollectCookies() {

--- a/interfaces.go
+++ b/interfaces.go
@@ -247,50 +247,48 @@ type Request struct {
 	Env         map[string]string `json:"env,omitempty"`
 }
 
-func sendDefaultPIIEnabled(client *Client) bool {
-	return client != nil && client.options.SendDefaultPII
-}
-
-func newRequest(r *http.Request, sendDefaultPII bool) *Request {
+func newRequest(r *http.Request, client *Client) *Request {
 	prot := protocol.SchemeHTTP
 	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		prot = protocol.SchemeHTTPS
 	}
 	url := fmt.Sprintf("%s://%s%s", prot, r.Host, r.URL.Path)
 
-	var cookies string
-	var env map[string]string
-	headers := map[string]string{}
-
-	if sendDefaultPII {
-		// We read only the first Cookie header because of the specification:
-		// https://tools.ietf.org/html/rfc6265#section-5.4
-		// When the user agent generates an HTTP request, the user agent MUST NOT
-		// attach more than one Cookie header field.
-		cookies = r.Header.Get("Cookie")
-
-		headers = make(map[string]string, len(r.Header))
-		for k, v := range r.Header {
-			headers[k] = strings.Join(v, ",")
+	dc := snapshotDataCollection(nil, false)
+	if client != nil && client.options.DataCollection != nil {
+		dc = *client.options.DataCollection
+	}
+	cookies := dc.FilterCookies(r.Header.Get("Cookie"))
+	headers := make(map[string]string, len(r.Header)+1)
+	for k, v := range r.Header {
+		if strings.EqualFold(k, "Cookie") {
+			continue
 		}
-
-		if addr, port, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-			env = map[string]string{"REMOTE_ADDR": addr, "REMOTE_PORT": port}
-		}
-	} else {
-		for k, v := range r.Header {
-			if !IsSensitiveHeader(k) {
-				headers[k] = strings.Join(v, ",")
+		headers[k] = strings.Join(v, ",")
+	}
+	if rawCookie := r.Header.Get("Cookie"); rawCookie != "" {
+		if dc.CollectCookies() {
+			if cookies != "" {
+				headers["Cookie"] = cookies
+			} else {
+				headers["Cookie"] = filteredValue
 			}
 		}
 	}
-
 	headers["Host"] = r.Host
+	headers = dc.FilterRequestHeaders(headers)
+
+	var env map[string]string
+	if dc.UserInfo.Value {
+		if addr, port, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+			env = map[string]string{"REMOTE_ADDR": addr, "REMOTE_PORT": port}
+		}
+	}
 
 	return &Request{
 		URL:         url,
 		Method:      r.Method,
-		QueryString: r.URL.RawQuery,
+		QueryString: dc.FilterQueryString(r.URL.RawQuery),
 		Cookies:     cookies,
 		Headers:     headers,
 		Env:         env,
@@ -302,7 +300,7 @@ func newRequest(r *http.Request, sendDefaultPII bool) *Request {
 // NewRequest avoids operations that depend on network access. In particular, it
 // does not read r.Body.
 func NewRequest(r *http.Request) *Request {
-	return newRequest(r, sendDefaultPIIEnabled(CurrentHub().Client()))
+	return newRequest(r, CurrentHub().Client())
 }
 
 // Mechanism is the mechanism by which an exception was generated and handled.

--- a/interfaces.go
+++ b/interfaces.go
@@ -265,22 +265,20 @@ func newRequest(r *http.Request, client *Client) *Request {
 	} else {
 		dc = snapshotDataCollection(nil, legacyPII)
 	}
-	cookies := dc.FilterCookies(r.Header.Get("Cookie"))
+	var cookies string
 	headers := make(map[string]string, len(r.Header)+1)
+	if dc.CollectCookies() {
+		rawCookie := r.Header.Get("Cookie")
+		cookies = dc.FilterCookies(rawCookie)
+		if cookies != "" {
+			headers["Cookie"] = cookies
+		}
+	}
 	for k, v := range r.Header {
 		if strings.EqualFold(k, "Cookie") {
 			continue
 		}
 		headers[k] = strings.Join(v, ",")
-	}
-	if rawCookie := r.Header.Get("Cookie"); rawCookie != "" {
-		if dc.CollectCookies() {
-			if cookies != "" {
-				headers["Cookie"] = cookies
-			} else {
-				headers["Cookie"] = filteredValue
-			}
-		}
 	}
 	headers["Host"] = r.Host
 	headers = dc.FilterRequestHeaders(headers)

--- a/interfaces.go
+++ b/interfaces.go
@@ -254,9 +254,16 @@ func newRequest(r *http.Request, client *Client) *Request {
 	}
 	url := fmt.Sprintf("%s://%s%s", prot, r.Host, r.URL.Path)
 
-	dc := snapshotDataCollection(nil, false)
+	legacyPII := false
+	if client != nil {
+		legacyPII = client.options.SendDefaultPII // nolint: staticcheck // intended use for backwards compatibility
+	}
+
+	var dc DataCollection
 	if client != nil && client.options.DataCollection != nil {
 		dc = *client.options.DataCollection
+	} else {
+		dc = snapshotDataCollection(nil, legacyPII)
 	}
 	cookies := dc.FilterCookies(r.Header.Get("Cookie"))
 	headers := make(map[string]string, len(r.Header)+1)

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -154,6 +154,24 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "malformed cookies are dropped",
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "/test/", nil)
+				r.Header.Add("Cookie", "debug; user_session=abc; =empty; theme=dark")
+				return r
+			},
+			want: &Request{
+				URL:     "http://example.com/test/",
+				Method:  "POST",
+				Cookies: "user_session=[Filtered]; theme=dark",
+				Headers: map[string]string{
+					"Cookie": "user_session=[Filtered]; theme=dark",
+					"Host":   "example.com",
+				},
+				Env: map[string]string{"REMOTE_ADDR": "192.0.2.1", "REMOTE_PORT": "1234"},
+			},
+		},
+		{
 			name: "off modes omit categories entirely",
 			dc: &DataCollection{
 				UserInfo: Set(false),

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -74,109 +75,169 @@ func TestUserMarshalJson(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
-	currentHub.BindClient(&Client{
-		options: ClientOptions{
-			SendDefaultPII: true,
-		},
-	})
-	// Unbind the client afterwards, to not affect other tests
-	defer currentHub.stackTop().SetClient(nil)
+	t.Parallel()
 
-	t.Run("standard request", func(t *testing.T) {
-		const payload = `{"test_data": true}`
-		r := httptest.NewRequest("POST", "/test/?q=sentry", strings.NewReader(payload))
-		r.Header.Add("Authorization", "Bearer 1234567890")
-		r.Header.Add("Proxy-Authorization", "Bearer 123")
-		r.Header.Add("Cookie", "foo=bar")
-		r.Header.Add("X-Forwarded-For", "127.0.0.1")
-		r.Header.Add("X-Real-Ip", "127.0.0.1")
-		r.Header.Add("Some-Header", "some-header value")
-
-		got := NewRequest(r)
-		want := &Request{
-			URL:         "http://example.com/test/",
-			Method:      "POST",
-			Data:        "",
-			QueryString: "q=sentry",
-			Cookies:     "foo=bar",
-			Headers: map[string]string{
-				"Authorization":       "Bearer 1234567890",
-				"Proxy-Authorization": "Bearer 123",
-				"Cookie":              "foo=bar",
-				"Host":                "example.com",
-				"X-Forwarded-For":     "127.0.0.1",
-				"X-Real-Ip":           "127.0.0.1",
-				"Some-Header":         "some-header value",
-			},
-			Env: map[string]string{
-				"REMOTE_ADDR": "192.0.2.1",
-				"REMOTE_PORT": "1234",
-			},
+	makeClient := func(t *testing.T, dc *DataCollection) *Client {
+		t.Helper()
+		if dc == nil {
+			dc = &DataCollection{}
 		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("Request mismatch (-want +got):\n%s", diff)
+		client, err := NewClient(ClientOptions{
+			Dsn:            "https://key@sentry.io/1",
+			DataCollection: dc,
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
-	})
-
-	t.Run("request with TLS", func(t *testing.T) {
-		r := httptest.NewRequest("POST", "https://example.com/test", nil)
-		r.TLS = &tls.ConnectionState{} // Simulate TLS connection
-
-		got := NewRequest(r)
-
-		if !strings.HasPrefix(got.URL, "https://") {
-			t.Errorf("Request with TLS should have HTTPS URL, got %s", got.URL)
-		}
-	})
-
-	t.Run("request with X-Forwarded-Proto header", func(t *testing.T) {
-		r := httptest.NewRequest("POST", "http://example.com/test", nil)
-		r.Header.Set("X-Forwarded-Proto", "https")
-
-		got := NewRequest(r)
-
-		if !strings.HasPrefix(got.URL, "https://") {
-			t.Errorf("Request with X-Forwarded-Proto: https should have HTTPS URL, got %s", got.URL)
-		}
-	})
-
-	t.Run("request with malformed RemoteAddr", func(t *testing.T) {
-		r := httptest.NewRequest("POST", "http://example.com/test", nil)
-		r.RemoteAddr = "malformed-address" // Invalid format
-
-		got := NewRequest(r)
-
-		if got.Env != nil {
-			t.Error("Request with malformed RemoteAddr should not set Env")
-		}
-	})
-}
-
-func TestNewRequestWithNoPII(t *testing.T) {
-	const payload = `{"test_data": true}`
-	r := httptest.NewRequest("POST", "/test/?q=sentry", strings.NewReader(payload))
-	r.Header.Add("Authorization", "Bearer 1234567890")
-	r.Header.Add("Proxy-Authorization", "Bearer 123")
-	r.Header.Add("Cookie", "foo=bar")
-	r.Header.Add("X-Forwarded-For", "127.0.0.1")
-	r.Header.Add("X-Real-Ip", "127.0.0.1")
-	r.Header.Add("Some-Header", "some-header value")
-
-	got := NewRequest(r)
-	want := &Request{
-		URL:         "http://example.com/test/",
-		Method:      "POST",
-		Data:        "",
-		QueryString: "q=sentry",
-		Cookies:     "",
-		Headers: map[string]string{
-			"Host":        "example.com",
-			"Some-Header": "some-header value",
-		},
-		Env: nil,
+		return client
 	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Request mismatch (-want +got):\n%s", diff)
+
+	tests := []struct {
+		name    string
+		dc      *DataCollection
+		makeReq func() *http.Request
+		want    *Request
+	}{
+		{
+			name: "default denylist filtering",
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "/test/?q=sentry", nil)
+				r.Header.Add("Authorization", "Bearer 1234567890")
+				r.Header.Add("Proxy-Authorization", "Bearer 123")
+				r.Header.Add("Cookie", "foo=bar")
+				r.Header.Add("X-Forwarded-For", "127.0.0.1")
+				r.Header.Add("X-Real-Ip", "127.0.0.1")
+				r.Header.Add("Some-Header", "some-header value")
+				return r
+			},
+			want: &Request{
+				URL:         "http://example.com/test/",
+				Method:      "POST",
+				QueryString: "q=sentry",
+				Cookies:     "foo=bar",
+				Headers: map[string]string{
+					"Authorization":       "[Filtered]",
+					"Proxy-Authorization": "[Filtered]",
+					"Cookie":              "foo=bar",
+					"Host":                "example.com",
+					"X-Forwarded-For":     "127.0.0.1",
+					"X-Real-Ip":           "127.0.0.1",
+					"Some-Header":         "some-header value",
+				},
+				Env: map[string]string{"REMOTE_ADDR": "192.0.2.1", "REMOTE_PORT": "1234"},
+			},
+		},
+		{
+			name: "user info disabled omits env",
+			dc:   &DataCollection{UserInfo: Set(false)},
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "/test/?token=abc123&page=5", nil)
+				r.Header.Add("Authorization", "Bearer 1234567890")
+				r.Header.Add("Cookie", "user_session=abc; theme=dark-mode")
+				r.Header.Add("X-Request-Id", "req-123")
+				r.Header.Add("Some-Header", "some-header value")
+				return r
+			},
+			want: &Request{
+				URL:         "http://example.com/test/",
+				Method:      "POST",
+				QueryString: "token=[Filtered]&page=5",
+				Cookies:     "user_session=[Filtered]; theme=dark-mode",
+				Headers: map[string]string{
+					"Authorization": "[Filtered]",
+					"Cookie":        "user_session=[Filtered]; theme=dark-mode",
+					"Host":          "example.com",
+					"Some-Header":   "some-header value",
+					"X-Request-Id":  "req-123",
+				},
+				Env: nil,
+			},
+		},
+		{
+			name: "off modes omit categories entirely",
+			dc: &DataCollection{
+				UserInfo: Set(false),
+				Cookies:  &KeyValueCollectionBehavior{Mode: CollectionOff},
+				HTTPHeaders: &HeaderCollectionConfig{
+					Request: &KeyValueCollectionBehavior{Mode: CollectionOff},
+				},
+				QueryParams: &KeyValueCollectionBehavior{Mode: CollectionOff},
+			},
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "/test/?token=abc123&page=5", nil)
+				r.Header.Add("Authorization", "Bearer 1234567890")
+				r.Header.Add("Cookie", "user_session=abc; theme=dark-mode")
+				r.Header.Add("X-Request-Id", "req-123")
+				r.Header.Add("Some-Header", "some-header value")
+				return r
+			},
+			want: &Request{
+				URL:     "http://example.com/test/",
+				Method:  "POST",
+				Headers: nil,
+				Env:     nil,
+			},
+		},
+		{
+			name: "TLS request uses https",
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "https://example.com/test", nil)
+				r.TLS = &tls.ConnectionState{}
+				return r
+			},
+			want: &Request{
+				URL:    "https://example.com/test",
+				Method: "POST",
+				Headers: map[string]string{
+					"Host": "example.com",
+				},
+				Env: map[string]string{"REMOTE_ADDR": "192.0.2.1", "REMOTE_PORT": "1234"},
+			},
+		},
+		{
+			name: "X-Forwarded-Proto header uses https",
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "http://example.com/test", nil)
+				r.Header.Set("X-Forwarded-Proto", "https")
+				return r
+			},
+			want: &Request{
+				URL:    "https://example.com/test",
+				Method: "POST",
+				Headers: map[string]string{
+					"Host":              "example.com",
+					"X-Forwarded-Proto": "https",
+				},
+				Env: map[string]string{"REMOTE_ADDR": "192.0.2.1", "REMOTE_PORT": "1234"},
+			},
+		},
+		{
+			name: "malformed RemoteAddr omits env",
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "http://example.com/test", nil)
+				r.RemoteAddr = "malformed-address"
+				return r
+			},
+			want: &Request{
+				URL:    "http://example.com/test",
+				Method: "POST",
+				Headers: map[string]string{
+					"Host": "example.com",
+				},
+				Env: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := makeClient(t, tt.dc)
+			got := newRequest(tt.makeReq(), client)
+			if diff := cmp.Diff(tt.want, got, testutils.EquateKeyValueStrings()); diff != "" {
+				t.Errorf("Request mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/testutils/cmp.go
+++ b/internal/testutils/cmp.go
@@ -1,0 +1,55 @@
+package testutils
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// EquateKeyValueStrings compares strings after normalizing key-value pair order.
+// It handles query strings ("a=1&b=2"), cookie strings ("a=1; b=2"), and
+// strings containing a URL query component such as span descriptions.
+func EquateKeyValueStrings() cmp.Option {
+	return cmp.Comparer(func(x, y string) bool {
+		return normalizeComparableString(x) == normalizeComparableString(y)
+	})
+}
+
+func normalizeComparableString(s string) string {
+	return normalizeURLQuery(normalizeKeyValueString(normalizeKeyValueString(s, "&"), ";"))
+}
+
+func normalizeURLQuery(s string) string {
+	beforeQuery, rest, ok := strings.Cut(s, "?")
+	if !ok {
+		return s
+	}
+	query, fragment, hasFragment := strings.Cut(rest, "#")
+	normalized := beforeQuery + "?" + normalizeKeyValueString(query, "&")
+	if hasFragment {
+		normalized += "#" + fragment
+	}
+	return normalized
+}
+
+func normalizeKeyValueString(s, separator string) string {
+	parts := strings.Split(s, separator)
+	if len(parts) < 2 {
+		return s
+	}
+
+	trimmed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return s
+		}
+		if !strings.Contains(part, "=") {
+			return s
+		}
+		trimmed = append(trimmed, part)
+	}
+	sort.Strings(trimmed)
+	return strings.Join(trimmed, separator)
+}

--- a/iris/sentryiris_test.go
+++ b/iris/sentryiris_test.go
@@ -27,6 +27,7 @@ func TestIntegration(t *testing.T) {
 		Method      string
 		WantStatus  int
 		Body        string
+		ContentType string
 		Handler     iris.Handler
 
 		WantEvent       *sentry.Event
@@ -106,7 +107,8 @@ func TestIntegration(t *testing.T) {
 			RoutePath:   "/post",
 			Method:      "POST",
 			WantStatus:  200,
-			Body:        "payload",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
 			Handler: func(ctx iris.Context) {
 				hub := sentryiris.GetHubFromContext(ctx)
 				body, err := io.ReadAll(ctx.Request().Body)
@@ -124,9 +126,10 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"Accept-Encoding": "gzip",
 						"User-Agent":      "Go-http-client/1.1",
 					},
@@ -145,14 +148,15 @@ func TestIntegration(t *testing.T) {
 			},
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -356,6 +360,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
@@ -406,6 +411,9 @@ func TestIntegration(t *testing.T) {
 
 		if len(tt.Body) > 0 {
 			reqHeaders["Content-Length"] = strconv.Itoa(len(tt.Body))
+		}
+		if tt.ContentType != "" {
+			reqHeaders["Content-Type"] = tt.ContentType
 		}
 
 		res := srv.Request(tt.Method, tt.RequestPath).

--- a/negroni/sentrynegroni_test.go
+++ b/negroni/sentrynegroni_test.go
@@ -21,10 +21,11 @@ func TestIntegration(t *testing.T) {
 	largePayload := strings.Repeat("Large", 3*1024) // 15 KB
 
 	tests := []struct {
-		Path    string
-		Method  string
-		Body    string
-		Handler http.Handler
+		Path        string
+		Method      string
+		Body        string
+		ContentType string
+		Handler     http.Handler
 
 		WantStatus      int
 		WantEvent       *sentry.Event
@@ -75,9 +76,10 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
-			Path:   "/post",
-			Method: "POST",
-			Body:   "payload",
+			Path:        "/post",
+			Method:      "POST",
+			Body:        `{"safe":"value"}`,
+			ContentType: "application/json",
 			Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				hub := sentry.GetHubFromContext(r.Context())
 				body, err := io.ReadAll(r.Body)
@@ -90,14 +92,15 @@ func TestIntegration(t *testing.T) {
 			WantStatus: http.StatusOK,
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelInfo,
-				Message: "post: payload",
+				Message: `post: {"safe":"value"}`,
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -109,10 +112,11 @@ func TestIntegration(t *testing.T) {
 				Request: &sentry.Request{
 					URL:    "/post",
 					Method: "POST",
-					Data:   "payload",
+					Data:   `{"safe":"value"}`,
 					Headers: map[string]string{
 						"Accept-Encoding": "gzip",
-						"Content-Length":  "7",
+						"Content-Length":  "16",
+						"Content-Type":    "application/json",
 						"User-Agent":      "Go-http-client/1.1",
 					},
 				},
@@ -287,6 +291,7 @@ func TestIntegration(t *testing.T) {
 	err := sentry.Init(sentry.ClientOptions{
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			eventsCh <- event
 			return event
@@ -339,6 +344,9 @@ func TestIntegration(t *testing.T) {
 		req, err := http.NewRequest(tt.Method, srv.URL+tt.Path, strings.NewReader(tt.Body))
 		if err != nil {
 			t.Fatal(err)
+		}
+		if tt.ContentType != "" {
+			req.Header.Set("Content-Type", tt.ContentType)
 		}
 		res, err := c.Do(req)
 		if err != nil {

--- a/scope.go
+++ b/scope.go
@@ -411,7 +411,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 	}
 
 	if event.Request == nil && scope.request != nil {
-		event.Request = newRequest(scope.request, sendDefaultPIIEnabled(client))
+		event.Request = newRequest(scope.request, client)
 		// NOTE: The SDK does not attempt to send partial request body data.
 		//
 		// The reason being that Sentry's ingest pipeline and UI are optimized
@@ -421,8 +421,9 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		//
 		// Users can still send more data along their events if they want to,
 		// for example using Event.Contexts.
-		if scope.requestBody != nil && !scope.requestBody.Overflow() {
-			event.Request.Data = string(scope.requestBody.Bytes())
+		dc := client.GetDataCollection()
+		if scope.requestBody != nil && !scope.requestBody.Overflow() && dc.CollectHTTPBody(BodyIncomingRequest) {
+			event.Request.Data = dc.FilterHTTPBody(scope.requestBody.Bytes(), scope.request.Header.Get("Content-Type"))
 		}
 	}
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go/attribute"
+	"github.com/getsentry/sentry-go/internal/testutils"
+	"github.com/google/go-cmp/cmp"
 )
 
 const sharedContextsKey = "sharedContextsKey"
@@ -649,11 +651,11 @@ func TestApplyToEventUsingEmptyEvent(t *testing.T) {
 
 func TestApplyToEventUsesClientPIISettingsForRequest(t *testing.T) {
 	previousClient := currentHub.Client()
-	currentHub.BindClient(&Client{
-		options: ClientOptions{
-			SendDefaultPII: true,
-		},
-	})
+	currentClient, err := NewClient(ClientOptions{Dsn: "https://key@sentry.io/1", SendDefaultPII: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentHub.BindClient(currentClient)
 	defer currentHub.BindClient(previousClient)
 
 	scope := NewScope()
@@ -663,11 +665,17 @@ func TestApplyToEventUsesClientPIISettingsForRequest(t *testing.T) {
 	request.Header.Set("Some-Header", "some-header value")
 	scope.SetRequest(request)
 
-	event := scope.ApplyToEvent(NewEvent(), nil, &Client{
-		options: ClientOptions{
-			SendDefaultPII: false,
+	requestClient, err := NewClient(ClientOptions{
+		Dsn: "https://key@sentry.io/1",
+		DataCollection: &DataCollection{
+			UserInfo: Set(false),
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := scope.ApplyToEvent(NewEvent(), nil, requestClient)
 
 	if event.Request == nil {
 		t.Fatal("expected request to be attached")
@@ -677,13 +685,98 @@ func TestApplyToEventUsesClientPIISettingsForRequest(t *testing.T) {
 		URL:         "http://example.com/test",
 		Method:      "POST",
 		QueryString: "",
+		Cookies:     "foo=bar",
 		Headers: map[string]string{
-			"Host":        "example.com",
-			"Some-Header": "some-header value",
+			"Authorization": "[Filtered]",
+			"Cookie":        "foo=bar",
+			"Host":          "example.com",
+			"Some-Header":   "some-header value",
+		},
+		Env: nil,
+	}
+
+	assertEqual(t, event.Request, want, "should honor the passed client data collection setting")
+}
+
+func TestApplyToEventUsesExplicitDataCollectionForRequest(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		Dsn: "https://key@sentry.io/1",
+		DataCollection: &DataCollection{
+			UserInfo: Set(false),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scope := NewScope()
+	request := httptest.NewRequest("POST", "http://example.com/test?token=secret&page=5", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	request.Header.Set("Cookie", "user_session=abc; theme=dark")
+	request.Header.Set("Some-Header", "some-header value")
+	scope.SetRequest(request)
+
+	event := scope.ApplyToEvent(NewEvent(), nil, client)
+	if event.Request == nil {
+		t.Fatal("expected request to be attached")
+	}
+
+	want := &Request{
+		URL:         "http://example.com/test",
+		Method:      "POST",
+		QueryString: "token=[Filtered]&page=5",
+		Cookies:     "user_session=[Filtered]; theme=dark",
+		Headers: map[string]string{
+			"Authorization": "[Filtered]",
+			"Cookie":        "user_session=[Filtered]; theme=dark",
+			"Host":          "example.com",
+			"Some-Header":   "some-header value",
 		},
 	}
 
-	assertEqual(t, event.Request, want, "should honor the request-scoped client PII setting")
+	if diff := cmp.Diff(want, event.Request, testutils.EquateKeyValueStrings()); diff != "" {
+		t.Errorf("request mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestApplyToEventHTTPBodyCollection(t *testing.T) {
+	tests := []struct {
+		name     string
+		bodies   []BodyType
+		body     []byte
+		wantData string
+	}{
+		{name: "default collects and filters incoming request body", bodies: nil, body: []byte(`{"key":"value","safe":"value"}`), wantData: `{"key":"[Filtered]","safe":"value"}`},
+		{name: "empty disables request body", bodies: []BodyType{}, body: []byte(`{"key":"value"}`), wantData: ""},
+		{name: "incoming request enabled", bodies: []BodyType{BodyIncomingRequest}, body: []byte(`{"safe":"value"}`), wantData: `{"safe":"value"}`},
+		{name: "other body type does not collect request body", bodies: []BodyType{BodyOutgoingRequest}, body: []byte(`{"key":"value"}`), wantData: ""},
+		{name: "opaque body is filtered entirely", bodies: nil, body: []byte(`raw body`), wantData: filteredValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(ClientOptions{
+				Dsn:            "https://key@sentry.io/1",
+				DataCollection: &DataCollection{HTTPBodies: tt.bodies},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			scope := NewScope()
+			request := httptest.NewRequest("POST", "http://example.com/test", nil)
+			scope.SetRequest(request)
+			scope.SetRequestBody(tt.body)
+
+			event := scope.ApplyToEvent(NewEvent(), nil, client)
+			if event.Request == nil {
+				t.Fatal("expected request to be attached")
+			}
+			if diff := cmp.Diff(tt.wantData, event.Request.Data); diff != "" {
+				t.Errorf("request body mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestEventProcessorsModifiesEvent(t *testing.T) {


### PR DESCRIPTION
### Description
This adds the sensitive data collection filters to all HTTP integrations. It includes correctly filtering raw request bodies, which propagates to the payload changes for all framework tests.

#skip-changelog

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
