### PR TITLE
fix: preserve literal '%' in non-format log messages

### DIFF
--- a/log.go
+++ b/log.go
@@ -138,11 +138,13 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		attrs[k] = v
 	}
 
+	body := message
 	if len(args) > 0 {
 		attrs["sentry.message.template"] = attribute.StringValue(message)
 		for i, p := range args {
 			attrs[fmt.Sprintf("sentry.message.parameters.%d", i)] = attribute.StringValue(fmt.Sprintf("%+v", p))
 		}
+		body = fmt.Sprintf(message, args...)
 	}
 
 	log := &Log{
@@ -151,14 +153,14 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		SpanID:     spanID,
 		Level:      level,
 		Severity:   severity,
-		Body:       fmt.Sprintf(message, args...),
+		Body:       body,
 		Attributes: attrs,
 	}
 	log.approximateSize = computeLogSize(log)
 
 	client.captureLog(log, scope)
 	if client.options.Debug {
-		debuglog.Printf(message, args...)
+		debuglog.Println(body)
 	}
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -432,6 +432,61 @@ func Test_sentryLogger_Write(t *testing.T) {
 	}
 }
 
+func Test_sentryLogger_EmitPreservesLiteralPercent(t *testing.T) {
+	// Emit and Write are the non-format logging methods, so a literal '%' in
+	// the message must be preserved verbatim instead of being interpreted as a
+	// fmt verb.
+	tests := []struct {
+		name     string
+		logFunc  func(ctx context.Context, l Logger)
+		wantBody string
+	}{
+		{
+			name: "Emit with single percent",
+			logFunc: func(ctx context.Context, l Logger) {
+				l.Info().WithCtx(ctx).Emit("disk usage at 95% capacity")
+			},
+			wantBody: "disk usage at 95% capacity",
+		},
+		{
+			name: "Emit with format-like verbs",
+			logFunc: func(ctx context.Context, l Logger) {
+				l.Warn().WithCtx(ctx).Emit("got %s and %d, 100% done")
+			},
+			wantBody: "got %s and %d, 100% done",
+		},
+		{
+			name: "Write with percent",
+			logFunc: func(_ context.Context, l Logger) {
+				if _, err := l.Write([]byte("progress 50% complete\n")); err != nil {
+					t.Errorf("Write returned unexpected error: %v", err)
+				}
+			},
+			wantBody: "progress 50% complete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, mockTransport := setupMockTransport()
+			l := NewLogger(ctx)
+			tt.logFunc(ctx, l)
+			flushFromContext(ctx, testutils.FlushTimeout())
+
+			gotEvents := mockTransport.Events()
+			if len(gotEvents) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(gotEvents))
+			}
+			if len(gotEvents[0].Logs) != 1 {
+				t.Fatalf("expected 1 log, got %d", len(gotEvents[0].Logs))
+			}
+			if got := gotEvents[0].Logs[0].Body; got != tt.wantBody {
+				t.Errorf("Body mismatch: got %q, want %q", got, tt.wantBody)
+			}
+		})
+	}
+}
+
 func Test_sentryLogger_FlushAttributesAfterSend(t *testing.T) {
 	msg := []byte("something")
 	ctx, mockTransport := setupMockTransport()


### PR DESCRIPTION
The structured logger formats every log body with `fmt.Sprintf(message, args...)` in `(*sentryLogger).log`, including the non-format methods. `Emit` builds its message with `fmt.Sprint(args...)` and calls `log` with no remaining args, and `Write` goes through `Emit`, so a literal `%` in those messages is treated as a format verb.

```go
l.Info().Emit("disk usage at 95% capacity")
// Body: "disk usage at 95%!c(MISSING)apacity"
```

This also affects messages routed through the logging integrations, which forward the user's message via `Emit(...)` with no args (e.g. `slog`, `logrus`, `zap`).

Only run `fmt.Sprintf` when there are args; otherwise use the message as-is. The same resolved body is used for the debug logger output.

Added `Test_sentryLogger_EmitPreservesLiteralPercent` covering `Emit`, `Write`, and a message with format-like verbs. It fails before the change and passes after.

Tested: `go test -race .`, `go vet .`, `gofmt -s`, and `golangci-lint run ./` all clean.