### PR TITLE
feat: PushScope shorthand now returns the new scope reference

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -101,9 +101,9 @@ func ConfigureScope(f func(scope *Scope)) {
 }
 
 // PushScope is a shorthand for CurrentHub().PushScope.
-func PushScope() {
+func PushScope() *Scope {
 	hub := CurrentHub()
-	hub.PushScope()
+	return hub.PushScope()
 }
 
 // PopScope is a shorthand for CurrentHub().PopScope.

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -1,0 +1,16 @@
+package sentry
+
+import (
+	"testing"
+)
+
+func TestPushScopeReturnsCurrentScope(t *testing.T) {
+	initialScope := CurrentHub().Scope()
+	pushedScope := PushScope()
+	defer PopScope()
+
+	pushedScope.SetTag("foo", "bar")
+
+	assertEqual(t, initialScope.tags["foo"], "")
+	assertEqual(t, pushedScope.tags["foo"], "bar")
+}


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The [documentation](https://pkg.go.dev/github.com/getsentry/sentry-go#PushScope) says `PushScope` is a shorthand for `CurrentHub().PushScope`. However, so far, `PushScope` returned nothing while `CurrentHub().PushScope` returned the pushed `Scope`.

This PR updates `sentry.PushScope` to forward the return value from `CurrentHub().PushScope`, so that the shorthand behaves the same as the written-out variant. This aligns with the implementation of other shorthands, such as `FlushWithContext` and `LastEventID`.