### PR TITLE
fix(scope): deep-copy event processors when cloning a scope

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -346,7 +346,10 @@ func (scope *Scope) Clone() *Scope {
 	clone.level = scope.level
 	clone.request = scope.request
 	clone.requestBody = scope.requestBody
-	clone.eventProcessors = scope.eventProcessors
+	if scope.eventProcessors != nil {
+		clone.eventProcessors = make([]EventProcessor, len(scope.eventProcessors))
+		copy(clone.eventProcessors, scope.eventProcessors)
+	}
 	clone.propagationContext = scope.propagationContext
 	clone.span = scope.span
 	return clone

--- a/scope_test.go
+++ b/scope_test.go
@@ -368,7 +368,10 @@ func TestScopeBasicInheritance(t *testing.T) {
 
 	assertEqual(t, scope.attributes, clone.attributes)
 	assertEqual(t, scope.requestBody, clone.requestBody)
-	assertEqual(t, scope.eventProcessors, clone.eventProcessors)
+	// Event processors are function values, which reflect.DeepEqual can only
+	// compare by identity through a shared backing array; compare the count
+	// instead so the clone keeps its own slice (see Clone).
+	assertEqual(t, len(scope.eventProcessors), len(clone.eventProcessors))
 }
 
 func TestScopeParentChangedInheritance(t *testing.T) {
@@ -501,6 +504,41 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 
 	assertEqual(t, len(scope.eventProcessors), 1)
 	assertEqual(t, len(clone.eventProcessors), 2)
+}
+
+func TestScopeCloneEventProcessorsIsolation(t *testing.T) {
+	var ran []string
+	mark := func(id string) EventProcessor {
+		return func(event *Event, _ *EventHint) *Event {
+			ran = append(ran, id)
+			return event
+		}
+	}
+
+	// Three processors give the parent's slice spare capacity (len 3, cap 4),
+	// which clones used to share, so appending to one clone overwrote the
+	// other clone's appended processor through the shared backing array.
+	scope := NewScope()
+	scope.AddEventProcessor(mark("a"))
+	scope.AddEventProcessor(mark("b"))
+	scope.AddEventProcessor(mark("c"))
+
+	clone1 := scope.Clone()
+	clone2 := scope.Clone()
+	clone1.AddEventProcessor(mark("x"))
+	clone2.AddEventProcessor(mark("y"))
+
+	ran = nil
+	clone1.ApplyToEvent(NewEvent(), nil, nil)
+	assertEqual(t, []string{"a", "b", "c", "x"}, ran)
+
+	ran = nil
+	clone2.ApplyToEvent(NewEvent(), nil, nil)
+	assertEqual(t, []string{"a", "b", "c", "y"}, ran)
+
+	ran = nil
+	scope.ApplyToEvent(NewEvent(), nil, nil)
+	assertEqual(t, []string{"a", "b", "c"}, ran)
 }
 
 func TestClear(t *testing.T) {


### PR DESCRIPTION
### Description

`Scope.Clone()` deep-copies every slice field (breadcrumbs, attachments, fingerprint) except `eventProcessors`, which shares the original's backing array:

```go
clone.eventProcessors = scope.eventProcessors
```

This was changed to a shared slice in #349, on the reasoning that "`Scope.AddEventProcessor` always creates a new slice, so we can share the backing array." That only holds when the slice has no spare capacity. `AddEventProcessor` appends, and `append` reuses the backing array while `len < cap`, so two clones of a scope that already has spare capacity write the same slot:

```
parent: 3 processors -> len 3, cap 4 (spare)
clone1 := parent.Clone(); clone2 := parent.Clone()  // both share the backing array
clone1.AddEventProcessor(x)  // writes backing[3]
clone2.AddEventProcessor(y)  // overwrites backing[3]; clone1 now runs y
```

Hubs/Scopes are cloned per request, so two goroutines cloning the same scope and adding a processor also race on that slot. `go test -race` on `master`:

```
WARNING: DATA RACE
Write at 0x... by goroutine 9:   scope.go:365   (append in AddEventProcessor)
Previous write at 0x... by goroutine 10: scope.go:365
```

Fix: copy the slice like the other fields (the `nil` guard keeps an unset processor list `nil` rather than an empty slice). `TestScopeCloneEventProcessorsIsolation` fails before this change and passes after. One assertion in `TestScopeBasicInheritance` compared the two processor slices with `assertEqual`; that only passed because `reflect.DeepEqual` short-circuits when two slices share a backing pointer (function values are otherwise never equal), so it now compares the count.

Tested with `go test -race ./` and `golangci-lint run ./`.
