### PR TITLE
fix: isolate event processor across clones

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -346,7 +346,7 @@ func (scope *Scope) Clone() *Scope {
 	clone.level = scope.level
 	clone.request = scope.request
 	clone.requestBody = scope.requestBody
-	clone.eventProcessors = scope.eventProcessors
+	clone.eventProcessors = scope.eventProcessors[:len(scope.eventProcessors):len(scope.eventProcessors)]
 	clone.propagationContext = scope.propagationContext
 	clone.span = scope.span
 	return clone

--- a/scope_test.go
+++ b/scope_test.go
@@ -429,6 +429,38 @@ func TestScopeParentChangedInheritance(t *testing.T) {
 	assertEqual(t, s2, scope.GetSpan())
 }
 
+func TestScopeCloneEventProcessorsIsolation(t *testing.T) {
+	var ran []string
+	mark := func(id string) EventProcessor {
+		return func(event *Event, _ *EventHint) *Event {
+			ran = append(ran, id)
+			return event
+		}
+	}
+
+	scope := NewScope()
+	scope.AddEventProcessor(mark("a"))
+	scope.AddEventProcessor(mark("b"))
+	scope.AddEventProcessor(mark("c"))
+
+	clone1 := scope.Clone()
+	clone2 := scope.Clone()
+	clone1.AddEventProcessor(mark("x"))
+	clone2.AddEventProcessor(mark("y"))
+
+	ran = nil
+	clone1.ApplyToEvent(NewEvent(), nil, nil)
+	assertEqual(t, []string{"a", "b", "c", "x"}, ran)
+
+	ran = nil
+	clone2.ApplyToEvent(NewEvent(), nil, nil)
+	assertEqual(t, []string{"a", "b", "c", "y"}, ran)
+
+	ran = nil
+	scope.ApplyToEvent(NewEvent(), nil, nil)
+	assertEqual(t, []string{"a", "b", "c"}, ran)
+}
+
 func TestScopeChildOverrideInheritance(t *testing.T) {
 	scope := NewScope()
 


### PR DESCRIPTION
### Description

This fixes a bug where registering event processors on the same backing array would write to the same slot. The event processors are append-only, so we can still keep sharing the same backing array, but to avoid the bug we can limit the capacity to the array length, so that we always allocate a fresh backing array. This is more efficient than clone, since additions are infrequent compared to scope clones.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
