### PR TITLE
ref: move limited buffer under utils

### DIFF
--- a/internal/httputils/body.go
+++ b/internal/httputils/body.go
@@ -1,0 +1,78 @@
+package httputils
+
+import (
+	"bytes"
+	"io"
+)
+
+// MaxBodyBytes is the maximum number of bytes the SDK captures from an HTTP
+// body for attaching to events or spans. Bodies larger than this are dropped
+// rather than truncated, to avoid invalid partial structured payloads.
+const MaxBodyBytes = 10 * 1024
+
+// ReadCloser combines an io.Reader and an io.Closer to implement io.ReadCloser.
+type ReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// LimitedBuffer is like a bytes.Buffer, but limited to store at most Capacity
+// bytes. Any writes past the capacity are silently discarded, similar to
+// io.Discard.
+type LimitedBuffer struct {
+	Capacity int
+
+	bytes.Buffer
+	overflow bool
+}
+
+// NewLimitedBuffer returns a LimitedBuffer with the given capacity.
+func NewLimitedBuffer(capacity int) *LimitedBuffer {
+	return &LimitedBuffer{Capacity: capacity}
+}
+
+// NewLimitedBufferFromBytes returns a LimitedBuffer initialized from b.
+func NewLimitedBufferFromBytes(capacity int, b []byte) *LimitedBuffer {
+	buf := NewLimitedBuffer(capacity)
+	if len(b) > capacity {
+		buf.overflow = true
+		b = b[:capacity]
+	}
+	buf.Buffer = *bytes.NewBuffer(b)
+	return buf
+}
+
+// Write implements io.Writer.
+func (b *LimitedBuffer) Write(p []byte) (n int, err error) {
+	originalLen := len(p)
+	if b.overflow {
+		return originalLen, nil
+	}
+	left := b.Capacity - b.Len()
+	if left < 0 {
+		left = 0
+	}
+	if len(p) > left {
+		b.overflow = true
+		p = p[:left]
+	}
+	_, err = b.Buffer.Write(p)
+	return originalLen, err
+}
+
+// Overflow returns true if the LimitedBuffer discarded bytes written to it.
+func (b *LimitedBuffer) Overflow() bool {
+	return b.overflow
+}
+
+// ReadBody reads up to MaxBodyBytes from r and returns the bytes read.
+func ReadBody(r io.Reader) []byte {
+	if r == nil {
+		return nil
+	}
+	data, err := io.ReadAll(io.LimitReader(r, MaxBodyBytes+1))
+	if err != nil || len(data) == 0 || len(data) > MaxBodyBytes {
+		return nil
+	}
+	return data
+}

--- a/internal/httputils/body_test.go
+++ b/internal/httputils/body_test.go
@@ -1,0 +1,80 @@
+package httputils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func TestReadBody(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader io.Reader
+		want   []byte
+	}{
+		{name: "nil reader", reader: nil, want: nil},
+		{name: "empty reader", reader: strings.NewReader(""), want: nil},
+		{name: "small body", reader: strings.NewReader("hello"), want: []byte("hello")},
+		{name: "at limit", reader: bytes.NewReader(bytes.Repeat([]byte("a"), MaxBodyBytes)), want: bytes.Repeat([]byte("a"), MaxBodyBytes)},
+		{name: "oversized body dropped", reader: bytes.NewReader(bytes.Repeat([]byte("a"), MaxBodyBytes+1)), want: nil},
+		{name: "read error dropped", reader: iotest.ErrReader(errors.New("boom")), want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReadBody(tt.reader)
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("ReadBody len=%d, want len=%d", len(got), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestLimitedBuffer(t *testing.T) {
+	t.Run("stores bytes within capacity", func(t *testing.T) {
+		buf := NewLimitedBuffer(5)
+		n, err := buf.Write([]byte("hello"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 5 {
+			t.Fatalf("Write returned %d, want 5", n)
+		}
+		if got := string(buf.Bytes()); got != "hello" {
+			t.Fatalf("Bytes = %q, want %q", got, "hello")
+		}
+		if buf.Overflow() {
+			t.Fatal("Overflow = true, want false")
+		}
+	})
+
+	t.Run("drops bytes after capacity", func(t *testing.T) {
+		buf := NewLimitedBuffer(5)
+		n, err := buf.Write([]byte("hello world"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != len("hello world") {
+			t.Fatalf("Write returned %d, want %d", n, len("hello world"))
+		}
+		if got := string(buf.Bytes()); got != "hello" {
+			t.Fatalf("Bytes = %q, want %q", got, "hello")
+		}
+		if !buf.Overflow() {
+			t.Fatal("Overflow = false, want true")
+		}
+	})
+
+	t.Run("initial bytes mark overflow", func(t *testing.T) {
+		buf := NewLimitedBufferFromBytes(5, []byte("hello world"))
+		if got := string(buf.Bytes()); got != "hello" {
+			t.Fatalf("Bytes = %q, want %q", got, "hello")
+		}
+		if !buf.Overflow() {
+			t.Fatal("Overflow = false, want true")
+		}
+	})
+}

--- a/internal/httputils/body_test.go
+++ b/internal/httputils/body_test.go
@@ -43,7 +43,7 @@ func TestLimitedBuffer(t *testing.T) {
 		if n != 5 {
 			t.Fatalf("Write returned %d, want 5", n)
 		}
-		if got := string(buf.Bytes()); got != "hello" {
+		if got := buf.String(); got != "hello" {
 			t.Fatalf("Bytes = %q, want %q", got, "hello")
 		}
 		if buf.Overflow() {
@@ -60,7 +60,7 @@ func TestLimitedBuffer(t *testing.T) {
 		if n != len("hello world") {
 			t.Fatalf("Write returned %d, want %d", n, len("hello world"))
 		}
-		if got := string(buf.Bytes()); got != "hello" {
+		if got := buf.String(); got != "hello" {
 			t.Fatalf("Bytes = %q, want %q", got, "hello")
 		}
 		if !buf.Overflow() {
@@ -70,7 +70,7 @@ func TestLimitedBuffer(t *testing.T) {
 
 	t.Run("initial bytes mark overflow", func(t *testing.T) {
 		buf := NewLimitedBufferFromBytes(5, []byte("hello world"))
-		if got := string(buf.Bytes()); got != "hello" {
+		if got := buf.String(); got != "hello" {
 			t.Fatalf("Bytes = %q, want %q", got, "hello")
 		}
 		if !buf.Overflow() {

--- a/scope.go
+++ b/scope.go
@@ -1,7 +1,6 @@
 package sentry
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"maps"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/getsentry/sentry-go/attribute"
 	"github.com/getsentry/sentry-go/internal/debuglog"
+	"github.com/getsentry/sentry-go/internal/httputils"
 	"github.com/getsentry/sentry-go/internal/ratelimit"
 	"github.com/getsentry/sentry-go/report"
 )
@@ -128,15 +128,15 @@ func (scope *Scope) SetRequest(r *http.Request) {
 	}
 
 	// Don't buffer request body if we know it is oversized.
-	if r.ContentLength > maxRequestBodyBytes {
+	if r.ContentLength > httputils.MaxBodyBytes {
 		return
 	}
 	// Don't buffer if there is no body.
 	if r.Body == nil || r.Body == http.NoBody {
 		return
 	}
-	buf := &limitedBuffer{Capacity: maxRequestBodyBytes}
-	r.Body = readCloser{
+	buf := httputils.NewLimitedBuffer(httputils.MaxBodyBytes)
+	r.Body = httputils.ReadCloser{
 		Reader: io.TeeReader(r.Body, buf),
 		Closer: r.Body,
 	}
@@ -152,59 +152,7 @@ func (scope *Scope) SetRequestBody(b []byte) {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
-	capacity := maxRequestBodyBytes
-	overflow := false
-	if len(b) > capacity {
-		overflow = true
-		b = b[:capacity]
-	}
-	scope.requestBody = &limitedBuffer{
-		Capacity: capacity,
-		Buffer:   *bytes.NewBuffer(b),
-		overflow: overflow,
-	}
-}
-
-// maxRequestBodyBytes is the default maximum request body size to send to
-// Sentry.
-const maxRequestBodyBytes = 10 * 1024
-
-// A limitedBuffer is like a bytes.Buffer, but limited to store at most Capacity
-// bytes. Any writes past the capacity are silently discarded, similar to
-// io.Discard.
-type limitedBuffer struct {
-	Capacity int
-
-	bytes.Buffer
-	overflow bool
-}
-
-// Write implements io.Writer.
-func (b *limitedBuffer) Write(p []byte) (n int, err error) {
-	// Silently ignore writes after overflow.
-	if b.overflow {
-		return len(p), nil
-	}
-	left := b.Capacity - b.Len()
-	if left < 0 {
-		left = 0
-	}
-	if len(p) > left {
-		b.overflow = true
-		p = p[:left]
-	}
-	return b.Buffer.Write(p)
-}
-
-// Overflow returns true if the limitedBuffer discarded bytes written to it.
-func (b *limitedBuffer) Overflow() bool {
-	return b.overflow
-}
-
-// readCloser combines an io.Reader and an io.Closer to implement io.ReadCloser.
-type readCloser struct {
-	io.Reader
-	io.Closer
+	scope.requestBody = httputils.NewLimitedBufferFromBytes(httputils.MaxBodyBytes, b)
 }
 
 // SetAttributes adds attributes to the current scope.


### PR DESCRIPTION
### Description
This moves the limited buffer under httputils, to keep body parsing behavior consistent.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
