### PR TITLE
feat: parse request body for outgoing http

### DIFF
--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -139,6 +139,31 @@ func (dc DataCollection) FilterCookies(rawCookies string) string {
 	return strings.Join(parts, "; ")
 }
 
+// FilterSetCookie applies the configured cookie collection behavior to a
+// single Set-Cookie header value.
+//
+// Multiple Set-Cookie headers must be filtered individually, never joined
+// beforehand.
+func (dc DataCollection) FilterSetCookie(setCookie string) string {
+	if !dc.CollectCookies() {
+		return ""
+	}
+	nameValue, attributes, hasAttributes := strings.Cut(setCookie, ";")
+	name, value, ok := strings.Cut(nameValue, "=")
+	name = strings.TrimSpace(name)
+	if !ok || name == "" {
+		return ""
+	}
+	if dc.shouldFilterKey(name, dc.Cookies) {
+		value = filteredValue
+	}
+	filtered := name + "=" + value
+	if hasAttributes {
+		filtered += ";" + attributes
+	}
+	return filtered
+}
+
 // FilterHTTPBody applies sensitive-key filtering to parseable HTTP body data.
 // Opaque raw bodies are replaced entirely.
 func (dc DataCollection) FilterHTTPBody(body []byte, contentType string) string {

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -145,8 +145,8 @@ func (dc DataCollection) FilterSetCookie(setCookie string) string {
 	if !dc.CollectCookies() {
 		return ""
 	}
-	nameValue, attributes, hasAttributes := strings.Cut(setCookie, ";")
-	name, value, ok := strings.Cut(nameValue, "=")
+	parts := strings.Split(setCookie, ";")
+	name, value, ok := strings.Cut(parts[0], "=")
 	name = strings.TrimSpace(name)
 	if !ok || name == "" {
 		return ""
@@ -154,11 +154,19 @@ func (dc DataCollection) FilterSetCookie(setCookie string) string {
 	if dc.shouldFilterKey(name, dc.Cookies) {
 		value = filteredValue
 	}
-	filtered := name + "=" + value
-	if hasAttributes {
-		filtered += ";" + attributes
+	parts[0] = name + "=" + value
+
+	for i := 1; i < len(parts); i++ {
+		attribute, _, ok := strings.Cut(parts[i], "=")
+		if !ok {
+			continue
+		}
+		if name := strings.TrimSpace(attribute); name != "" && dc.shouldFilterKey(name, dc.Cookies) {
+			parts[i] = attribute + "=" + filteredValue
+		}
 	}
-	return filtered
+
+	return strings.Join(parts, ";")
 }
 
 // FilterHTTPBody applies sensitive-key filtering to parseable HTTP body data.

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -187,6 +187,11 @@ func (dc DataCollection) filterURLValues(values url.Values, behavior *KeyValueCo
 }
 
 func (dc DataCollection) filterJSONValue(value any, behavior *KeyValueCollectionBehavior) any {
+	return dc.filterJSONNode(value, behavior, false)
+}
+
+// filterJSONNode recursively filters a decoded JSON value.
+func (dc DataCollection) filterJSONNode(value any, behavior *KeyValueCollectionBehavior, keyed bool) any {
 	if behavior != nil && behavior.Mode == CollectionOff {
 		return nil
 	}
@@ -198,17 +203,20 @@ func (dc DataCollection) filterJSONValue(value any, behavior *KeyValueCollection
 			if dc.shouldFilterKey(key, behavior) {
 				filtered[key] = filteredValue
 			} else {
-				filtered[key] = dc.filterJSONValue(child, behavior)
+				filtered[key] = dc.filterJSONNode(child, behavior, true)
 			}
 		}
 		return filtered
 	case []any:
 		filtered := make([]any, len(value))
 		for i, child := range value {
-			filtered[i] = dc.filterJSONValue(child, behavior)
+			filtered[i] = dc.filterJSONNode(child, behavior, keyed)
 		}
 		return filtered
 	default:
+		if !keyed {
+			return filteredValue
+		}
 		return value
 	}
 }

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -116,11 +116,8 @@ func (dc DataCollection) FilterURL(u *url.URL) string {
 }
 
 // FilterCookies applies the configured cookie collection behavior.
-func (dc DataCollection) FilterCookies(rawCookies string) string {
-	if rawCookies == "" {
-		return ""
-	}
-	parsed := parseKeyValueString(rawCookies, ';')
+func (dc DataCollection) FilterCookies(values []string) string {
+	parsed := parseKeyValueStrings(values, ';')
 	if len(parsed) == 0 {
 		return ""
 	}
@@ -136,12 +133,19 @@ func (dc DataCollection) FilterCookies(rawCookies string) string {
 	return strings.Join(parts, "; ")
 }
 
-// FilterSetCookie applies the configured cookie collection behavior to a
-// single Set-Cookie header value.
-//
-// Multiple Set-Cookie headers must be filtered individually, never joined
-// beforehand.
-func (dc DataCollection) FilterSetCookie(setCookie string) string {
+// FilterSetCookies applies the configured cookie collection behavior to
+// Set-Cookie header values.
+func (dc DataCollection) FilterSetCookies(values []string) string {
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if cookie := dc.filterSetCookie(value); cookie != "" {
+			filtered = append(filtered, cookie)
+		}
+	}
+	return strings.Join(filtered, ", ")
+}
+
+func (dc DataCollection) filterSetCookie(setCookie string) string {
 	if !dc.CollectCookies() {
 		return ""
 	}
@@ -283,20 +287,22 @@ func matchesDenyTerms(key string, terms []string) bool {
 	return false
 }
 
-// parseKeyValueString splits a string like "a=1; b=2" into a map.
+// parseKeyValueStrings splits strings like "a=1; b=2" into a map.
 // Malformed parts without '=' and parts with empty keys are skipped.
-func parseKeyValueString(s string, separator rune) map[string]string {
+func parseKeyValueStrings(values []string, separator rune) map[string]string {
 	result := make(map[string]string)
-	for _, part := range strings.Split(s, string(separator)) {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
+	for _, value := range values {
+		for _, part := range strings.Split(value, string(separator)) {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			key, value, ok := strings.Cut(part, "=")
+			if !ok || strings.TrimSpace(key) == "" {
+				continue
+			}
+			result[key] = value
 		}
-		key, value, ok := strings.Cut(part, "=")
-		if !ok || strings.TrimSpace(key) == "" {
-			continue
-		}
-		result[key] = value
 	}
 	return result
 }

--- a/data_collection_filter.go
+++ b/data_collection_filter.go
@@ -101,10 +101,7 @@ func (dc DataCollection) FilterQueryString(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
 	}
-	values, err := url.ParseQuery(rawQuery)
-	if err != nil {
-		return ""
-	}
+	values, _ := url.ParseQuery(rawQuery)
 	return dc.filterURLValues(values, dc.QueryParams)
 }
 

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -163,7 +163,7 @@ func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 		{
 			name: "cookies are parsed and filtered per cookie name",
 			filter: func(_ *testing.T, dc DataCollection) map[string]string {
-				return parseKeyValueString(dc.FilterCookies("debug; =bad; empty=; user_session=secret; theme=dark"), ';')
+				return parseKeyValueStrings([]string{dc.FilterCookies([]string{"debug; =bad; empty=", "user_session=secret; theme=dark"})}, ';')
 			},
 			want: map[string]string{
 				"empty":        "",
@@ -276,76 +276,84 @@ func TestNewClientDataCollectionHTTPBodyFilters(t *testing.T) {
 	}
 }
 
-func TestFilterSetCookie(t *testing.T) {
+func TestFilterSetCookies(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name           string
 		dataCollection *DataCollection
-		setCookie      string
+		setCookies     []string
 		want           string
 	}{
 		{
-			name:      "sensitive cookie value redacted and attributes preserved",
-			setCookie: "sessionid=abc123; Path=/; HttpOnly; Secure; Max-Age=3600",
-			want:      "sessionid=[Filtered]; Path=/; HttpOnly; Secure; Max-Age=3600",
+			name:       "sensitive cookie value redacted and attributes preserved",
+			setCookies: []string{"sessionid=abc123; Path=/; HttpOnly; Secure; Max-Age=3600"},
+			want:       "sessionid=[Filtered]; Path=/; HttpOnly; Secure; Max-Age=3600",
 		},
 		{
-			name:      "non-sensitive cookie unchanged",
-			setCookie: "theme=dark; Path=/settings; SameSite=Lax",
-			want:      "theme=dark; Path=/settings; SameSite=Lax",
+			name:       "non-sensitive cookie unchanged",
+			setCookies: []string{"theme=dark; Path=/settings; SameSite=Lax"},
+			want:       "theme=dark; Path=/settings; SameSite=Lax",
 		},
 		{
-			name:      "attributes with commas and equals are not misparsed as cookies",
-			setCookie: "theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com",
-			want:      "theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com",
+			name:       "attributes with commas and equals are not misparsed as cookies",
+			setCookies: []string{"theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com"},
+			want:       "theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com",
 		},
 		{
-			name:      "sensitive attribute value redacted",
-			setCookie: "theme=dark; Password=hunter=2; Path=/; HttpOnly",
-			want:      "theme=dark; Password=[Filtered]; Path=/; HttpOnly",
+			name:       "sensitive attribute value redacted",
+			setCookies: []string{"theme=dark; Password=hunter=2; Path=/; HttpOnly"},
+			want:       "theme=dark; Password=[Filtered]; Path=/; HttpOnly",
 		},
 		{
-			name:      "cookie without attributes",
-			setCookie: "token=abc",
-			want:      "token=[Filtered]",
+			name:       "cookie without attributes",
+			setCookies: []string{"token=abc"},
+			want:       "token=[Filtered]",
+		},
+		{
+			name: "multiple header values are filtered separately",
+			setCookies: []string{
+				"sessionid=abc123; Path=/; HttpOnly",
+				"theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
+			},
+			want: "sessionid=[Filtered]; Path=/; HttpOnly, theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
 		},
 		{
 			name: "custom deny terms apply to the cookie name",
 			dataCollection: &DataCollection{
 				Cookies: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"theme"}},
 			},
-			setCookie: "theme=dark; Path=/",
-			want:      "theme=[Filtered]; Path=/",
+			setCookies: []string{"theme=dark; Path=/"},
+			want:       "theme=[Filtered]; Path=/",
 		},
 		{
 			name: "custom deny terms apply to attributes",
 			dataCollection: &DataCollection{
 				Cookies: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"domain"}},
 			},
-			setCookie: "theme=dark; Domain=private.example.com; Secure",
-			want:      "theme=dark; Domain=[Filtered]; Secure",
+			setCookies: []string{"theme=dark; Domain=private.example.com; Secure"},
+			want:       "theme=dark; Domain=[Filtered]; Secure",
 		},
 		{
 			name: "allow list still scrubs built-in sensitive names",
 			dataCollection: &DataCollection{
 				Cookies: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"sessionid", "theme"}},
 			},
-			setCookie: "sessionid=abc123; Path=/",
-			want:      "sessionid=[Filtered]; Path=[Filtered]",
+			setCookies: []string{"sessionid=abc123; Path=/"},
+			want:       "sessionid=[Filtered]; Path=[Filtered]",
 		},
 		{
 			name: "off mode omits collection",
 			dataCollection: &DataCollection{
 				Cookies: &KeyValueCollectionBehavior{Mode: CollectionOff},
 			},
-			setCookie: "theme=dark; Path=/",
-			want:      "",
+			setCookies: []string{"theme=dark; Path=/"},
+			want:       "",
 		},
 		{
-			name:      "malformed value without name=value pair is dropped",
-			setCookie: "HttpOnly",
-			want:      "",
+			name:       "malformed value without name=value pair is dropped",
+			setCookies: []string{"HttpOnly"},
+			want:       "",
 		},
 	}
 
@@ -354,8 +362,8 @@ func TestFilterSetCookie(t *testing.T) {
 			t.Parallel()
 
 			dc := newClientDataCollection(t, tt.dataCollection)
-			if got := dc.FilterSetCookie(tt.setCookie); got != tt.want {
-				t.Errorf("FilterSetCookie(%q) = %q, want %q", tt.setCookie, got, tt.want)
+			if got := dc.FilterSetCookies(tt.setCookies); got != tt.want {
+				t.Errorf("FilterSetCookies(%q) = %q, want %q", tt.setCookies, got, tt.want)
 			}
 		})
 	}

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -301,6 +301,11 @@ func TestFilterSetCookie(t *testing.T) {
 			want:      "theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com",
 		},
 		{
+			name:      "sensitive attribute value redacted",
+			setCookie: "theme=dark; Password=hunter=2; Path=/; HttpOnly",
+			want:      "theme=dark; Password=[Filtered]; Path=/; HttpOnly",
+		},
+		{
 			name:      "cookie without attributes",
 			setCookie: "token=abc",
 			want:      "token=[Filtered]",
@@ -314,12 +319,20 @@ func TestFilterSetCookie(t *testing.T) {
 			want:      "theme=[Filtered]; Path=/",
 		},
 		{
+			name: "custom deny terms apply to attributes",
+			dataCollection: &DataCollection{
+				Cookies: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"domain"}},
+			},
+			setCookie: "theme=dark; Domain=private.example.com; Secure",
+			want:      "theme=dark; Domain=[Filtered]; Secure",
+		},
+		{
 			name: "allow list still scrubs built-in sensitive names",
 			dataCollection: &DataCollection{
 				Cookies: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"sessionid", "theme"}},
 			},
 			setCookie: "sessionid=abc123; Path=/",
-			want:      "sessionid=[Filtered]; Path=/",
+			want:      "sessionid=[Filtered]; Path=[Filtered]",
 		},
 		{
 			name: "off mode omits collection",

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -260,6 +260,78 @@ func TestNewClientDataCollectionHTTPBodyFilters(t *testing.T) {
 	}
 }
 
+func TestFilterSetCookie(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		dataCollection *DataCollection
+		setCookie      string
+		want           string
+	}{
+		{
+			name:      "sensitive cookie value redacted and attributes preserved",
+			setCookie: "sessionid=abc123; Path=/; HttpOnly; Secure; Max-Age=3600",
+			want:      "sessionid=[Filtered]; Path=/; HttpOnly; Secure; Max-Age=3600",
+		},
+		{
+			name:      "non-sensitive cookie unchanged",
+			setCookie: "theme=dark; Path=/settings; SameSite=Lax",
+			want:      "theme=dark; Path=/settings; SameSite=Lax",
+		},
+		{
+			name:      "attributes with commas and equals are not misparsed as cookies",
+			setCookie: "theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com",
+			want:      "theme=dark; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Domain=example.com",
+		},
+		{
+			name:      "cookie without attributes",
+			setCookie: "token=abc",
+			want:      "token=[Filtered]",
+		},
+		{
+			name: "custom deny terms apply to the cookie name",
+			dataCollection: &DataCollection{
+				Cookies: &KeyValueCollectionBehavior{Mode: CollectionDenyList, Terms: []string{"theme"}},
+			},
+			setCookie: "theme=dark; Path=/",
+			want:      "theme=[Filtered]; Path=/",
+		},
+		{
+			name: "allow list still scrubs built-in sensitive names",
+			dataCollection: &DataCollection{
+				Cookies: &KeyValueCollectionBehavior{Mode: CollectionAllowList, Terms: []string{"sessionid", "theme"}},
+			},
+			setCookie: "sessionid=abc123; Path=/",
+			want:      "sessionid=[Filtered]; Path=/",
+		},
+		{
+			name: "off mode omits collection",
+			dataCollection: &DataCollection{
+				Cookies: &KeyValueCollectionBehavior{Mode: CollectionOff},
+			},
+			setCookie: "theme=dark; Path=/",
+			want:      "",
+		},
+		{
+			name:      "malformed value without name=value pair is dropped",
+			setCookie: "HttpOnly",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dc := newClientDataCollection(t, tt.dataCollection)
+			if got := dc.FilterSetCookie(tt.setCookie); got != tt.want {
+				t.Errorf("FilterSetCookie(%q) = %q, want %q", tt.setCookie, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFilterHTTPBodyRedactsScalarJSONBodies(t *testing.T) {
 	t.Parallel()
 

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -145,6 +145,22 @@ func TestNewClientDataCollectionKeyValueFilters(t *testing.T) {
 			},
 		},
 		{
+			name: "malformed query preserves successfully parsed parameters",
+			filter: func(t *testing.T, dc DataCollection) map[string]string {
+				t.Helper()
+				got, err := parseQueryString(t, dc.FilterQueryString("safe=ok&token=secret&bad=%ZZ&page=1"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return got
+			},
+			want: map[string]string{
+				"safe":  "ok",
+				"token": filteredValue,
+				"page":  "1",
+			},
+		},
+		{
 			name: "cookies are parsed and filtered per cookie name",
 			filter: func(_ *testing.T, dc DataCollection) map[string]string {
 				return parseKeyValueString(dc.FilterCookies("debug; =bad; empty=; user_session=secret; theme=dark"), ';')

--- a/data_collection_filter_test.go
+++ b/data_collection_filter_test.go
@@ -260,6 +260,51 @@ func TestNewClientDataCollectionHTTPBodyFilters(t *testing.T) {
 	}
 }
 
+func TestFilterHTTPBodyRedactsScalarJSONBodies(t *testing.T) {
+	t.Parallel()
+
+	const secret = "hunter2-super-secret"
+
+	tests := []struct {
+		name        string
+		body        []byte
+		contentType string
+	}{
+		{
+			name:        "top-level JSON string",
+			body:        []byte(`"Bearer ` + secret + `"`),
+			contentType: "application/json",
+		},
+		{
+			name:        "top-level JSON array of scalars",
+			body:        []byte(`["user@example.com","` + secret + `"]`),
+			contentType: "application/json",
+		},
+		{
+			name:        "scalars in nested arrays",
+			body:        []byte(`[["` + secret + `"]]`),
+			contentType: "application/json",
+		},
+		{
+			name:        "sniffed JSON array with non-JSON content type",
+			body:        []byte(`["` + secret + `"]`),
+			contentType: "text/plain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dc := newClientDataCollection(t, nil)
+			got := dc.FilterHTTPBody(tt.body, tt.contentType)
+			if strings.Contains(got, secret) {
+				t.Errorf("FilterHTTPBody(%q, %q) leaked sensitive scalar value: got %q", tt.body, tt.contentType, got)
+			}
+		})
+	}
+}
+
 func TestNewClientDataCollectionCollectHTTPBody(t *testing.T) {
 	t.Parallel()
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -175,11 +175,22 @@ func setScopeMetadata(hub *sentry.Hub, method string, md metadata.MD) {
 	})
 }
 
-func filterMetadataCookies(dc sentry.DataCollection, values []string) (string, bool) {
+func filterMetadataCookies(dc sentry.DataCollection, key string, values []string) (string, bool) {
 	if !dc.CollectCookies() {
 		return "", false
 	}
-	cookies := dc.FilterCookies(strings.Join(values, "; "))
+	var cookies string
+	if strings.EqualFold(key, "set-cookie") {
+		filtered := make([]string, 0, len(values))
+		for _, value := range values {
+			if cookie := dc.FilterSetCookie(value); cookie != "" {
+				filtered = append(filtered, cookie)
+			}
+		}
+		cookies = strings.Join(filtered, ", ")
+	} else {
+		cookies = dc.FilterCookies(strings.Join(values, "; "))
+	}
 	return cookies, cookies != ""
 }
 
@@ -198,7 +209,7 @@ func metadataToContext(client *sentry.Client, md metadata.MD) map[string]any {
 		value := strings.Join(values, ",")
 		if strings.EqualFold(key, "cookie") || strings.EqualFold(key, "set-cookie") {
 			var ok bool
-			value, ok = filterMetadataCookies(dc, values)
+			value, ok = filterMetadataCookies(dc, key, values)
 			if !ok {
 				continue
 			}

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -176,20 +176,11 @@ func setScopeMetadata(hub *sentry.Hub, method string, md metadata.MD) {
 }
 
 func filterMetadataCookies(dc sentry.DataCollection, key string, values []string) (string, bool) {
-	if !dc.CollectCookies() {
-		return "", false
-	}
 	var cookies string
 	if strings.EqualFold(key, "set-cookie") {
-		filtered := make([]string, 0, len(values))
-		for _, value := range values {
-			if cookie := dc.FilterSetCookie(value); cookie != "" {
-				filtered = append(filtered, cookie)
-			}
-		}
-		cookies = strings.Join(filtered, ", ")
+		cookies = dc.FilterSetCookies(values)
 	} else {
-		cookies = dc.FilterCookies(strings.Join(values, "; "))
+		cookies = dc.FilterCookies(values)
 	}
 	return cookies, cookies != ""
 }

--- a/grpc/server_internal_test.go
+++ b/grpc/server_internal_test.go
@@ -73,12 +73,12 @@ func TestMetadataToContext(t *testing.T) {
 			}(),
 			md: metadata.MD{
 				"cookie":       []string{"session=secret; theme=dark"},
-				"set-cookie":   []string{"auth_token=secret; preference=blue"},
+				"set-cookie":   []string{"auth_token=secret; password=hunter2; preference=blue"},
 				"x-request-id": []string{"req-123"},
 			},
 			want: map[string]any{
 				"cookie":       "session=[Filtered]; theme=dark",
-				"set-cookie":   "auth_token=[Filtered]; preference=blue",
+				"set-cookie":   "auth_token=[Filtered]; password=[Filtered]; preference=blue",
 				"x-request-id": "req-123",
 			},
 		},

--- a/grpc/server_internal_test.go
+++ b/grpc/server_internal_test.go
@@ -83,6 +83,28 @@ func TestMetadataToContext(t *testing.T) {
 			},
 		},
 		{
+			name: "set-cookie metadata preserves attributes per cookie",
+			client: func() *sentry.Client {
+				client, err := sentry.NewClient(sentry.ClientOptions{
+					Dsn:            "https://key@sentry.io/1",
+					DataCollection: &sentry.DataCollection{},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return client
+			}(),
+			md: metadata.MD{
+				"set-cookie": []string{
+					"sessionid=abc123; Path=/; HttpOnly",
+					"theme=dark; Path=/settings; Secure",
+				},
+			},
+			want: map[string]any{
+				"set-cookie": "sessionid=[Filtered]; Path=/; HttpOnly, theme=dark; Path=/settings; Secure",
+			},
+		},
+		{
 			name: "cookie metadata can be disabled separately",
 			client: func() *sentry.Client {
 				client, err := sentry.NewClient(sentry.ClientOptions{

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -13,6 +13,7 @@ package sentryhttpclient
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -139,15 +140,9 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 	span.SetData("http.request.method", request.Method)
 	span.SetData("server.address", request.URL.Hostname())
 	span.SetData("server.port", request.URL.Port())
-	for key, value := range dc.FilterRequestHeaders(headerStringMap(request.Header)) {
+	for key, value := range filterOutgoingRequestHeaders(dc, request.Header) {
 		span.SetData("http.request.header."+strings.ToLower(key), value)
 	}
-	if dc.CollectHTTPBody(sentry.BodyOutgoingRequest) {
-		if body := readOutgoingRequestBody(request); body != nil {
-			span.SetData("http.request.body", dc.FilterHTTPBody(body, request.Header.Get("Content-Type")))
-		}
-	}
-
 	// Always add `Baggage` and `Sentry-Trace` headers.
 	request = request.Clone(request.Context())
 	request.Header.Add(sentry.SentryBaggageHeader, span.ToBaggage())
@@ -156,7 +151,19 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 		request.Header.Add(sentry.TraceparentHeader, span.ToTraceparent())
 	}
 
+	var requestBody *httputils.LimitedBuffer
+	if dc.CollectHTTPBody(sentry.BodyOutgoingRequest) && request.Body != nil && request.Body != http.NoBody && request.ContentLength <= httputils.MaxBodyBytes {
+		requestBody = httputils.NewLimitedBuffer(httputils.MaxBodyBytes)
+		request.Body = &httputils.ReadCloser{
+			Reader: io.TeeReader(request.Body, requestBody),
+			Closer: request.Body,
+		}
+	}
+
 	response, err := s.originalRoundTripper.RoundTrip(request)
+	if requestBody != nil && !requestBody.Overflow() && requestBody.Len() > 0 {
+		span.SetData("http.request.body", dc.FilterHTTPBody(requestBody.Bytes(), request.Header.Get("Content-Type")))
+	}
 	if err != nil {
 		span.Status = sentry.SpanStatusInternalError
 		return response, err
@@ -166,7 +173,7 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 		span.Status = sentry.HTTPtoSpanStatus(response.StatusCode)
 		span.SetData("http.response.status_code", response.StatusCode)
 		span.SetData("http.response_content_length", response.ContentLength)
-		for key, value := range dc.FilterResponseHeaders(headerStringMap(response.Header)) {
+		for key, value := range filterIncomingResponseHeaders(dc, response.Header) {
 			span.SetData("http.response.header."+strings.ToLower(key), value)
 		}
 	}
@@ -174,29 +181,38 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 	return response, err
 }
 
-// headerStringMap flattens HTTP headers into a map.
-func headerStringMap(h http.Header) map[string]string {
-	if len(h) == 0 {
-		return nil
-	}
-	m := make(map[string]string, len(h))
-	for key, values := range h {
-		m[key] = strings.Join(values, ",")
-	}
-	return m
+func filterOutgoingRequestHeaders(dc sentry.DataCollection, headers http.Header) map[string]string {
+	return dc.FilterRequestHeaders(headerStringMap(headers, dc, "Cookie"))
 }
 
-// readOutgoingRequestBody returns a copy of the outgoing request body via
-// request.GetBody so the actual request stream sent to the server is left
-// untouched.
-func readOutgoingRequestBody(request *http.Request) []byte {
-	if request.GetBody == nil {
+func filterIncomingResponseHeaders(dc sentry.DataCollection, headers http.Header) map[string]string {
+	return dc.FilterResponseHeaders(headerStringMap(headers, dc, "Set-Cookie"))
+}
+
+// headerStringMap flattens HTTP headers into a map. Cookie headers are parsed
+// and filtered through the cookie collection settings before header filtering.
+func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader string) map[string]string {
+	if len(headers) == 0 {
 		return nil
 	}
-	rc, err := request.GetBody()
-	if err != nil || rc == nil {
-		return nil
+
+	m := make(map[string]string, len(headers))
+	for key, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+
+		value := strings.Join(values, ",")
+		if strings.EqualFold(key, cookieHeader) {
+			if !dc.CollectCookies() {
+				continue
+			}
+			value = dc.FilterCookies(strings.Join(values, "; "))
+			if value == "" {
+				continue
+			}
+		}
+		m[key] = value
 	}
-	defer rc.Close()
-	return httputils.ReadBody(rc)
+	return m
 }

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -139,7 +139,7 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 	span.SetData("http.request.method", request.Method)
 	span.SetData("server.address", request.URL.Hostname())
 	span.SetData("server.port", request.URL.Port())
-	for key, value := range dc.FilterResponseHeaders(headerStringMap(request.Header)) {
+	for key, value := range dc.FilterRequestHeaders(headerStringMap(request.Header)) {
 		span.SetData("http.request.header."+strings.ToLower(key), value)
 	}
 	if dc.CollectHTTPBody(sentry.BodyOutgoingRequest) {

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/httputils"
 )
 
 // SentryRoundTripTracerOption provides a specific type in which defines the option for SentryRoundTripper.
@@ -138,6 +139,14 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 	span.SetData("http.request.method", request.Method)
 	span.SetData("server.address", request.URL.Hostname())
 	span.SetData("server.port", request.URL.Port())
+	for key, value := range dc.FilterResponseHeaders(headerStringMap(request.Header)) {
+		span.SetData("http.request.header."+strings.ToLower(key), value)
+	}
+	if dc.CollectHTTPBody(sentry.BodyOutgoingRequest) {
+		if body := readOutgoingRequestBody(request); body != nil {
+			span.SetData("http.request.body", dc.FilterHTTPBody(body, request.Header.Get("Content-Type")))
+		}
+	}
 
 	// Always add `Baggage` and `Sentry-Trace` headers.
 	request = request.Clone(request.Context())
@@ -157,7 +166,37 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 		span.Status = sentry.HTTPtoSpanStatus(response.StatusCode)
 		span.SetData("http.response.status_code", response.StatusCode)
 		span.SetData("http.response_content_length", response.ContentLength)
+		for key, value := range dc.FilterResponseHeaders(headerStringMap(response.Header)) {
+			span.SetData("http.response.header."+strings.ToLower(key), value)
+		}
 	}
 
 	return response, err
+}
+
+// headerStringMap flattens HTTP headers into a map.
+func headerStringMap(h http.Header) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(h))
+	for key, values := range h {
+		m[key] = strings.Join(values, ",")
+	}
+	return m
+}
+
+// readOutgoingRequestBody returns a copy of the outgoing request body via
+// request.GetBody so the actual request stream sent to the server is left
+// untouched.
+func readOutgoingRequestBody(request *http.Request) []byte {
+	if request.GetBody == nil {
+		return nil
+	}
+	rc, err := request.GetBody()
+	if err != nil || rc == nil {
+		return nil
+	}
+	defer rc.Close()
+	return httputils.ReadBody(rc)
 }

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -152,7 +152,8 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 	}
 
 	var requestBody *httputils.LimitedBuffer
-	if dc.CollectHTTPBody(sentry.BodyOutgoingRequest) && request.Body != nil && request.Body != http.NoBody && request.ContentLength <= httputils.MaxBodyBytes {
+	hasRequestBody := request.Body != nil && request.Body != http.NoBody
+	if dc.CollectHTTPBody(sentry.BodyOutgoingRequest) && hasRequestBody && request.ContentLength <= httputils.MaxBodyBytes {
 		requestBody = httputils.NewLimitedBuffer(httputils.MaxBodyBytes)
 		request.Body = &httputils.ReadCloser{
 			Reader: io.TeeReader(request.Body, requestBody),

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -183,34 +183,17 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 }
 
 func filterOutgoingRequestHeaders(dc sentry.DataCollection, headers http.Header) map[string]string {
-	return dc.FilterRequestHeaders(headerStringMap(headers, dc, "Cookie", filterCookieValues))
+	return dc.FilterRequestHeaders(headerStringMap(headers, dc, "Cookie", dc.FilterCookies))
 }
 
 func filterIncomingResponseHeaders(dc sentry.DataCollection, headers http.Header) map[string]string {
-	return dc.FilterResponseHeaders(headerStringMap(headers, dc, "Set-Cookie", filterSetCookieValues))
-}
-
-// filterCookieValues filters Cookie header values, which hold semicolon-
-// separated name=value pairs and may be joined before parsing.
-func filterCookieValues(dc sentry.DataCollection, values []string) string {
-	return dc.FilterCookies(strings.Join(values, "; "))
-}
-
-// filterSetCookieValues filters each Set-Cookie header individually.
-func filterSetCookieValues(dc sentry.DataCollection, values []string) string {
-	filtered := make([]string, 0, len(values))
-	for _, value := range values {
-		if cookie := dc.FilterSetCookie(value); cookie != "" {
-			filtered = append(filtered, cookie)
-		}
-	}
-	return strings.Join(filtered, ", ")
+	return dc.FilterResponseHeaders(headerStringMap(headers, dc, "Set-Cookie", dc.FilterSetCookies))
 }
 
 // headerStringMap flattens HTTP headers into a map. Cookie headers are parsed
 // and filtered through the cookie collection settings via filterCookies
 // before header filtering.
-func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader string, filterCookies func(sentry.DataCollection, []string) string) map[string]string {
+func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader string, filterCookies func([]string) string) map[string]string {
 	if len(headers) == 0 {
 		return nil
 	}
@@ -226,7 +209,7 @@ func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader
 			if !dc.CollectCookies() {
 				continue
 			}
-			value = filterCookies(dc, values)
+			value = filterCookies(values)
 			if value == "" {
 				continue
 			}

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -182,16 +182,34 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 }
 
 func filterOutgoingRequestHeaders(dc sentry.DataCollection, headers http.Header) map[string]string {
-	return dc.FilterRequestHeaders(headerStringMap(headers, dc, "Cookie"))
+	return dc.FilterRequestHeaders(headerStringMap(headers, dc, "Cookie", filterCookieValues))
 }
 
 func filterIncomingResponseHeaders(dc sentry.DataCollection, headers http.Header) map[string]string {
-	return dc.FilterResponseHeaders(headerStringMap(headers, dc, "Set-Cookie"))
+	return dc.FilterResponseHeaders(headerStringMap(headers, dc, "Set-Cookie", filterSetCookieValues))
+}
+
+// filterCookieValues filters Cookie header values, which hold semicolon-
+// separated name=value pairs and may be joined before parsing.
+func filterCookieValues(dc sentry.DataCollection, values []string) string {
+	return dc.FilterCookies(strings.Join(values, "; "))
+}
+
+// filterSetCookieValues filters each Set-Cookie header individually.
+func filterSetCookieValues(dc sentry.DataCollection, values []string) string {
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if cookie := dc.FilterSetCookie(value); cookie != "" {
+			filtered = append(filtered, cookie)
+		}
+	}
+	return strings.Join(filtered, ", ")
 }
 
 // headerStringMap flattens HTTP headers into a map. Cookie headers are parsed
-// and filtered through the cookie collection settings before header filtering.
-func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader string) map[string]string {
+// and filtered through the cookie collection settings via filterCookies
+// before header filtering.
+func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader string, filterCookies func(sentry.DataCollection, []string) string) map[string]string {
 	if len(headers) == 0 {
 		return nil
 	}
@@ -207,7 +225,7 @@ func headerStringMap(headers http.Header, dc sentry.DataCollection, cookieHeader
 			if !dc.CollectCookies() {
 				continue
 			}
-			value = dc.FilterCookies(strings.Join(values, "; "))
+			value = filterCookies(dc, values)
 			if value == "" {
 				continue
 			}

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -151,13 +151,14 @@ func TestIntegration(t *testing.T) {
 			WantResponseLength: 1024,
 			WantSpan: &sentry.Span{ //nolint:gosec // G101: not real credentials
 				Data: map[string]interface{}{
-					"http.fragment":                string(""),
-					"http.query":                   string(""),
-					"http.request.method":          string("POST"),
-					"http.response.status_code":    int(200),
-					"http.response_content_length": int64(1024),
-					"server.address":               string("example.com"),
-					"server.port":                  string("4321"),
+					"http.fragment":                     string(""),
+					"http.query":                        string(""),
+					"http.request.method":               string("POST"),
+					"http.request.header.authorization": string("[Filtered]"),
+					"http.response.status_code":         int(200),
+					"http.response_content_length":      int64(1024),
+					"server.address":                    string("example.com"),
+					"server.port":                       string("4321"),
 				},
 				Description: "POST https://john:xxxxx@example.com:4321/secret",
 				Op:          "http.client",
@@ -314,6 +315,12 @@ func TestIntegration(t *testing.T) {
 			continue
 		}
 
+		// The noopRoundTripper always returns a Content-Length response header,
+		// which the default deny-list collects as span data.
+		if !tt.WantError {
+			tt.WantSpan.Data["http.response.header.content-length"] = strconv.Itoa(tt.WantResponseLength)
+		}
+
 		var foundMatch = false
 		var diffs []string
 		for _, gotSpan := range gotSpans {
@@ -328,6 +335,158 @@ func TestIntegration(t *testing.T) {
 		if !foundMatch {
 			t.Errorf("Span mismatch (-want +got):\n%s", strings.Join(diffs, "\n"))
 		}
+	}
+}
+
+type bodyRoundTripper struct {
+	responseBody    string
+	responseHeaders map[string]string
+}
+
+func (b *bodyRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	for k, v := range b.responseHeaders {
+		header.Set(k, v)
+	}
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        header,
+		Body:          io.NopCloser(strings.NewReader(b.responseBody)),
+		ContentLength: int64(len(b.responseBody)),
+		Request:       request,
+	}, nil
+}
+
+func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
+	tests := []struct {
+		name           string
+		dataCollection *sentry.DataCollection
+		wantData       map[string]interface{}
+		wantAbsent     []string
+	}{
+		{
+			name:           "default collects and filters headers and bodies",
+			dataCollection: &sentry.DataCollection{},
+			wantData: map[string]interface{}{
+				"http.request.header.authorization": "[Filtered]",
+				"http.request.header.x-custom":      "custom-value",
+				"http.request.body":                 `{"password":"[Filtered]","safe":"keep"}`,
+				"http.response.header.content-type": "application/json",
+			},
+			wantAbsent: []string{"http.response.body"},
+		},
+		{
+			name: "bodies disabled keeps headers but drops bodies",
+			dataCollection: &sentry.DataCollection{
+				HTTPBodies: []sentry.BodyType{},
+			},
+			wantData: map[string]interface{}{
+				"http.request.header.x-custom":      "custom-value",
+				"http.response.header.content-type": "application/json",
+			},
+			wantAbsent: []string{"http.request.body", "http.response.body"},
+		},
+		{
+			name: "headers disabled keeps bodies but drops headers",
+			dataCollection: &sentry.DataCollection{
+				HTTPHeaders: &sentry.HeaderCollectionConfig{
+					Request:  &sentry.KeyValueCollectionBehavior{Mode: sentry.CollectionOff},
+					Response: &sentry.KeyValueCollectionBehavior{Mode: sentry.CollectionOff},
+				},
+			},
+			wantData: map[string]interface{}{
+				"http.request.body": `{"password":"[Filtered]","safe":"keep"}`,
+			},
+			wantAbsent: []string{
+				"http.request.header.authorization",
+				"http.request.header.x-custom",
+				"http.response.header.content-type",
+				"http.response.body",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spansCh := make(chan []*sentry.Span, 1)
+			sentryClient, err := sentry.NewClient(sentry.ClientOptions{
+				EnableTracing:    true,
+				TracesSampleRate: 1.0,
+				DataCollection:   tt.dataCollection,
+				BeforeSendTransaction: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+					spansCh <- event.Spans
+					return event
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hub := sentry.NewHub(sentryClient, sentry.NewScope())
+			ctx := sentry.SetHubOnContext(context.Background(), hub)
+			span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
+			ctx = span.Context()
+
+			request, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.com/api",
+				strings.NewReader(`{"password":"secret","safe":"keep"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Authorization", "Bearer secret")
+			request.Header.Set("X-Custom", "custom-value")
+
+			responseBody := `{"token":"abc","data":"ok"}`
+			roundTripper := &bodyRoundTripper{
+				responseBody:    responseBody,
+				responseHeaders: map[string]string{"Content-Type": "application/json"},
+			}
+			client := &http.Client{Transport: sentryhttpclient.NewSentryRoundTripper(roundTripper)}
+
+			response, err := client.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// The caller must still be able to read the full, untouched body.
+			gotBody, err := io.ReadAll(response.Body)
+			response.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(gotBody) != responseBody {
+				t.Errorf("response body = %q, want %q", gotBody, responseBody)
+			}
+
+			span.Finish()
+			if ok := sentryClient.Flush(testutils.FlushTimeout()); !ok {
+				t.Fatal("sentry.Flush timed out")
+			}
+			close(spansCh)
+
+			var got *sentry.Span
+			for spans := range spansCh {
+				for _, candidate := range spans {
+					if candidate.Op == "http.client" {
+						got = candidate
+					}
+				}
+			}
+			if got == nil {
+				t.Fatal("missing http.client span")
+			}
+
+			for key, want := range tt.wantData {
+				if diff := cmp.Diff(want, got.Data[key], testutils.EquateKeyValueStrings()); diff != "" {
+					t.Errorf("span data[%q] mismatch (-want +got):\n%s", key, diff)
+				}
+			}
+			for _, key := range tt.wantAbsent {
+				if _, ok := got.Data[key]; ok {
+					t.Errorf("span data[%q] should be absent, got %v", key, got.Data[key])
+				}
+			}
+		})
 	}
 }
 
@@ -398,13 +557,14 @@ func TestIntegration_GlobalClientOptions(t *testing.T) {
 	gotSpan := got[0]
 	wantSpan := &sentry.Span{
 		Data: map[string]interface{}{
-			"http.fragment":                string(""),
-			"http.query":                   string(""),
-			"http.request.method":          string("POST"),
-			"http.response.status_code":    int(200),
-			"http.response_content_length": int64(48),
-			"server.address":               string("example.com"),
-			"server.port":                  string(""),
+			"http.fragment":                       string(""),
+			"http.query":                          string(""),
+			"http.request.method":                 string("POST"),
+			"http.response.status_code":           int(200),
+			"http.response_content_length":        int64(48),
+			"http.response.header.content-length": string("48"),
+			"server.address":                      string("example.com"),
+			"server.port":                         string(""),
 		},
 		Description: "POST https://example.com",
 		Op:          "http.client",
@@ -634,13 +794,14 @@ func TestDataCollectionFiltersQuerySpanData(t *testing.T) {
 			name:       "filters sensitive query values",
 			requestURL: "https://example.com/foo?page=1&token=secret#readme",
 			wantData: map[string]interface{}{
-				"http.fragment":                "readme",
-				"http.query":                   "page=1&token=[Filtered]",
-				"http.request.method":          "GET",
-				"http.response.status_code":    200,
-				"http.response_content_length": int64(0),
-				"server.address":               "example.com",
-				"server.port":                  "",
+				"http.fragment":                       "readme",
+				"http.query":                          "page=1&token=[Filtered]",
+				"http.request.method":                 "GET",
+				"http.response.status_code":           200,
+				"http.response_content_length":        int64(0),
+				"http.response.header.content-length": "0",
+				"server.address":                      "example.com",
+				"server.port":                         "",
 			},
 			wantDesc: "GET https://example.com/foo?page=1&token=[Filtered]#readme",
 		},
@@ -651,12 +812,13 @@ func TestDataCollectionFiltersQuerySpanData(t *testing.T) {
 			},
 			requestURL: "https://example.com/foo?page=1&token=secret#readme",
 			wantData: map[string]interface{}{
-				"http.fragment":                "readme",
-				"http.request.method":          "GET",
-				"http.response.status_code":    200,
-				"http.response_content_length": int64(0),
-				"server.address":               "example.com",
-				"server.port":                  "",
+				"http.fragment":                       "readme",
+				"http.request.method":                 "GET",
+				"http.response.status_code":           200,
+				"http.response_content_length":        int64(0),
+				"http.response.header.content-length": "0",
+				"server.address":                      "example.com",
+				"server.port":                         "",
 			},
 			wantDesc: "GET https://example.com/foo#readme",
 		},

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -387,19 +387,19 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 			wantAbsent: []string{"http.request.body", "http.response.body"},
 		},
 		{
-			name: "headers disabled keeps bodies but drops headers",
+			name: "response headers disabled keeps request headers and bodies",
 			dataCollection: &sentry.DataCollection{
 				HTTPHeaders: &sentry.HeaderCollectionConfig{
-					Request:  &sentry.KeyValueCollectionBehavior{Mode: sentry.CollectionOff},
+					Request:  &sentry.KeyValueCollectionBehavior{},
 					Response: &sentry.KeyValueCollectionBehavior{Mode: sentry.CollectionOff},
 				},
 			},
 			wantData: map[string]interface{}{
-				"http.request.body": `{"password":"[Filtered]","safe":"keep"}`,
+				"http.request.header.authorization": "[Filtered]",
+				"http.request.header.x-custom":      "custom-value",
+				"http.request.body":                 `{"password":"[Filtered]","safe":"keep"}`,
 			},
 			wantAbsent: []string{
-				"http.request.header.authorization",
-				"http.request.header.x-custom",
 				"http.response.header.content-type",
 				"http.response.body",
 			},

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -344,6 +344,10 @@ type bodyRoundTripper struct {
 }
 
 func (b *bodyRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.Body != nil {
+		_, _ = io.Copy(io.Discard, request.Body)
+		_ = request.Body.Close()
+	}
 	header := http.Header{}
 	for k, v := range b.responseHeaders {
 		header.Set(k, v)
@@ -369,9 +373,11 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 			dataCollection: &sentry.DataCollection{},
 			wantData: map[string]interface{}{
 				"http.request.header.authorization": "[Filtered]",
+				"http.request.header.cookie":        "session=[Filtered]; theme=dark",
 				"http.request.header.x-custom":      "custom-value",
 				"http.request.body":                 `{"password":"[Filtered]","safe":"keep"}`,
 				"http.response.header.content-type": "application/json",
+				"http.response.header.set-cookie":   "session=[Filtered]; theme=dark",
 			},
 			wantAbsent: []string{"http.response.body"},
 		},
@@ -381,8 +387,10 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 				HTTPBodies: []sentry.BodyType{},
 			},
 			wantData: map[string]interface{}{
+				"http.request.header.cookie":        "session=[Filtered]; theme=dark",
 				"http.request.header.x-custom":      "custom-value",
 				"http.response.header.content-type": "application/json",
+				"http.response.header.set-cookie":   "session=[Filtered]; theme=dark",
 			},
 			wantAbsent: []string{"http.request.body", "http.response.body"},
 		},
@@ -396,6 +404,7 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 			},
 			wantData: map[string]interface{}{
 				"http.request.header.authorization": "[Filtered]",
+				"http.request.header.cookie":        "session=[Filtered]; theme=dark",
 				"http.request.header.x-custom":      "custom-value",
 				"http.request.body":                 `{"password":"[Filtered]","safe":"keep"}`,
 			},
@@ -434,12 +443,16 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 			}
 			request.Header.Set("Content-Type", "application/json")
 			request.Header.Set("Authorization", "Bearer secret")
+			request.Header.Set("Cookie", "session=secret; theme=dark")
 			request.Header.Set("X-Custom", "custom-value")
 
 			responseBody := `{"token":"abc","data":"ok"}`
 			roundTripper := &bodyRoundTripper{
-				responseBody:    responseBody,
-				responseHeaders: map[string]string{"Content-Type": "application/json"},
+				responseBody: responseBody,
+				responseHeaders: map[string]string{
+					"Content-Type": "application/json",
+					"Set-Cookie":   "session=secret; theme=dark",
+				},
 			}
 			client := &http.Client{Transport: sentryhttpclient.NewSentryRoundTripper(roundTripper)}
 

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -543,7 +543,7 @@ func TestSetCookieResponseHeadersPreserveAttributes(t *testing.T) {
 
 	header := http.Header{}
 	header.Add("Set-Cookie", "sessionid=abc123; Path=/; HttpOnly")
-	header.Add("Set-Cookie", "theme=dark; Path=/settings; Secure")
+	header.Add("Set-Cookie", "theme=dark; Password=hunter2; Path=/settings; Secure")
 	client := &http.Client{Transport: sentryhttpclient.NewSentryRoundTripper(&headerRoundTripper{header: header})}
 
 	response, err := client.Do(request)
@@ -570,7 +570,7 @@ func TestSetCookieResponseHeadersPreserveAttributes(t *testing.T) {
 		t.Fatal("missing http.client span")
 	}
 
-	want := "sessionid=[Filtered]; Path=/; HttpOnly, theme=dark; Path=/settings; Secure"
+	want := "sessionid=[Filtered]; Path=/; HttpOnly, theme=dark; Password=[Filtered]; Path=/settings; Secure"
 	if diff := cmp.Diff(want, got.Data["http.response.header.set-cookie"]); diff != "" {
 		t.Errorf("span data[\"http.response.header.set-cookie\"] mismatch (-want +got):\n%s", diff)
 	}

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -503,6 +503,79 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 	}
 }
 
+type headerRoundTripper struct {
+	header http.Header
+}
+
+func (h *headerRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     h.header.Clone(),
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    request,
+	}, nil
+}
+
+func TestSetCookieResponseHeadersPreserveAttributes(t *testing.T) {
+	spansCh := make(chan []*sentry.Span, 1)
+	sentryClient, err := sentry.NewClient(sentry.ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+		DataCollection:   &sentry.DataCollection{},
+		BeforeSendTransaction: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			spansCh <- event.Spans
+			return event
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hub := sentry.NewHub(sentryClient, sentry.NewScope())
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+	span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
+	ctx = span.Context()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com/api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := http.Header{}
+	header.Add("Set-Cookie", "sessionid=abc123; Path=/; HttpOnly")
+	header.Add("Set-Cookie", "theme=dark; Path=/settings; Secure")
+	client := &http.Client{Transport: sentryhttpclient.NewSentryRoundTripper(&headerRoundTripper{header: header})}
+
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+
+	span.Finish()
+	if ok := sentryClient.Flush(testutils.FlushTimeout()); !ok {
+		t.Fatal("sentry.Flush timed out")
+	}
+	close(spansCh)
+
+	var got *sentry.Span
+	for spans := range spansCh {
+		for _, candidate := range spans {
+			if candidate.Op == "http.client" {
+				got = candidate
+			}
+		}
+	}
+	if got == nil {
+		t.Fatal("missing http.client span")
+	}
+
+	want := "sessionid=[Filtered]; Path=/; HttpOnly, theme=dark; Path=/settings; Secure"
+	if diff := cmp.Diff(want, got.Data["http.response.header.set-cookie"]); diff != "" {
+		t.Errorf("span data[\"http.response.header.set-cookie\"] mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestIntegration_GlobalClientOptions(t *testing.T) {
 	spansCh := make(chan []*sentry.Span, 1)
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -259,8 +259,7 @@ func newRequest(r *http.Request, client *Client) *Request {
 	var cookies string
 	headers := make(map[string]string, len(r.Header)+1)
 	if dc.CollectCookies() {
-		rawCookie := r.Header.Get("Cookie")
-		cookies = dc.FilterCookies(rawCookie)
+		cookies = dc.FilterCookies(r.Header.Values("Cookie"))
 		if cookies != "" {
 			headers["Cookie"] = cookies
 		}

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -172,6 +172,25 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple cookie header values are combined",
+			makeReq: func() *http.Request {
+				r := httptest.NewRequest("POST", "/test/", nil)
+				r.Header.Add("Cookie", "user_session=abc")
+				r.Header.Add("Cookie", "theme=dark")
+				return r
+			},
+			want: &Request{
+				URL:     "http://example.com/test/",
+				Method:  "POST",
+				Cookies: "user_session=[Filtered]; theme=dark",
+				Headers: map[string]string{
+					"Cookie": "user_session=[Filtered]; theme=dark",
+					"Host":   "example.com",
+				},
+				Env: map[string]string{"REMOTE_ADDR": "192.0.2.1", "REMOTE_PORT": "1234"},
+			},
+		},
+		{
 			name: "off modes omit categories entirely",
 			dc: &DataCollection{
 				UserInfo: Set(false),


### PR DESCRIPTION
### Description
This adds request and response parsing for outgoing http client spans.

### Issues
* resolves: #1251 
* resolves: GO-133

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)

-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>


### Changelog Entry
- Add `ClientOptions.DataCollection` for granular control over data collected by automatic instrumentation, replacing the broad `SendDefaultPII` switch. `DataCollection` can independently configure automatic `user.*` population, cookies, request/response headers, HTTP bodies, and query parameters. When configured, it is the source of truth and `SendDefaultPII` is ignored.
  - For backwards compatibility, clients that do not configure `DataCollection` keep a best-effort mapping of the previous `SendDefaultPII` behavior. To opt in to the new defaults, pass an empty `DataCollection` and then restrict individual categories as needed.
  ```go
  sentry.Init(sentry.ClientOptions{
  	Dsn: "https://public@example.com/1",

  	// Opt in to the new data collection defaults. Omitted fields use their
  	// defaults: user info, cookies, headers, query params, and supported HTTP
  	// bodies are collected, with sensitive values filtered.
  	DataCollection: &sentry.DataCollection{},
  })
  ```
  - To opt in while disabling automatic user info and HTTP bodies, configure those fields explicitly:
  ```go
  sentry.Init(sentry.ClientOptions{
  	Dsn: "https://public@example.com/1",
  	DataCollection: &sentry.DataCollection{
  		UserInfo:   sentry.Set(false),
  		HTTPBodies: []sentry.BodyType{},
  	},
  })
