### PR TITLE
fix: unaligned 64-bit atomic panic on 32-bit platforms in telemetry buffers

### DIFF
--- a/internal/telemetry/bucketed_buffer.go
+++ b/internal/telemetry/bucketed_buffer.go
@@ -46,8 +46,10 @@ type BucketedBuffer[T any] struct {
 	timeout        time.Duration
 	lastFlushTime  time.Time
 
-	offered   int64
-	dropped   int64
+	// atomic.Int64 instead of int64 + atomic ops: 64-bit atomics on plain
+	// mid-struct fields panic on 32-bit platforms (4-byte field alignment).
+	offered   atomic.Int64
+	dropped   atomic.Int64
 	onDropped func(item T, reason string)
 }
 
@@ -94,7 +96,7 @@ func NewBucketedBuffer[T any](
 }
 
 func (b *BucketedBuffer[T]) Offer(item T) bool {
-	atomic.AddInt64(&b.offered, 1)
+	b.offered.Add(1)
 
 	traceID := ""
 	if ta, ok := any(item).(TraceAware); ok {
@@ -152,7 +154,7 @@ func (b *BucketedBuffer[T]) handleOverflow(item T, traceID string) bool {
 		oldestBucket := b.buckets[b.head]
 		if oldestBucket == nil {
 			b.recordDroppedItem(item)
-			atomic.AddInt64(&b.dropped, 1)
+			b.dropped.Add(1)
 			if b.onDropped != nil {
 				b.onDropped(item, "buffer_full_invalid_state")
 			}
@@ -162,7 +164,7 @@ func (b *BucketedBuffer[T]) handleOverflow(item T, traceID string) bool {
 			delete(b.traceIndex, oldestBucket.traceID)
 		}
 		droppedCount := len(oldestBucket.items)
-		atomic.AddInt64(&b.dropped, int64(droppedCount))
+		b.dropped.Add(int64(droppedCount))
 		for _, di := range oldestBucket.items {
 			b.recordDroppedItem(di)
 			if b.onDropped != nil {
@@ -183,14 +185,14 @@ func (b *BucketedBuffer[T]) handleOverflow(item T, traceID string) bool {
 		b.totalItems++
 		return true
 	case OverflowPolicyDropNewest:
-		atomic.AddInt64(&b.dropped, 1)
+		b.dropped.Add(1)
 		b.recordDroppedItem(item)
 		if b.onDropped != nil {
 			b.onDropped(item, "buffer_full_drop_newest")
 		}
 		return false
 	default:
-		atomic.AddInt64(&b.dropped, 1)
+		b.dropped.Add(1)
 		b.recordDroppedItem(item)
 		if b.onDropped != nil {
 			b.onDropped(item, "unknown_overflow_policy")
@@ -351,8 +353,8 @@ func (b *BucketedBuffer[T]) Utilization() float64 {
 	}
 	return float64(b.totalItems) / float64(b.itemCapacity)
 }
-func (b *BucketedBuffer[T]) OfferedCount() int64  { return atomic.LoadInt64(&b.offered) }
-func (b *BucketedBuffer[T]) DroppedCount() int64  { return atomic.LoadInt64(&b.dropped) }
+func (b *BucketedBuffer[T]) OfferedCount() int64  { return b.offered.Load() }
+func (b *BucketedBuffer[T]) DroppedCount() int64  { return b.dropped.Load() }
 func (b *BucketedBuffer[T]) AcceptedCount() int64 { return b.OfferedCount() - b.DroppedCount() }
 func (b *BucketedBuffer[T]) DropRate() float64 {
 	off := b.OfferedCount()

--- a/internal/telemetry/ring_buffer.go
+++ b/internal/telemetry/ring_buffer.go
@@ -30,8 +30,10 @@ type RingBuffer[T any] struct {
 	timeout       time.Duration
 	lastFlushTime time.Time
 
-	offered   int64
-	dropped   int64
+	// atomic.Int64 instead of int64 + atomic ops: 64-bit atomics on plain
+	// mid-struct fields panic on 32-bit platforms (4-byte field alignment).
+	offered   atomic.Int64
+	dropped   atomic.Int64
 	onDropped func(item T, reason string)
 }
 
@@ -72,7 +74,7 @@ func (b *RingBuffer[T]) SetDroppedCallback(callback func(item T, reason string))
 }
 
 func (b *RingBuffer[T]) Offer(item T) bool {
-	atomic.AddInt64(&b.offered, 1)
+	b.offered.Add(1)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -91,7 +93,7 @@ func (b *RingBuffer[T]) Offer(item T) bool {
 		b.head = (b.head + 1) % b.capacity
 		b.tail = (b.tail + 1) % b.capacity
 
-		atomic.AddInt64(&b.dropped, 1)
+		b.dropped.Add(1)
 		b.recordDroppedItem(oldItem)
 		if b.onDropped != nil {
 			b.onDropped(oldItem, "buffer_full_drop_oldest")
@@ -99,7 +101,7 @@ func (b *RingBuffer[T]) Offer(item T) bool {
 		return true
 
 	case OverflowPolicyDropNewest:
-		atomic.AddInt64(&b.dropped, 1)
+		b.dropped.Add(1)
 		b.recordDroppedItem(item)
 		if b.onDropped != nil {
 			b.onDropped(item, "buffer_full_drop_newest")
@@ -107,7 +109,7 @@ func (b *RingBuffer[T]) Offer(item T) bool {
 		return false
 
 	default:
-		atomic.AddInt64(&b.dropped, 1)
+		b.dropped.Add(1)
 		b.recordDroppedItem(item)
 		if b.onDropped != nil {
 			b.onDropped(item, "unknown_overflow_policy")
@@ -244,11 +246,11 @@ func (b *RingBuffer[T]) Utilization() float64 {
 }
 
 func (b *RingBuffer[T]) OfferedCount() int64 {
-	return atomic.LoadInt64(&b.offered)
+	return b.offered.Load()
 }
 
 func (b *RingBuffer[T]) DroppedCount() int64 {
-	return atomic.LoadInt64(&b.dropped)
+	return b.dropped.Load()
 }
 
 func (b *RingBuffer[T]) AcceptedCount() int64 {


### PR DESCRIPTION
### Description

On 32-bit platforms (`GOARCH=arm`, `GOARCH=386`), every event capture panics with `unaligned 64-bit atomic operation`: the `offered`/`dropped` counters of `RingBuffer` and `BucketedBuffer` are plain `int64` fields in the middle of the struct, and the compiler only guarantees them 4-byte alignment there, while 64-bit `sync/atomic` operations require 8-byte alignment (see the "Bugs" section of the `sync/atomic` docs). Since `Client.CaptureEvent` routes through `RingBuffer.Offer` by default, the SDK is effectively unusable on 32-bit ARM (e.g. Raspberry Pi) unless `DisableTelemetryBuffer` is set.

This PR replaces the counters with `atomic.Int64`, whose alignment is guaranteed by the runtime regardless of field position, so future struct refactorings can't reintroduce the panic.

Verified with the existing test suite on a 32-bit target — before the change it reproduces the panic natively:

```
$ GOARCH=386 go test ./internal/telemetry/
panic: unaligned 64-bit atomic operation
  ...
  github.com/getsentry/sentry-go/internal/telemetry.(*RingBuffer[...]).Offer(...)
      internal/telemetry/ring_buffer.go:75
FAIL
```

after the change:

```
$ GOARCH=386 go test ./internal/telemetry/
ok      github.com/getsentry/sentry-go/internal/telemetry
```

`go test ./...`, `go vet`, `gofmt` are clean on amd64 as well.

### Issues

* resolves: #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
