### PR TITLE
fix: preserve '%' literal in log messages

### DIFF
--- a/log.go
+++ b/log.go
@@ -101,7 +101,7 @@ func (l *sentryLogger) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, message string, entryAttrs map[string]attribute.Value, args ...interface{}) {
+func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, message string, entryAttrs map[string]attribute.Value, format bool, args ...interface{}) {
 	if message == "" {
 		return
 	}
@@ -138,6 +138,11 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		attrs[k] = v
 	}
 
+	body := message
+	if format {
+		body = fmt.Sprintf(message, args...)
+	}
+
 	if len(args) > 0 {
 		attrs["sentry.message.template"] = attribute.StringValue(message)
 		for i, p := range args {
@@ -151,14 +156,14 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		SpanID:     spanID,
 		Level:      level,
 		Severity:   severity,
-		Body:       fmt.Sprintf(message, args...),
+		Body:       body,
 		Attributes: attrs,
 	}
 	log.approximateSize = computeLogSize(log)
 
 	client.captureLog(log, scope)
 	if client.options.Debug {
-		debuglog.Printf(message, args...)
+		debuglog.Print(body)
 	}
 }
 
@@ -327,7 +332,7 @@ func (e *logEntry) Uint64(key string, value uint64) LogEntry {
 }
 
 func (e *logEntry) Emit(args ...interface{}) {
-	e.logger.log(e.ctx, e.level, e.severity, fmt.Sprint(args...), e.attributes)
+	e.logger.log(e.ctx, e.level, e.severity, fmt.Sprint(args...), e.attributes, false)
 
 	if e.level == LogLevelFatal {
 		if e.shouldPanic {
@@ -340,7 +345,7 @@ func (e *logEntry) Emit(args ...interface{}) {
 }
 
 func (e *logEntry) Emitf(format string, args ...interface{}) {
-	e.logger.log(e.ctx, e.level, e.severity, format, e.attributes, args...)
+	e.logger.log(e.ctx, e.level, e.severity, format, e.attributes, true, args...)
 
 	if e.level == LogLevelFatal {
 		if e.shouldPanic {

--- a/log_test.go
+++ b/log_test.go
@@ -432,6 +432,66 @@ func Test_sentryLogger_Write(t *testing.T) {
 	}
 }
 
+func Test_sentryLogger_EmitPreservesLiteralPercent(t *testing.T) {
+	tests := []struct {
+		name     string
+		logFunc  func(t *testing.T, ctx context.Context, l Logger)
+		wantBody string
+	}{
+		{
+			name: "Emit with percent",
+			logFunc: func(t *testing.T, ctx context.Context, l Logger) {
+				t.Helper()
+				l.Info().WithCtx(ctx).Emit("disk usage at 95% capacity")
+			},
+			wantBody: "disk usage at 95% capacity",
+		},
+		{
+			name: "Emitf with escaped percent",
+			logFunc: func(t *testing.T, ctx context.Context, l Logger) {
+				t.Helper()
+				l.Warn().WithCtx(ctx).Emitf("got %s and %d, 100%% done", "string", 10)
+			},
+			wantBody: "got string and 10, 100% done",
+		},
+		{
+			name: "Write with percent",
+			logFunc: func(t *testing.T, _ context.Context, l Logger) {
+				t.Helper()
+				msg := []byte("progress 50% complete\n")
+				n, err := l.Write(msg)
+				if err != nil {
+					t.Errorf("Write returned unexpected error: %v", err)
+				}
+				if n != len(msg) {
+					t.Errorf("Write returned wrong byte count: got %d, want %d", n, len(msg))
+				}
+			},
+			wantBody: "progress 50% complete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, mockTransport := setupMockTransport()
+			l := NewLogger(ctx)
+			tt.logFunc(t, ctx, l)
+			flushFromContext(ctx, testutils.FlushTimeout())
+
+			gotEvents := mockTransport.Events()
+			if len(gotEvents) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(gotEvents))
+			}
+			if len(gotEvents[0].Logs) != 1 {
+				t.Fatalf("expected 1 log, got %d", len(gotEvents[0].Logs))
+			}
+			if got := gotEvents[0].Logs[0].Body; got != tt.wantBody {
+				t.Errorf("Body mismatch: got %q, want %q", got, tt.wantBody)
+			}
+		})
+	}
+}
+
 func Test_sentryLogger_FlushAttributesAfterSend(t *testing.T) {
 	msg := []byte("something")
 	ctx, mockTransport := setupMockTransport()
@@ -754,7 +814,7 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 		{
 			name:        "Logs enabled (default)",
 			disableLogs: false,
-			message:     "test message",
+			message:     "disk usage at 95% capacity",
 		},
 		{
 			name:        "Logs disabled",
@@ -785,9 +845,10 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 
 			got := buf.String()
 			if !tt.disableLogs {
-				assertEqual(t, strings.Contains(got, "test message"), true)
+				assertEqual(t, strings.Contains(got, tt.message), true)
+				assertEqual(t, strings.Contains(got, "%!"), false)
 			} else {
-				assertEqual(t, strings.Contains(got, "test message"), false)
+				assertEqual(t, strings.Contains(got, tt.message), false)
 			}
 		})
 	}


### PR DESCRIPTION
### Description
Fixes logs captured with emit to preserve `%` string literals.


### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
