### PR TITLE
fix: omit empty event id for standalone client reports

### DIFF
--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -17,7 +17,7 @@ type Envelope struct {
 // EnvelopeHeader represents the header of a Sentry envelope.
 type EnvelopeHeader struct {
 	// EventID is the unique identifier for this event
-	EventID string `json:"event_id"`
+	EventID string `json:"event_id,omitempty"`
 
 	// SentAt is the timestamp when the event was sent from the SDK as string in RFC 3339 format.
 	// Used for clock drift correction of the event timestamp. The time zone must be UTC.

--- a/internal/protocol/envelope_test.go
+++ b/internal/protocol/envelope_test.go
@@ -132,6 +132,31 @@ func TestEnvelope_ItemsAndSerialization(t *testing.T) {
 	})
 }
 
+func TestEnvelope_SerializationOmitsEmptyEventID(t *testing.T) {
+	envelope := NewEnvelope(
+		&EnvelopeHeader{SentAt: time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)},
+		NewClientReportItem([]byte(`{"timestamp":"2026-07-13T12:00:00Z","discarded_events":[]}`)),
+	)
+
+	data, err := envelope.Serialize()
+	if err != nil {
+		t.Fatalf("Serialize() failed: %v", err)
+	}
+
+	headerData, _, ok := bytes.Cut(data, []byte("\n"))
+	if !ok {
+		t.Fatal("Serialized envelope does not contain an item")
+	}
+
+	var header map[string]any
+	if err := json.Unmarshal(headerData, &header); err != nil {
+		t.Fatalf("Failed to unmarshal envelope header: %v", err)
+	}
+	if _, ok := header["event_id"]; ok {
+		t.Errorf("Envelope header contains an empty event_id: %s", headerData)
+	}
+}
+
 func TestEnvelope_WriteTo(t *testing.T) {
 	header := &EnvelopeHeader{
 		EventID: "12345678901234567890123456789012",


### PR DESCRIPTION
### Description
This changes event_id json serialization to `omitempty` to skip serializing an empty value that would get rejected by relay on standalone client reports

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
