### PR TITLE
fix: fix fiber route name when using middlewares

### DIFF
--- a/fiber/go.mod
+++ b/fiber/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.71.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/fiber/go.sum
+++ b/fiber/go.sum
@@ -18,6 +18,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
+github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -29,6 +31,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
+github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.71.0 h1:tepR7H+Guh9VUqxxcPggYi8R3lGUu2Rsdh+z7/FCY3k=

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -92,10 +92,9 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 	ctx.SetUserContext(transaction.Context())
 
 	defer func() {
-		if routePath := ctx.Route().Path; routePath != "" {
-			transaction.Name = fmt.Sprintf("%s %s", r.Method, routePath)
-			transaction.Source = sentry.SourceRoute
-		}
+		// Fiber v2 does not expose whether ctx.Route() originates from a middleware. We keep the
+		// URL-based name (opposite to v3) because middlewares that short-circuits the handler chain can
+		// otherwise replace the ctx.Route(). See https://github.com/getsentry/sentry-go/issues/1361.
 		status := ctx.Response().StatusCode()
 		transaction.Status = sentry.HTTPtoSpanStatus(status)
 		transaction.SetData("http.response.status_code", status)

--- a/fiber/sentryfiber_test.go
+++ b/fiber/sentryfiber_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cache"
 
 	"github.com/getsentry/sentry-go"
 	sentryfiber "github.com/getsentry/sentry-go/fiber"
@@ -19,7 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func wantFiberTransaction(routePath, requestURL, method, body string, status int) *sentry.Event {
+func wantFiberTransaction(requestURL, method, body string, status int) *sentry.Event {
 	headers := map[string]string{
 		"Host":       "example.com",
 		"User-Agent": "fiber",
@@ -34,14 +35,14 @@ func wantFiberTransaction(routePath, requestURL, method, body string, status int
 	return &sentry.Event{
 		Level:       sentry.LevelInfo,
 		Type:        "transaction",
-		Transaction: fmt.Sprintf("%s %s", method, routePath),
+		Transaction: fmt.Sprintf("%s %s", method, requestURL),
 		Request: &sentry.Request{
 			URL:     "http://example.com" + requestURL,
 			Method:  method,
 			Data:    body,
 			Headers: headers,
 		},
-		TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+		TransactionInfo: &sentry.TransactionInfo{Source: "url"},
 		Contexts: map[string]sentry.Context{
 			"trace": sentry.TraceContext{
 				Data: map[string]interface{}{
@@ -142,7 +143,7 @@ func TestIntegration(t *testing.T) {
 						"User-Agent": "fiber",
 					},
 				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
 				Contexts: map[string]sentry.Context{
 					"trace": sentry.TraceContext{
 						Data: map[string]interface{}{
@@ -176,7 +177,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			WantTransaction: wantFiberTransaction("/post", "/post", http.MethodPost, `{"safe":"value"}`, http.StatusOK),
+			WantTransaction: wantFiberTransaction("/post", http.MethodPost, `{"safe":"value"}`, http.StatusOK),
 		},
 		{
 			Path:       "/get",
@@ -207,7 +208,7 @@ func TestIntegration(t *testing.T) {
 						"User-Agent": "fiber",
 					},
 				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
 				Contexts: map[string]sentry.Context{
 					"trace": sentry.TraceContext{
 						Data: map[string]interface{}{
@@ -239,7 +240,7 @@ func TestIntegration(t *testing.T) {
 			WantTransaction: &sentry.Event{
 				Level:       sentry.LevelInfo,
 				Type:        "transaction",
-				Transaction: "GET /get/:id",
+				Transaction: "GET /get/123",
 				Request: &sentry.Request{
 					URL:    "http://example.com/get/123",
 					Method: http.MethodGet,
@@ -248,7 +249,7 @@ func TestIntegration(t *testing.T) {
 						"User-Agent": "fiber",
 					},
 				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
 				Contexts: map[string]sentry.Context{
 					"trace": sentry.TraceContext{
 						Data: map[string]interface{}{
@@ -295,7 +296,7 @@ func TestIntegration(t *testing.T) {
 						"User-Agent":     "fiber",
 					},
 				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
 				Contexts: map[string]sentry.Context{
 					"trace": sentry.TraceContext{
 						Data: map[string]interface{}{
@@ -330,7 +331,7 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			WantTransaction: wantFiberTransaction("/post/body-ignored", "/post/body-ignored", http.MethodPost, `{"safe":"body ignored"}`, http.StatusOK),
+			WantTransaction: wantFiberTransaction("/post/body-ignored", http.MethodPost, `{"safe":"body ignored"}`, http.StatusOK),
 		},
 		{
 			Path:       "/post/error-handler",
@@ -368,7 +369,7 @@ func TestIntegration(t *testing.T) {
 						"Content-Length": "0",
 					},
 				},
-				TransactionInfo: &sentry.TransactionInfo{Source: "route"},
+				TransactionInfo: &sentry.TransactionInfo{Source: "url"},
 				Contexts: map[string]sentry.Context{
 					"trace": sentry.TraceContext{
 						Data: map[string]interface{}{
@@ -504,6 +505,48 @@ func TestIntegration(t *testing.T) {
 
 	if diff := cmp.Diff(wantCodes, gotCodes, cmp.Options{}); diff != "" {
 		t.Fatalf("Transaction status codes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransactionNameWithCacheHit(t *testing.T) {
+	transactions := make(chan *sentry.Event, 2)
+	err := sentry.Init(sentry.ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			transactions <- tx
+			return tx
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := fiber.New()
+	app.Use(sentryfiber.New(sentryfiber.Options{}))
+	app.Use(cache.New(cache.Config{Expiration: 30 * time.Second}))
+	app.Get("/items", func(c *fiber.Ctx) error {
+		c.Response().Header.Set(fiber.HeaderCacheControl, "public")
+		return c.SendString("ok")
+	})
+
+	for range 2 {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com/items", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+
+	for i := range 2 {
+		tx := <-transactions
+		if tx.Transaction != "GET /items" {
+			t.Errorf("Transaction %d name = %q, want %q", i, tx.Transaction, "GET /items")
+		}
 	}
 }
 

--- a/fiberv3/sentryfiber.go
+++ b/fiberv3/sentryfiber.go
@@ -92,7 +92,7 @@ func (h *handler) handle(ctx fiber.Ctx) error {
 	ctx.SetContext(transaction.Context())
 
 	defer func() {
-		if routePath := ctx.Route().Path; routePath != "" {
+		if routePath := ctx.Route().Path; routePath != "" && !ctx.IsMiddleware() {
 			transaction.Name = fmt.Sprintf("%s %s", r.Method, routePath)
 			transaction.Source = sentry.SourceRoute
 		}

--- a/fiberv3/sentryfiber_test.go
+++ b/fiberv3/sentryfiber_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	fiber "github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/cache"
 
 	"github.com/getsentry/sentry-go"
 	sentryfiber "github.com/getsentry/sentry-go/fiberv3"
@@ -503,6 +504,48 @@ func TestIntegration(t *testing.T) {
 
 	if diff := cmp.Diff(wantCodes, gotCodes, cmp.Options{}); diff != "" {
 		t.Fatalf("Transaction status codes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransactionNameWithCacheHit(t *testing.T) {
+	transactions := make(chan *sentry.Event, 2)
+	err := sentry.Init(sentry.ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+		BeforeSendTransaction: func(tx *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			transactions <- tx
+			return tx
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := fiber.New()
+	app.Use(sentryfiber.New(sentryfiber.Options{}))
+	app.Use(cache.New(cache.Config{Expiration: 30 * time.Second}))
+	app.Get("/items", func(c fiber.Ctx) error {
+		c.Response().Header.Set(fiber.HeaderCacheControl, "public")
+		return c.SendString("ok")
+	})
+
+	for range 2 {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com/items", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+
+	for i := range 2 {
+		tx := <-transactions
+		if tx.Transaction != "GET /items" {
+			t.Errorf("Transaction %d name = %q, want %q", i, tx.Transaction, "GET /items")
+		}
 	}
 }
 


### PR DESCRIPTION
### Description
This partially reverts https://github.com/getsentry/sentry-go/pull/1325 and fixes the transaction route name when using middlewares for fiber and fiberv3.

The problem originates from middlewares that short-circuit and update `ctx.Route()`, thus changing the `transaction.name` to the middleware path rather than the correct route name. For fiberv3 the solution is using `ctx.IsMiddleware` to not update `transaction.name` when the route url is from a middleware. For fiber v2 however the functionality doesn't exist, so we should rely on the initial route and `transaction_source = url`. 

### Issues
* resolves: #1361 
* resolves: GO-152

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
