### PR TITLE
fix(echo): propagate span through request context

### DIFF
--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -116,6 +116,8 @@ func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 		hub.Scope().SetRequest(r)
 		ctx.Set(valuesKey, hub)
 		ctx.Set(transactionKey, transaction)
+		r = r.WithContext(transaction.Context())
+		ctx.SetRequest(r)
 		defer h.recoverWithSentry(hub, r)
 
 		err := next(ctx)

--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -569,6 +569,9 @@ func TestGetSpanFromContext(t *testing.T) {
 		if span == nil {
 			t.Error("expecting span to not be nil")
 		}
+		if requestSpan := sentry.SpanFromContext(c.Request().Context()); requestSpan != span {
+			t.Error("expecting request context to contain the middleware span")
+		}
 		return c.NoContent(http.StatusOK)
 	}, sentryecho.New(sentryecho.Options{}))
 


### PR DESCRIPTION
### Description

  - Attach the middleware transaction context to Echo's request so downstream handlers can retrieve the active span from `Request.Context()`.

  - Adds regression coverage verifying that the request context contains the same span exposed by `sentryecho.GetSpanFromContext`.