### PR TITLE
fix: guard the buffered request body against concurrent access

### DIFF
--- a/internal/httputils/body.go
+++ b/internal/httputils/body.go
@@ -3,6 +3,7 @@ package httputils
 import (
 	"bytes"
 	"io"
+	"sync"
 )
 
 // MaxBodyBytes is the maximum number of bytes the SDK captures from an HTTP
@@ -19,10 +20,15 @@ type ReadCloser struct {
 // LimitedBuffer is like a bytes.Buffer, but limited to store at most Capacity
 // bytes. Any writes past the capacity are silently discarded, similar to
 // io.Discard.
+//
+// A LimitedBuffer is safe for concurrent use. It is typically filled from the
+// goroutine that reads the request body, while the buffered bytes are read
+// from whichever goroutine captures an event.
 type LimitedBuffer struct {
 	Capacity int
 
-	bytes.Buffer
+	mu       sync.Mutex
+	buf      bytes.Buffer
 	overflow bool
 }
 
@@ -38,17 +44,20 @@ func NewLimitedBufferFromBytes(capacity int, b []byte) *LimitedBuffer {
 		buf.overflow = true
 		b = b[:capacity]
 	}
-	buf.Buffer = *bytes.NewBuffer(b)
+	buf.buf = *bytes.NewBuffer(b)
 	return buf
 }
 
 // Write implements io.Writer.
 func (b *LimitedBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	originalLen := len(p)
 	if b.overflow {
 		return originalLen, nil
 	}
-	left := b.Capacity - b.Len()
+	left := b.Capacity - b.buf.Len()
 	if left < 0 {
 		left = 0
 	}
@@ -56,12 +65,43 @@ func (b *LimitedBuffer) Write(p []byte) (n int, err error) {
 		b.overflow = true
 		p = p[:left]
 	}
-	_, err = b.Buffer.Write(p)
+	_, err = b.buf.Write(p)
 	return originalLen, err
+}
+
+// Bytes returns a copy of the buffered bytes. The copy keeps the result stable
+// while the buffer keeps growing.
+func (b *LimitedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.buf.Len() == 0 {
+		return nil
+	}
+	return bytes.Clone(b.buf.Bytes())
+}
+
+// Len returns the number of buffered bytes.
+func (b *LimitedBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Len()
+}
+
+// String returns the buffered bytes as a string.
+func (b *LimitedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
 }
 
 // Overflow returns true if the LimitedBuffer discarded bytes written to it.
 func (b *LimitedBuffer) Overflow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	return b.overflow
 }
 

--- a/internal/httputils/body_test.go
+++ b/internal/httputils/body_test.go
@@ -68,6 +68,35 @@ func TestLimitedBuffer(t *testing.T) {
 		}
 	})
 
+	t.Run("reads while being written", func(t *testing.T) {
+		buf := NewLimitedBuffer(64)
+
+		start := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			<-start
+			for range 1000 {
+				_ = buf.Overflow()
+				_ = buf.Len()
+				_ = buf.Bytes()
+			}
+		}()
+		close(start)
+		for range 1000 {
+			_, _ = buf.Write([]byte("chunk"))
+		}
+
+		<-done
+
+		if got := buf.Len(); got != 64 {
+			t.Fatalf("Len = %d, want 64", got)
+		}
+		if !buf.Overflow() {
+			t.Fatal("Overflow = false, want true")
+		}
+	})
+
 	t.Run("initial bytes mark overflow", func(t *testing.T) {
 		buf := NewLimitedBufferFromBytes(5, []byte("hello world"))
 		if got := buf.String(); got != "hello" {


### PR DESCRIPTION
`Scope.SetRequest` replaces the request body with a `TeeReader` that fills a `LimitedBuffer`, so the buffer is written from whichever goroutine reads the body. the same buffer is read in `Scope.ApplyToEvent` when an event is captured

nothing synchronizes the two sides: the reader holds the scope lock, the `TeeReader` takes none. `Scope.Clone` also copies the pointer to the buffer, so cloning the hub for a goroutine, which is the documented way to use the SDK concurrently, shares the buffer instead of isolating it

it is reachable without opting into body collection: `SetRequest` installs the tee unconditionally, and `ApplyToEvent` evaluates `requestBody.Overflow()` before it checks `CollectHTTPBody`, so the flag is read while the body is still streaming. `go test -race` reports the write in `LimitedBuffer.Write` against the read in `Overflow`

this serializes access inside `LimitedBuffer`. the embedded `bytes.Buffer` is unexported so the promoted methods cannot bypass the lock, and `Bytes` returns a copy so the result stays stable while the body keeps growing. the buffer is capped at 10 KiB, so the copy is bounded