### PR TITLE
fix: build DSN urls with net/url instead of string concatenation

### DIFF
--- a/internal/protocol/dsn.go
+++ b/internal/protocol/dsn.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -142,6 +143,18 @@ func NewDsn(rawURL string) (*Dsn, error) {
 	}, nil
 }
 
+// hostPort returns the host of the DSN, enclosed in brackets when it is an IPv6
+// address, followed by the port when it is not the default one for the scheme.
+func (dsn Dsn) hostPort() string {
+	if dsn.port == dsn.scheme.defaultPort() {
+		if strings.Contains(dsn.host, ":") {
+			return "[" + dsn.host + "]"
+		}
+		return dsn.host
+	}
+	return net.JoinHostPort(dsn.host, strconv.Itoa(dsn.port))
+}
+
 // String formats Dsn struct into a valid string url.
 func (dsn Dsn) String() string {
 	var url string
@@ -149,10 +162,7 @@ func (dsn Dsn) String() string {
 	if dsn.secretKey != "" {
 		url += fmt.Sprintf(":%s", dsn.secretKey)
 	}
-	url += fmt.Sprintf("@%s", dsn.host)
-	if dsn.port != dsn.scheme.defaultPort() {
-		url += fmt.Sprintf(":%d", dsn.port)
-	}
+	url += fmt.Sprintf("@%s", dsn.hostPort())
 	if dsn.path != "" {
 		url += dsn.path
 	}
@@ -210,17 +220,11 @@ func (dsn *Dsn) SetOrgID(orgID uint64) {
 // GetAPIURL returns the URL of the envelope endpoint of the project
 // associated with the DSN.
 func (dsn Dsn) GetAPIURL() *url.URL {
-	var rawURL string
-	rawURL += fmt.Sprintf("%s://%s", dsn.scheme, dsn.host)
-	if dsn.port != dsn.scheme.defaultPort() {
-		rawURL += fmt.Sprintf(":%d", dsn.port)
+	return &url.URL{
+		Scheme: string(dsn.scheme),
+		Host:   dsn.hostPort(),
+		Path:   fmt.Sprintf("%s/api/%s/%s/", dsn.path, dsn.projectID, "envelope"),
 	}
-	if dsn.path != "" {
-		rawURL += dsn.path
-	}
-	rawURL += fmt.Sprintf("/api/%s/%s/", dsn.projectID, "envelope")
-	parsedURL, _ := url.Parse(rawURL)
-	return parsedURL
 }
 
 // RequestHeaders returns all the necessary headers that have to be used in the transport when sending events

--- a/internal/protocol/dsn_test.go
+++ b/internal/protocol/dsn_test.go
@@ -56,6 +56,30 @@ var dsnTests = map[string]DsnTest{
 		url:    "http://domain/api/42/store/",
 		envURL: "http://domain/api/42/envelope/",
 	},
+	"IPv6WithPort": {
+		in: "https://public@[2001:db8::1]:8888/42",
+		dsn: &Dsn{
+			scheme:    SchemeHTTPS,
+			publicKey: "public",
+			host:      "2001:db8::1",
+			port:      8888,
+			projectID: "42",
+		},
+		url:    "https://[2001:db8::1]:8888/api/42/store/",
+		envURL: "https://[2001:db8::1]:8888/api/42/envelope/",
+	},
+	"IPv6DefaultPort": {
+		in: "https://public@[::1]/42",
+		dsn: &Dsn{
+			scheme:    SchemeHTTPS,
+			publicKey: "public",
+			host:      "::1",
+			port:      443,
+			projectID: "42",
+		},
+		url:    "https://[::1]/api/42/store/",
+		envURL: "https://[::1]/api/42/envelope/",
+	},
 }
 
 func TestNewDsn(t *testing.T) {
@@ -72,6 +96,54 @@ func TestNewDsn(t *testing.T) {
 			url := dsn.GetAPIURL().String()
 			if diff := cmp.Diff(tt.envURL, url); diff != "" {
 				t.Errorf("dsn.EnvelopeAPIURL() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetAPIURLIsNeverNil(t *testing.T) {
+	tests := map[string]string{
+		"IPv6ZoneID":     "http://public@[fe80::1%25eth0]:9000/42",
+		"EncodedNewline": "http://public@domain/42%0A",
+		"EncodedNull":    "http://public@domain/42%00",
+		"EncodedHash":    "http://public@domain/pre%23fix/42",
+	}
+
+	for name, in := range tests {
+		t.Run(name, func(t *testing.T) {
+			dsn, err := NewDsn(in)
+			if err != nil {
+				t.Skipf("NewDsn() rejects %q: %v", in, err)
+			}
+			// Callers dereference the result from a background goroutine, where
+			// a nil URL takes the whole process down.
+			apiURL := dsn.GetAPIURL()
+			if apiURL == nil {
+				t.Fatalf("GetAPIURL() = nil for %q, which NewDsn() accepted", in)
+			}
+			if !strings.HasSuffix(apiURL.Path, "/envelope/") {
+				t.Errorf("GetAPIURL().Path = %q, want it to end in /envelope/", apiURL.Path)
+			}
+			if apiURL.RawQuery != "" || apiURL.Fragment != "" {
+				t.Errorf("GetAPIURL() = %q, want no query (%q) and no fragment (%q)", apiURL, apiURL.RawQuery, apiURL.Fragment)
+			}
+		})
+	}
+}
+
+func TestDsnStringRoundTrip(t *testing.T) {
+	for name, tt := range dsnTests {
+		t.Run(name, func(t *testing.T) {
+			dsn, err := NewDsn(tt.in)
+			if err != nil {
+				t.Fatalf("NewDsn() error: %q", err)
+			}
+			reparsed, err := NewDsn(dsn.String())
+			if err != nil {
+				t.Fatalf("NewDsn(%q) error: %q", dsn.String(), err)
+			}
+			if diff := cmp.Diff(dsn, reparsed, cmp.AllowUnexported(Dsn{})); diff != "" {
+				t.Errorf("re-parsing String() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
`GetAPIURL` assembles the envelope endpoint by concatenating strings and then drops the error from `url.Parse`, so a DSN that `NewDsn` accepts can still yield a nil URL. the transports dereference that result from their own goroutines, where a nil pointer takes the whole process down instead of surfacing as a configuration error

with `Dsn: "http://public@domain/42%0A"` `Init` returns no error and the first `CaptureMessage` panics in `AsyncTransport.worker`, so a `recover` in user code cannot catch it. the same happens for a percent-encoded null byte and for an IPv6 zone id. `dsn_test.go` already asserts `GetAPIURL() != nil`, so nil looks unintended

the same concatenation leaves IPv6 hosts unbracketed: `String` turns `http://key@[::1]/1` into `http://key@::1/1`, which re-parses with host ":" and port 1, and `MarshalJSON` carries that corrupted form

this builds the API URL as a `url.URL`, which escapes the path and cannot fail, and brackets IPv6 hosts in both `String` and `GetAPIURL`. tests cover the IPv6 cases, the round trip through `String` and the inputs that used to return nil