### PR TITLE
feat!: remove DisableLogs and DisableMetrics options

### DIFF
--- a/_examples/logs/main.go
+++ b/_examples/logs/main.go
@@ -12,7 +12,6 @@ import (
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "",
-		// Logs are enabled by default. Set DisableLogs: true to disable.
 	})
 	if err != nil {
 		panic(err)

--- a/client.go
+++ b/client.go
@@ -270,11 +270,6 @@ type ClientOptions struct {
 	MaxErrorDepth int
 	// Default event tags. These are overridden by tags set on a scope.
 	Tags map[string]string
-	// DisableLogs controls whether logs should be emitted.
-	// By default, logs are enabled. Set to true to disable log emission.
-	DisableLogs bool
-	// DisableMetrics controls when metrics should be emitted.
-	DisableMetrics bool
 	// DisableClientReports controls when client reports should be emitted.
 	DisableClientReports bool
 	// TraceIgnoreStatusCodes is a list of HTTP status codes that should not be traced.
@@ -442,14 +437,10 @@ func NewClient(options ClientOptions) (*Client, error) {
 		}
 		client.setupTransport()
 
-		if !options.DisableLogs {
-			client.batchLogger = newLogBatchProcessor(&client)
-			client.batchLogger.Start()
-		}
-		if !options.DisableMetrics {
-			client.batchMeter = newMetricBatchProcessor(&client)
-			client.batchMeter.Start()
-		}
+		client.batchLogger = newLogBatchProcessor(&client)
+		client.batchLogger.Start()
+		client.batchMeter = newMetricBatchProcessor(&client)
+		client.batchMeter.Start()
 	}
 	client.setupIntegrations()
 	if options.OrgID != 0 && client.dsn != nil {

--- a/log.go
+++ b/log.go
@@ -51,7 +51,7 @@ type logEntry struct {
 	shouldFatal bool
 }
 
-// NewLogger returns a Logger that emits logs to Sentry. If logging is turned off, all logs get discarded.
+// NewLogger returns a Logger that emits logs to Sentry.
 func NewLogger(ctx context.Context) Logger { // nolint: dupl
 	var hub *Hub
 	hub = GetHubFromContext(ctx)
@@ -60,7 +60,7 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 	}
 
 	client := hub.Client()
-	if client != nil && !client.options.DisableLogs {
+	if client != nil {
 		// Build default attrs
 		serverAddr := client.options.ServerName
 		if serverAddr == "" {
@@ -91,7 +91,7 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 		}
 	}
 
-	debuglog.Println("fallback to noopLogger: SDK not initialized or logs disabled")
+	debuglog.Println("fallback to noopLogger: SDK not initialized")
 	return &noopLogger{}
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -816,11 +816,6 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 			disableLogs: false,
 			message:     "disk usage at 95% capacity",
 		},
-		{
-			name:        "Logs disabled",
-			disableLogs: true,
-			message:     "test message",
-		},
 	}
 
 	for _, tt := range tests {
@@ -829,9 +824,8 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 
 			ctx := context.Background()
 			mockClient, _ := NewClient(ClientOptions{
-				Transport:   &MockTransport{},
-				DisableLogs: tt.disableLogs,
-				Debug:       true,
+				Transport: &MockTransport{},
+				Debug:     true,
 			})
 			hub := CurrentHub()
 			hub.BindClient(mockClient)
@@ -844,12 +838,8 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 			logger.Info().WithCtx(ctx).Emit(tt.message)
 
 			got := buf.String()
-			if !tt.disableLogs {
-				assertEqual(t, strings.Contains(got, tt.message), true)
-				assertEqual(t, strings.Contains(got, "%!"), false)
-			} else {
-				assertEqual(t, strings.Contains(got, tt.message), false)
-			}
+			assertEqual(t, strings.Contains(got, tt.message), true)
+			assertEqual(t, strings.Contains(got, "%!"), false)
 		})
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -807,14 +807,12 @@ func Test_sentryLogger_TracePropagationWithTransaction(t *testing.T) {
 
 func TestSentryLogger_DebugLogging(t *testing.T) {
 	tests := []struct {
-		name        string
-		disableLogs bool
-		message     string
+		name    string
+		message string
 	}{
 		{
-			name:        "Logs enabled (default)",
-			disableLogs: false,
-			message:     "disk usage at 95% capacity",
+			name:    "Logs enabled (default)",
+			message: "disk usage at 95% capacity",
 		},
 	}
 

--- a/logrus/logrusentry.go
+++ b/logrus/logrusentry.go
@@ -228,9 +228,6 @@ func (h *logHook) FlushWithContext(ctx context.Context) bool {
 // NewLogHook initializes a new Logrus hook which sends logs to a new Sentry client
 // configured according to opts.
 func NewLogHook(levels []logrus.Level, opts sentry.ClientOptions) (Hook, error) {
-	if opts.DisableLogs {
-		return nil, errors.New("cannot create log hook, DisableLogs is set to true")
-	}
 	client, err := sentry.NewClient(opts)
 	if err != nil {
 		return nil, err

--- a/logrus/logrusentry_test.go
+++ b/logrus/logrusentry_test.go
@@ -41,13 +41,6 @@ func TestNewLogHook(t *testing.T) {
 		}
 	})
 
-	t.Run("DisableLogs", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := NewLogHook(levels, sentry.ClientOptions{DisableLogs: true})
-		assert.EqualError(t, err, "cannot create log hook, DisableLogs is set to true")
-	})
-
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 

--- a/metrics.go
+++ b/metrics.go
@@ -47,7 +47,7 @@ const (
 	UnitPercent = "percent"
 )
 
-// NewMeter returns a new Meter. If there is no Client bound to the current hub, or if metrics are disabled,
+// NewMeter returns a new Meter. If there is no Client bound to the current hub,
 // it returns a no-op Meter that discards all metrics.
 func NewMeter(ctx context.Context) Meter {
 	hub := GetHubFromContext(ctx)
@@ -55,7 +55,7 @@ func NewMeter(ctx context.Context) Meter {
 		hub = CurrentHub()
 	}
 	client := hub.Client()
-	if client != nil && !client.options.DisableMetrics {
+	if client != nil {
 		// build default attrs
 		serverAddr := client.options.ServerName
 		if serverAddr == "" {
@@ -86,7 +86,7 @@ func NewMeter(ctx context.Context) Meter {
 		}
 	}
 
-	debuglog.Printf("fallback to noopMeter: metrics disabled")
+	debuglog.Printf("fallback to noopMeter: SDK not initialized")
 	return &noopMeter{}
 }
 
@@ -222,20 +222,20 @@ func (n *noopMeter) WithCtx(_ context.Context) Meter {
 
 // Count implements Meter.
 func (n *noopMeter) Count(name string, _ int64, _ ...MeterOption) {
-	debuglog.Printf("Metric %q is being dropped. Turn on metrics by setting DisableMetrics to false", name)
+	debuglog.Printf("Metric %q is being dropped. Ensure the SDK is initialized", name)
 }
 
 // Distribution implements Meter.
 func (n *noopMeter) Distribution(name string, _ float64, _ ...MeterOption) {
-	debuglog.Printf("Metric %q is being dropped. Turn on metrics by setting DisableMetrics to false", name)
+	debuglog.Printf("Metric %q is being dropped. Ensure the SDK is initialized", name)
 }
 
 // Gauge implements Meter.
 func (n *noopMeter) Gauge(name string, _ float64, _ ...MeterOption) {
-	debuglog.Printf("Metric %q is being dropped. Turn on metrics by setting DisableMetrics to false", name)
+	debuglog.Printf("Metric %q is being dropped. Ensure the SDK is initialized", name)
 }
 
 // SetAttributes implements Meter.
 func (n *noopMeter) SetAttributes(_ ...attribute.Builder) {
-	debuglog.Printf("No attributes attached. Turn on metrics by setting DisableMetrics to false")
+	debuglog.Printf("No attributes attached")
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -647,31 +647,6 @@ func Test_sentryMeter_AttributePrecedence(t *testing.T) {
 	}
 }
 
-func TestNewMeter_DisabledMetrics(t *testing.T) {
-	ctx := context.Background()
-	mockTransport := &MockTransport{}
-	mockClient, _ := NewClient(ClientOptions{
-		Dsn:            testDsn,
-		Transport:      mockTransport,
-		DisableMetrics: true,
-	})
-	hub := CurrentHub()
-	hub.BindClient(mockClient)
-	ctx = SetHubOnContext(ctx, hub)
-
-	meter := NewMeter(ctx)
-	meter.Count("test.count", 1)
-	meter.Gauge("test.gauge", 2.5)
-	meter.Distribution("test.dist", 3.14)
-
-	flushFromContext(ctx, testutils.FlushTimeout())
-
-	events := mockTransport.Events()
-	if len(events) != 0 {
-		t.Fatalf("expected no events with disabled metrics, got %d", len(events))
-	}
-}
-
 func Test_sentryMeter_EmptyName(t *testing.T) {
 	ctx, mockTransport := setupMetricsTest()
 	meter := NewMeter(ctx)

--- a/zap/README.md
+++ b/zap/README.md
@@ -180,5 +180,4 @@ scopedLogger.Info("Processing completed")
 ## Notes
 
 - This integration only sends logs to Sentry (not events/errors). For error reporting, use the main `sentry-go` package.
-- Logs are enabled by default. If you have `DisableLogs: true`, remove it to enable log emission.
 - Call `sentry.Flush()` before your application exits to ensure all logs are sent.


### PR DESCRIPTION
### Description
This is a followup to https://github.com/getsentry/sentry-go/pull/1306 and removes `DisableMetrics` and `DisableLogs` options. Users already need to use an integration or our own API to opt in to sending metrics and logs, so the option are somewhat conflicting.

### Issues
* resolves: #1391
* resolves: GO-158

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)

-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>

### Changelog Entry
- removing DisableLogs and DisableMetrics client options. Sending metrics and logs is already gated by the usage of our APIs already, so having a global kill switch is counter intuitive. Users that won't to opt out should just not call the relevant APIs or setup the integrations.