### PR TITLE
feat: add CapturePanic method

### DIFF
--- a/attribute/value.go
+++ b/attribute/value.go
@@ -305,6 +305,8 @@ func (t Type) String() string {
 	return "invalid"
 }
 
+const arrayType = "array"
+
 // mapTypesToStr is a map from attribute.Type to the primitive types the server understands.
 // https://develop.sentry.dev/sdk/foundations/data-model/attributes/#primitive-types
 var mapTypesToStr = map[Type]string{
@@ -313,9 +315,9 @@ var mapTypesToStr = map[Type]string{
 	INT64:        "integer",
 	FLOAT64:      "double",
 	STRING:       "string",
-	BOOLSLICE:    "array",
-	INT64SLICE:   "array",
-	FLOAT64SLICE: "array",
-	STRINGSLICE:  "array",
+	BOOLSLICE:    arrayType,
+	INT64SLICE:   arrayType,
+	FLOAT64SLICE: arrayType,
+	STRINGSLICE:  arrayType,
 	UINT64:       "integer", // wire format: same "integer" type
 }

--- a/capture_options.go
+++ b/capture_options.go
@@ -1,0 +1,35 @@
+package sentry
+
+import "context"
+
+// CaptureOption configures a single event capture.
+type CaptureOption func(*captureOptions)
+
+// WithEventHint supplies metadata to event processors and before-send hooks.
+func WithEventHint(hint *EventHint) CaptureOption {
+	return func(options *captureOptions) { options.hint = hint }
+}
+
+// WithLevel sets an explicit level for the capture.
+func WithLevel(level Level) CaptureOption {
+	return func(options *captureOptions) { options.level = level }
+}
+
+func resolveCaptureOptions(ctx context.Context, options []CaptureOption) captureOptions {
+	var resolved captureOptions
+	for _, option := range options {
+		if option != nil {
+			option(&resolved)
+		}
+	}
+
+	hint := &EventHint{}
+	if resolved.hint != nil {
+		*hint = *resolved.hint
+	}
+	if ctx != nil {
+		hint.Context = ctx
+	}
+	resolved.hint = hint
+	return resolved
+}

--- a/check_in.go
+++ b/check_in.go
@@ -76,7 +76,7 @@ func IntervalSchedule(value int64, unit MonitorScheduleUnit) MonitorSchedule {
 	}
 }
 
-type MonitorConfig struct { //nolint: maligned // prefer readability over optimal memory layout
+type MonitorConfig struct {
 	Schedule MonitorSchedule `json:"schedule,omitempty"`
 	// The allowed margin of minutes after the expected check-in time that
 	// the monitor will not be considered missed for.
@@ -93,7 +93,7 @@ type MonitorConfig struct { //nolint: maligned // prefer readability over optima
 	RecoveryThreshold int64 `json:"recovery_threshold,omitempty"`
 }
 
-type CheckIn struct { //nolint: maligned // prefer readability over optimal memory layout
+type CheckIn struct {
 	// Check-In ID (unique and client generated)
 	ID EventID `json:"check_in_id"`
 	// The distinct slug of the monitor.
@@ -106,7 +106,7 @@ type CheckIn struct { //nolint: maligned // prefer readability over optimal memo
 
 // serializedCheckIn is used by checkInMarshalJSON method on Event struct.
 // See https://develop.sentry.dev/sdk/check-ins/
-type serializedCheckIn struct { //nolint: maligned
+type serializedCheckIn struct {
 	// Check-In ID (unique and client generated).
 	CheckInID string `json:"check_in_id"`
 	// The distinct slug of the monitor.

--- a/client.go
+++ b/client.go
@@ -1023,7 +1023,7 @@ func applyScopeChain(event *Event, client *Client, scope *Scope, opts captureOpt
 	}
 	applyTraceToEvent(event, resolveTrace(scope, client, ctx))
 
-	return state.applyToEvent(event, opts.hint, opts, client)
+	return state.applyToEvent(event, opts.hint, client, opts)
 }
 
 func (client *Client) prepareEvent(event *Event, scope *Scope, opts captureOptions) *Event {

--- a/client.go
+++ b/client.go
@@ -634,20 +634,21 @@ type captureOptions struct {
 	hint *EventHint
 	// level is an explicit level from the capture call.
 	level Level
+	// defaultLevel is the helper's fallback when neither the event, capture
+	// options, nor scope provides a level.
+	defaultLevel Level
 }
 
 // CaptureMessage captures an arbitrary message.
 func (client *Client) CaptureMessage(message string, hint *EventHint, scope *Scope) *EventID {
 	event := client.eventFromMessage(message)
-	event.Level = LevelInfo
-	return client.CaptureEvent(event, hint, scope)
+	return client.captureEvent(event, scope, captureOptions{hint: hint, defaultLevel: LevelInfo})
 }
 
 // CaptureException captures an error.
 func (client *Client) CaptureException(exception error, hint *EventHint, scope *Scope) *EventID {
 	event := client.eventFromException(exception)
-	event.Level = LevelError
-	return client.CaptureEvent(event, hint, scope)
+	return client.captureEvent(event, scope, captureOptions{hint: hint, defaultLevel: LevelError})
 }
 
 // CaptureCheckIn captures a check in.
@@ -667,10 +668,18 @@ func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorCon
 // the utility methods like CaptureException. The return value is the
 // event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
 func (client *Client) CaptureEvent(event *Event, hint *EventHint, scope *Scope) *EventID {
+	return client.captureEvent(event, scope, captureOptions{hint: hint})
+}
+
+func (client *Client) captureEvent(event *Event, scope *Scope, opts captureOptions) *EventID {
 	if !client.IsEnabled() {
 		return nil
 	}
-	return client.processEvent(event, scope, captureOptions{hint: hint})
+	if event == nil {
+		event = client.eventFromException(usageError{fmt.Errorf("CaptureEvent called with nil event")})
+		event.Level = LevelError
+	}
+	return client.processEvent(event, scope, opts)
 }
 
 func (client *Client) captureLog(log *Log, capture signalCaptureContext) bool {
@@ -792,8 +801,7 @@ func (client *Client) RecoverWithContext(
 	default:
 		event = client.eventFromMessage(fmt.Sprintf("%#v", err))
 	}
-	event.Level = LevelFatal
-	return client.CaptureEvent(event, hint, scope)
+	return client.captureEvent(event, scope, captureOptions{hint: hint, defaultLevel: LevelFatal})
 }
 
 // Flush waits until the underlying Transport sends any buffered events to the

--- a/client.go
+++ b/client.go
@@ -102,14 +102,6 @@ type EventProcessor func(event *Event, hint *EventHint) *Event
 // needing the otel dependency on the root package.
 type externalContextTraceResolver func(ctx context.Context) (traceID TraceID, spanID SpanID, ok bool)
 
-// EventModifier is the interface that wraps the ApplyToEvent method.
-//
-// ApplyToEvent changes an event based on external data and/or
-// an event hint.
-type EventModifier interface {
-	ApplyToEvent(event *Event, hint *EventHint, client *Client) *Event
-}
-
 var globalEventProcessors []EventProcessor
 
 // AddGlobalEventProcessor adds processor to the global list of event
@@ -634,20 +626,32 @@ func (client *Client) GetDataCollection() DataCollection {
 	return *cloneDataCollection(client.options.DataCollection)
 }
 
+// captureOptions carries the per-capture values that take part in scope
+// merging precedence. It stays private; the public CaptureOption API is
+// parsed into this representation by the context capture PR.
+type captureOptions struct {
+	// hint carries metadata to event processors and before-send hooks.
+	hint *EventHint
+	// level is an explicit level from the capture call.
+	level Level
+}
+
 // CaptureMessage captures an arbitrary message.
-func (client *Client) CaptureMessage(message string, hint *EventHint, scope EventModifier) *EventID {
-	event := client.EventFromMessage(message, LevelInfo)
+func (client *Client) CaptureMessage(message string, hint *EventHint, scope *Scope) *EventID {
+	event := client.eventFromMessage(message)
+	event.Level = LevelInfo
 	return client.CaptureEvent(event, hint, scope)
 }
 
 // CaptureException captures an error.
-func (client *Client) CaptureException(exception error, hint *EventHint, scope EventModifier) *EventID {
-	event := client.EventFromException(exception, LevelError)
+func (client *Client) CaptureException(exception error, hint *EventHint, scope *Scope) *EventID {
+	event := client.eventFromException(exception)
+	event.Level = LevelError
 	return client.CaptureEvent(event, hint, scope)
 }
 
 // CaptureCheckIn captures a check in.
-func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig, scope EventModifier) *EventID {
+func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig, scope *Scope) *EventID {
 	event := client.EventFromCheckIn(checkIn, monitorConfig)
 	if event != nil && event.CheckIn != nil {
 		if client.CaptureEvent(event, nil, scope) != nil {
@@ -662,18 +666,19 @@ func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorCon
 // The event must already be assembled. Typically, code would instead use
 // the utility methods like CaptureException. The return value is the
 // event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
-func (client *Client) CaptureEvent(event *Event, hint *EventHint, scope EventModifier) *EventID {
+func (client *Client) CaptureEvent(event *Event, hint *EventHint, scope *Scope) *EventID {
 	if !client.IsEnabled() {
 		return nil
 	}
-	return client.processEvent(event, hint, scope)
+	return client.processEvent(event, scope, captureOptions{hint: hint})
 }
 
-func (client *Client) captureLog(log *Log, _ *Scope) bool {
+func (client *Client) captureLog(log *Log, capture signalCaptureContext) bool {
 	if log == nil {
 		return false
 	}
 
+	prepareLog(log, client, capture)
 	if client.options.BeforeSendLog != nil {
 		approxSize := log.ApproximateSize()
 		log = client.options.BeforeSendLog(log)
@@ -703,11 +708,16 @@ func (client *Client) captureLog(log *Log, _ *Scope) bool {
 	return true
 }
 
-func (client *Client) captureMetric(metric *Metric, _ *Scope) bool {
+func (client *Client) recordDiscard(reason report.DiscardReason, category ratelimit.Category, count int64) {
+	client.reportRecorder.Record(reason, category, count)
+}
+
+func (client *Client) captureMetric(metric *Metric, capture signalCaptureContext) bool {
 	if metric == nil {
 		return false
 	}
 
+	prepareMetric(metric, client, capture)
 	if client.options.BeforeSendMetric != nil {
 		metric = client.options.BeforeSendMetric(metric)
 		if metric == nil {
@@ -736,7 +746,7 @@ func (client *Client) captureMetric(metric *Metric, _ *Scope) bool {
 
 // Recover captures a panic.
 // Returns EventID if successfully, or nil if there's no error to recover from.
-func (client *Client) Recover(err any, hint *EventHint, scope EventModifier) *EventID {
+func (client *Client) Recover(err any, hint *EventHint, scope *Scope) *EventID {
 	if err == nil {
 		err = recover()
 	}
@@ -755,7 +765,7 @@ func (client *Client) RecoverWithContext(
 	ctx context.Context,
 	err any,
 	hint *EventHint,
-	scope EventModifier,
+	scope *Scope,
 ) *EventID {
 	if err == nil {
 		err = recover()
@@ -764,24 +774,25 @@ func (client *Client) RecoverWithContext(
 		return nil
 	}
 
-	if ctx != nil {
-		if hint == nil {
-			hint = &EventHint{}
+	if ctx != nil && (hint == nil || hint.Context == nil) {
+		resolved := EventHint{}
+		if hint != nil {
+			resolved = *hint
 		}
-		if hint.Context == nil {
-			hint.Context = ctx
-		}
+		resolved.Context = ctx
+		hint = &resolved
 	}
 
 	var event *Event
 	switch err := err.(type) {
 	case error:
-		event = client.EventFromException(err, LevelFatal)
+		event = client.eventFromException(err)
 	case string:
-		event = client.EventFromMessage(err, LevelFatal)
+		event = client.eventFromMessage(err)
 	default:
-		event = client.EventFromMessage(fmt.Sprintf("%#v", err), LevelFatal)
+		event = client.eventFromMessage(fmt.Sprintf("%#v", err))
 	}
+	event.Level = LevelFatal
 	return client.CaptureEvent(event, hint, scope)
 }
 
@@ -849,12 +860,17 @@ func (client *Client) Close() {
 
 // EventFromMessage creates an event from the given message string.
 func (client *Client) EventFromMessage(message string, level Level) *Event {
+	event := client.eventFromMessage(message)
+	event.Level = level
+	return event
+}
+
+func (client *Client) eventFromMessage(message string) *Event {
 	if message == "" {
 		err := usageError{fmt.Errorf("%s called with empty message", callerFunctionName())}
-		return client.EventFromException(err, level)
+		return client.eventFromException(err)
 	}
 	event := NewEvent()
-	event.Level = level
 	event.Message = message
 
 	if client.options.AttachStacktrace {
@@ -870,8 +886,13 @@ func (client *Client) EventFromMessage(message string, level Level) *Event {
 
 // EventFromException creates a new Sentry event from the given `error` instance.
 func (client *Client) EventFromException(exception error, level Level) *Event {
-	event := NewEvent()
+	event := client.eventFromException(exception)
 	event.Level = level
+	return event
+}
+
+func (client *Client) eventFromException(exception error) *Event {
+	event := NewEvent()
 
 	err := exception
 	if err == nil {
@@ -924,10 +945,14 @@ func (client *Client) GetSDKIdentifier() string {
 	return client.sdkIdentifier
 }
 
-func (client *Client) processEvent(event *Event, hint *EventHint, scope EventModifier) *EventID {
+func (client *Client) GetSDKVersion() string {
+	return client.sdkVersion
+}
+
+func (client *Client) processEvent(event *Event, scope *Scope, opts captureOptions) *EventID {
 	if event == nil {
 		err := usageError{fmt.Errorf("%s called with nil event", callerFunctionName())}
-		return client.CaptureException(err, hint, scope)
+		return client.CaptureException(err, opts.hint, scope)
 	}
 
 	// Transactions are sampled by options.TracesSampleRate or
@@ -939,11 +964,12 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 		return nil
 	}
 
-	if event = client.prepareEvent(event, hint, scope); event == nil {
+	if event = client.prepareEvent(event, scope, opts); event == nil {
 		return nil
 	}
 
 	// Apply beforeSend* processors
+	hint := opts.hint
 	if hint == nil {
 		hint = &EventHint{}
 	}
@@ -985,7 +1011,22 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	return &event.EventID
 }
 
-func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventModifier) *Event {
+// applyScopeChain merges the passed scope and global scope into event, resolves the trace
+// context, and runs the scope event processors. It returns nil when a processor drops the event.
+func applyScopeChain(event *Event, client *Client, scope *Scope, opts captureOptions) *Event {
+	client = normalizeClient(client)
+	state := resolveCaptureState(event, scope)
+
+	var ctx context.Context
+	if opts.hint != nil {
+		ctx = opts.hint.Context
+	}
+	applyTraceToEvent(event, resolveTrace(scope, client, ctx))
+
+	return state.applyToEvent(event, opts.hint, opts, client)
+}
+
+func (client *Client) prepareEvent(event *Event, scope *Scope, opts captureOptions) *Event {
 	if event.EventID == "" {
 		// TODO set EventID when the event is created, same as in other SDKs. It's necessary for profileTransaction.ID.
 		event.EventID = EventID(uuid())
@@ -993,10 +1034,6 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 
 	if event.Timestamp.IsZero() {
 		event.Timestamp = time.Now()
-	}
-
-	if event.Level == "" {
-		event.Level = LevelInfo
 	}
 
 	if event.ServerName == "" {
@@ -1030,13 +1067,12 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		}},
 	}
 
-	if scope != nil {
-		event = scope.ApplyToEvent(event, hint, client)
-		if event == nil {
-			return nil
-		}
+	event = applyScopeChain(event, client, scope, opts)
+	if event == nil {
+		return nil
 	}
 
+	hint := opts.hint
 	for _, processor := range client.eventProcessors {
 		id := event.EventID
 		category := event.toCategory()

--- a/client.go
+++ b/client.go
@@ -298,6 +298,7 @@ type ClientOptions struct {
 // instances. It must be created with NewClient.
 type Client struct {
 	mu                    sync.RWMutex
+	disabled              bool
 	options               ClientOptions
 	dsn                   *protocol.Dsn
 	eventProcessors       []EventProcessor
@@ -408,7 +409,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		var err error
 		dsn, err = protocol.NewDsn(options.Dsn)
 		if err != nil {
-			return nil, err
+			return NewNoopClient(), err
 		}
 	}
 
@@ -448,6 +449,37 @@ func NewClient(options ClientOptions) (*Client, error) {
 	}
 
 	return &client, nil
+}
+
+// NewNoopClient returns a non-nil client that safely discards telemetry.
+func NewNoopClient() *Client {
+	return &Client{
+		disabled: true,
+		options: ClientOptions{
+			DisableTelemetryBuffer: true,
+			MaxErrorDepth:          maxErrorDepth,
+			MaxSpans:               defaultMaxSpans,
+			TraceIgnoreStatusCodes: [][]int{{404}},
+		},
+		sdkIdentifier:  sdkIdentifier,
+		sdkVersion:     SDKVersion,
+		Transport:      new(noopTransport),
+		reportRecorder: report.NoopRecorder(),
+		reportProvider: report.NoopProvider(),
+	}
+}
+
+// IsEnabled reports whether the client processes telemetry.
+func (client *Client) IsEnabled() bool {
+	return client != nil && !client.disabled
+}
+
+// normalizeClient guarantees a non-nil client for internal and Hub callers.
+func normalizeClient(client *Client) *Client {
+	if client == nil {
+		return NewNoopClient()
+	}
+	return client
 }
 
 func (client *Client) setupTransport() {
@@ -596,7 +628,7 @@ func (client *Client) Options() ClientOptions {
 // GetDataCollection returns a copy of the resolved data collection
 // configuration used by the client.
 func (client *Client) GetDataCollection() DataCollection {
-	if client == nil || client.options.DataCollection == nil {
+	if !client.IsEnabled() || client.options.DataCollection == nil {
 		return DataCollection{}
 	}
 	return *cloneDataCollection(client.options.DataCollection)
@@ -618,8 +650,9 @@ func (client *Client) CaptureException(exception error, hint *EventHint, scope E
 func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig, scope EventModifier) *EventID {
 	event := client.EventFromCheckIn(checkIn, monitorConfig)
 	if event != nil && event.CheckIn != nil {
-		client.CaptureEvent(event, nil, scope)
-		return &event.CheckIn.ID
+		if client.CaptureEvent(event, nil, scope) != nil {
+			return &event.CheckIn.ID
+		}
 	}
 	return nil
 }
@@ -630,6 +663,9 @@ func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorCon
 // the utility methods like CaptureException. The return value is the
 // event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
 func (client *Client) CaptureEvent(event *Event, hint *EventHint, scope EventModifier) *EventID {
+	if !client.IsEnabled() {
+		return nil
+	}
 	return client.processEvent(event, hint, scope)
 }
 

--- a/client.go
+++ b/client.go
@@ -658,6 +658,13 @@ func (client *Client) CaptureException(ctx context.Context, exception error, opt
 	return client.captureEvent(ctx, event, ScopeFromContext(ctx), opts)
 }
 
+// CapturePanic captures a panic value returned by recover.
+//
+// It always attaches the stacktrace of the active panic.
+func (client *Client) CapturePanic(ctx context.Context, recovered any, options ...CaptureOption) *EventID {
+	return client.capturePanic(ctx, recovered, ScopeFromContext(ctx), resolveCaptureOptions(ctx, options))
+}
+
 // CaptureCheckIn captures a check in.
 func (client *Client) CaptureCheckIn(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig, options ...CaptureOption) *EventID {
 	event := client.EventFromCheckIn(checkIn, monitorConfig)
@@ -774,10 +781,10 @@ func (client *Client) captureMetric(metric *Metric, capture signalCaptureContext
 
 // Recover captures a panic from the current goroutine. It must be deferred.
 func (client *Client) Recover(ctx context.Context, options ...CaptureOption) *EventID {
-	return client.recoverValue(ctx, recover(), ScopeFromContext(ctx), resolveCaptureOptions(ctx, options))
+	return client.CapturePanic(ctx, recover(), options...)
 }
 
-func (client *Client) recoverValue(ctx context.Context, value any, scope *Scope, opts captureOptions) *EventID {
+func (client *Client) capturePanic(ctx context.Context, value any, scope *Scope, opts captureOptions) *EventID {
 	if value == nil {
 		return nil
 	}
@@ -785,14 +792,19 @@ func (client *Client) recoverValue(ctx context.Context, value any, scope *Scope,
 		opts.hint.RecoveredException = value
 	}
 
+	stacktrace := NewStacktrace()
 	var event *Event
 	switch value := value.(type) {
 	case error:
 		event = client.eventFromException(value)
+		event.Exception[len(event.Exception)-1].Stacktrace = stacktrace
 	case string:
 		event = client.eventFromMessage(value)
 	default:
 		event = client.eventFromMessage(fmt.Sprintf("%#v", value))
+	}
+	if len(event.Exception) == 0 {
+		event.Threads = []Thread{{Stacktrace: stacktrace, Current: true}}
 	}
 	opts.defaultLevel = LevelFatal
 	return client.captureEvent(ctx, event, scope, opts)

--- a/client.go
+++ b/client.go
@@ -640,38 +640,43 @@ type captureOptions struct {
 }
 
 // CaptureMessage captures an arbitrary message.
-func (client *Client) CaptureMessage(message string, hint *EventHint, scope *Scope) *EventID {
+func (client *Client) CaptureMessage(ctx context.Context, message string, options ...CaptureOption) *EventID {
 	event := client.eventFromMessage(message)
-	return client.captureEvent(event, scope, captureOptions{hint: hint, defaultLevel: LevelInfo})
+	opts := resolveCaptureOptions(ctx, options)
+	opts.defaultLevel = LevelInfo
+	return client.captureEvent(ctx, event, ScopeFromContext(ctx), opts)
 }
 
 // CaptureException captures an error.
-func (client *Client) CaptureException(exception error, hint *EventHint, scope *Scope) *EventID {
+func (client *Client) CaptureException(ctx context.Context, exception error, options ...CaptureOption) *EventID {
+	opts := resolveCaptureOptions(ctx, options)
+	if opts.hint.OriginalException == nil {
+		opts.hint.OriginalException = exception
+	}
 	event := client.eventFromException(exception)
-	return client.captureEvent(event, scope, captureOptions{hint: hint, defaultLevel: LevelError})
+	opts.defaultLevel = LevelError
+	return client.captureEvent(ctx, event, ScopeFromContext(ctx), opts)
 }
 
 // CaptureCheckIn captures a check in.
-func (client *Client) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig, scope *Scope) *EventID {
+func (client *Client) CaptureCheckIn(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig, options ...CaptureOption) *EventID {
 	event := client.EventFromCheckIn(checkIn, monitorConfig)
-	if event != nil && event.CheckIn != nil {
-		if client.CaptureEvent(event, nil, scope) != nil {
-			return &event.CheckIn.ID
-		}
+	if event == nil || event.CheckIn == nil {
+		return nil
 	}
-	return nil
+	checkInID := event.CheckIn.ID
+	if client.captureEvent(ctx, event, ScopeFromContext(ctx), resolveCaptureOptions(ctx, options)) == nil {
+		return nil
+	}
+	return &checkInID
 }
 
-// CaptureEvent captures an event on the currently active client if any.
-//
-// The event must already be assembled. Typically, code would instead use
-// the utility methods like CaptureException. The return value is the
-// event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
-func (client *Client) CaptureEvent(event *Event, hint *EventHint, scope *Scope) *EventID {
-	return client.captureEvent(event, scope, captureOptions{hint: hint})
+// CaptureEvent captures an event.
+func (client *Client) CaptureEvent(ctx context.Context, event *Event, options ...CaptureOption) *EventID {
+	return client.captureEvent(ctx, event, ScopeFromContext(ctx), resolveCaptureOptions(ctx, options))
 }
 
-func (client *Client) captureEvent(event *Event, scope *Scope, opts captureOptions) *EventID {
+func (client *Client) captureEvent(ctx context.Context, event *Event, scope *Scope, opts captureOptions) *EventID {
 	if !client.IsEnabled() {
 		return nil
 	}
@@ -679,7 +684,21 @@ func (client *Client) captureEvent(event *Event, scope *Scope, opts captureOptio
 		event = client.eventFromException(usageError{fmt.Errorf("CaptureEvent called with nil event")})
 		event.Level = LevelError
 	}
-	return client.processEvent(event, scope, opts)
+	if opts.level != "" {
+		event.Level = opts.level
+	}
+	if opts.hint == nil {
+		opts.hint = &EventHint{}
+	}
+	if ctx != nil {
+		opts.hint.Context = ctx
+	}
+
+	id, eligible := client.processEvent(event, scope, opts)
+	if id != nil && eligible && scope != nil {
+		scope.setLastEventID(*id)
+	}
+	return id
 }
 
 func (client *Client) captureLog(log *Log, capture signalCaptureContext) bool {
@@ -753,55 +772,30 @@ func (client *Client) captureMetric(metric *Metric, capture signalCaptureContext
 	return true
 }
 
-// Recover captures a panic.
-// Returns EventID if successfully, or nil if there's no error to recover from.
-func (client *Client) Recover(err any, hint *EventHint, scope *Scope) *EventID {
-	if err == nil {
-		err = recover()
-	}
-
-	// Normally we would not pass a nil Context, but RecoverWithContext doesn't
-	// use the Context for communicating deadline nor cancelation. All it does
-	// is store the Context in the EventHint and there nil means the Context is
-	// not available.
-	// nolint: staticcheck
-	return client.RecoverWithContext(nil, err, hint, scope)
+// Recover captures a panic from the current goroutine. It must be deferred.
+func (client *Client) Recover(ctx context.Context, options ...CaptureOption) *EventID {
+	return client.recoverValue(ctx, recover(), ScopeFromContext(ctx), resolveCaptureOptions(ctx, options))
 }
 
-// RecoverWithContext captures a panic and passes relevant context object.
-// Returns EventID if successfully, or nil if there's no error to recover from.
-func (client *Client) RecoverWithContext(
-	ctx context.Context,
-	err any,
-	hint *EventHint,
-	scope *Scope,
-) *EventID {
-	if err == nil {
-		err = recover()
-	}
-	if err == nil {
+func (client *Client) recoverValue(ctx context.Context, value any, scope *Scope, opts captureOptions) *EventID {
+	if value == nil {
 		return nil
 	}
-
-	if ctx != nil && (hint == nil || hint.Context == nil) {
-		resolved := EventHint{}
-		if hint != nil {
-			resolved = *hint
-		}
-		resolved.Context = ctx
-		hint = &resolved
+	if opts.hint.RecoveredException == nil {
+		opts.hint.RecoveredException = value
 	}
 
 	var event *Event
-	switch err := err.(type) {
+	switch value := value.(type) {
 	case error:
-		event = client.eventFromException(err)
+		event = client.eventFromException(value)
 	case string:
-		event = client.eventFromMessage(err)
+		event = client.eventFromMessage(value)
 	default:
-		event = client.eventFromMessage(fmt.Sprintf("%#v", err))
+		event = client.eventFromMessage(fmt.Sprintf("%#v", value))
 	}
-	return client.captureEvent(event, scope, captureOptions{hint: hint, defaultLevel: LevelFatal})
+	opts.defaultLevel = LevelFatal
+	return client.captureEvent(ctx, event, scope, opts)
 }
 
 // Flush waits until the underlying Transport sends any buffered events to the
@@ -957,23 +951,18 @@ func (client *Client) GetSDKVersion() string {
 	return client.sdkVersion
 }
 
-func (client *Client) processEvent(event *Event, scope *Scope, opts captureOptions) *EventID {
-	if event == nil {
-		err := usageError{fmt.Errorf("%s called with nil event", callerFunctionName())}
-		return client.CaptureException(err, opts.hint, scope)
-	}
-
+func (client *Client) processEvent(event *Event, scope *Scope, opts captureOptions) (*EventID, bool) {
 	// Transactions are sampled by options.TracesSampleRate or
 	// options.TracesSampler when they are started. Other events
 	// (errors, messages) are sampled here. Does not apply to check-ins.
 	if event.Type != transactionType && event.Type != checkInType && !sample(client.options.SampleRate) {
 		debuglog.Println("Event dropped due to SampleRate hit.")
 		client.reportRecorder.RecordOne(report.ReasonSampleRate, event.toCategory())
-		return nil
+		return nil, false
 	}
 
 	if event = client.prepareEvent(event, scope, opts); event == nil {
-		return nil
+		return nil, false
 	}
 
 	// Apply beforeSend* processors
@@ -990,7 +979,7 @@ func (client *Client) processEvent(event *Event, scope *Scope, opts captureOptio
 				debuglog.Println("Transaction dropped due to BeforeSendTransaction callback.")
 				client.reportRecorder.RecordOne(report.ReasonBeforeSend, ratelimit.CategoryTransaction)
 				client.reportRecorder.Record(report.ReasonBeforeSend, ratelimit.CategorySpan, int64(spanCountBefore))
-				return nil
+				return nil, false
 			}
 			// Track spans removed by the callback
 			if droppedSpans := spanCountBefore - event.GetSpanCount(); droppedSpans > 0 {
@@ -1003,7 +992,7 @@ func (client *Client) processEvent(event *Event, scope *Scope, opts captureOptio
 			if event = client.options.BeforeSend(event, hint); event == nil {
 				debuglog.Println("Event dropped due to BeforeSend callback.")
 				client.reportRecorder.RecordOne(report.ReasonBeforeSend, ratelimit.CategoryError)
-				return nil
+				return nil, false
 			}
 		}
 	}
@@ -1011,12 +1000,13 @@ func (client *Client) processEvent(event *Event, scope *Scope, opts captureOptio
 	if client.telemetryProcessor != nil {
 		if !client.telemetryProcessor.Add(event) {
 			debuglog.Println("Event dropped: telemetry buffer full or unavailable")
+			return nil, false
 		}
 	} else {
 		client.Transport.SendEvent(event)
 	}
 
-	return &event.EventID
+	return &event.EventID, event.Type != transactionType && event.Type != checkInType
 }
 
 // applyScopeChain merges the passed scope and global scope into event, resolves the trace

--- a/client_test.go
+++ b/client_test.go
@@ -35,7 +35,7 @@ func TestNewClientAllowsEmptyDSN(t *testing.T) {
 		t.Fatalf("expected no error when creating client without a DNS but got %v", err)
 	}
 
-	client.CaptureException(errors.New("custom error"), nil, &MockScope{})
+	client.CaptureException(errors.New("custom error"), nil, NewScope())
 	assertEqual(t, transport.lastEvent.Exception[0].Value, "custom error")
 }
 
@@ -51,8 +51,8 @@ func (e customComplexError) AnswerToLife() string {
 	return "42"
 }
 
-func setupClientTest() (*Client, *MockScope, *MockTransport) {
-	scope := &MockScope{}
+func setupClientTest() (*Client, *Scope, *MockTransport) {
+	scope := NewScope()
 	transport := &MockTransport{}
 	client, _ := NewClient(ClientOptions{
 		Dsn:       "http://whatever@example.com/1337",
@@ -523,7 +523,9 @@ func TestSampleRateCanDropEvent(t *testing.T) {
 
 func TestApplyToScopeCanDropEvent(t *testing.T) {
 	client, scope, transport := setupClientTest()
-	scope.shouldDropEvent = true
+	scope.AddEventProcessor(func(_ *Event, _ *EventHint) *Event {
+		return nil
+	})
 
 	client.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
 		if event == nil {
@@ -656,7 +658,7 @@ func TestIgnoreErrors(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			scope := &MockScope{}
+			scope := NewScope()
 			transport := &MockTransport{}
 			client, err := NewClient(ClientOptions{
 				Transport:    transport,
@@ -958,7 +960,7 @@ func BenchmarkProcessEvent(b *testing.B) {
 		b.Fatal(err)
 	}
 	for i := 0; i < b.N; i++ {
-		c.processEvent(&Event{}, nil, nil)
+		c.processEvent(&Event{}, nil, captureOptions{})
 	}
 }
 
@@ -1131,7 +1133,7 @@ func TestTelemetryEnvelopeCarriesIntegrations(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { client.Close() })
 
-	client.CaptureMessage("ping", nil, &MockScope{})
+	client.CaptureMessage("ping", nil, NewScope())
 	require.True(t, client.Flush(testutils.FlushTimeout()), "flush timed out")
 
 	select {

--- a/client_test.go
+++ b/client_test.go
@@ -77,6 +77,43 @@ func TestCaptureMessageShouldSucceedWithoutNilScope(t *testing.T) {
 	assertEqual(t, transport.lastEvent.Message, "foo")
 }
 
+func TestHelperCaptureLevelsRespectScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		capture func(*Client, *Scope)
+	}{
+		{
+			name: "message",
+			capture: func(client *Client, scope *Scope) {
+				client.CaptureMessage("message", nil, scope)
+			},
+		},
+		{
+			name: "exception",
+			capture: func(client *Client, scope *Scope) {
+				client.CaptureException(errors.New("error"), nil, scope)
+			},
+		},
+		{
+			name: "recover",
+			capture: func(client *Client, scope *Scope) {
+				client.Recover("panic", nil, scope)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, scope, transport := setupClientTest()
+			scope.SetLevel(LevelWarning)
+
+			tt.capture(client, scope)
+
+			assertEqual(t, LevelWarning, transport.lastEvent.Level)
+		})
+	}
+}
+
 func TestCaptureMessageEmptyString(t *testing.T) {
 	client, scope, transport := setupClientTest()
 	client.CaptureMessage("", nil, scope)

--- a/client_test.go
+++ b/client_test.go
@@ -35,7 +35,7 @@ func TestNewClientAllowsEmptyDSN(t *testing.T) {
 		t.Fatalf("expected no error when creating client without a DNS but got %v", err)
 	}
 
-	client.CaptureException(errors.New("custom error"), nil, NewScope())
+	client.CaptureException(context.Background(), errors.New("custom error"))
 	assertEqual(t, transport.lastEvent.Exception[0].Value, "custom error")
 }
 
@@ -67,37 +67,37 @@ func setupClientTest() (*Client, *Scope, *MockTransport) {
 }
 func TestCaptureMessageShouldSendEventWithProvidedMessage(t *testing.T) {
 	client, scope, transport := setupClientTest()
-	client.CaptureMessage("foo", nil, scope)
+	client.CaptureMessage(contextWithScope(context.Background(), scope), "foo")
 	assertEqual(t, transport.lastEvent.Message, "foo")
 }
 
 func TestCaptureMessageShouldSucceedWithoutNilScope(t *testing.T) {
 	client, _, transport := setupClientTest()
-	client.CaptureMessage("foo", nil, nil)
+	client.CaptureMessage(context.Background(), "foo")
 	assertEqual(t, transport.lastEvent.Message, "foo")
 }
 
 func TestHelperCaptureLevelsRespectScope(t *testing.T) {
 	tests := []struct {
 		name    string
-		capture func(*Client, *Scope)
+		capture func(context.Context, *Client, *Scope)
 	}{
 		{
 			name: "message",
-			capture: func(client *Client, scope *Scope) {
-				client.CaptureMessage("message", nil, scope)
+			capture: func(ctx context.Context, client *Client, _ *Scope) {
+				client.CaptureMessage(ctx, "message")
 			},
 		},
 		{
 			name: "exception",
-			capture: func(client *Client, scope *Scope) {
-				client.CaptureException(errors.New("error"), nil, scope)
+			capture: func(ctx context.Context, client *Client, _ *Scope) {
+				client.CaptureException(ctx, errors.New("error"))
 			},
 		},
 		{
 			name: "recover",
-			capture: func(client *Client, scope *Scope) {
-				client.Recover("panic", nil, scope)
+			capture: func(ctx context.Context, client *Client, scope *Scope) {
+				client.recoverValue(ctx, "panic", scope, resolveCaptureOptions(ctx, nil))
 			},
 		},
 	}
@@ -106,8 +106,9 @@ func TestHelperCaptureLevelsRespectScope(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client, scope, transport := setupClientTest()
 			scope.SetLevel(LevelWarning)
+			ctx := contextWithScope(context.Background(), scope)
 
-			tt.capture(client, scope)
+			tt.capture(ctx, client, scope)
 
 			assertEqual(t, LevelWarning, transport.lastEvent.Level)
 		})
@@ -116,7 +117,7 @@ func TestHelperCaptureLevelsRespectScope(t *testing.T) {
 
 func TestCaptureMessageEmptyString(t *testing.T) {
 	client, scope, transport := setupClientTest()
-	client.CaptureMessage("", nil, scope)
+	client.CaptureMessage(contextWithScope(context.Background(), scope), "")
 	want := &Event{
 		Exception: []Exception{
 			{
@@ -324,7 +325,7 @@ func TestCaptureException(t *testing.T) {
 			tt := tt
 			t.Run(grp.name+"/"+tt.name, func(t *testing.T) {
 				client, _, transport := setupClientTest()
-				client.CaptureException(tt.err, nil, nil)
+				client.CaptureException(context.Background(), tt.err)
 				if transport.lastEvent == nil {
 					t.Fatal("missing event")
 				}
@@ -344,11 +345,11 @@ func TestCaptureEvent(t *testing.T) {
 	timestamp := time.Now().UTC()
 	serverName := "testServer"
 
-	client.CaptureEvent(&Event{
+	client.CaptureEvent(context.Background(), &Event{
 		EventID:    eventID,
 		Timestamp:  timestamp,
 		ServerName: serverName,
-	}, nil, nil)
+	})
 
 	if transport.lastEvent == nil {
 		t.Fatal("missing event")
@@ -387,13 +388,13 @@ func TestCaptureEventShouldSendEventWithMessage(t *testing.T) {
 	client, scope, transport := setupClientTest()
 	event := NewEvent()
 	event.Message = "event message"
-	client.CaptureEvent(event, nil, scope)
+	client.CaptureEvent(contextWithScope(context.Background(), scope), event)
 	assertEqual(t, transport.lastEvent.Message, "event message")
 }
 
 func TestCaptureEventNil(t *testing.T) {
 	client, scope, transport := setupClientTest()
-	client.CaptureEvent(nil, nil, scope)
+	client.CaptureEvent(contextWithScope(context.Background(), scope), nil)
 	want := &Event{
 		Exception: []Exception{
 			{
@@ -480,7 +481,7 @@ func TestCaptureCheckIn(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client, _, transport := setupClientTest()
-			client.CaptureCheckIn(tt.checkIn, tt.monitorConfig, nil)
+			client.CaptureCheckIn(context.Background(), tt.checkIn, tt.monitorConfig)
 			capturedEvent := transport.lastEvent
 
 			if tt.expectNilEvent && capturedEvent == nil {
@@ -509,10 +510,10 @@ func TestCaptureCheckIn(t *testing.T) {
 
 func TestNoopClientCaptureCheckIn(t *testing.T) {
 	client := NewNoopClient()
-	checkInID := client.CaptureCheckIn(&CheckIn{
+	checkInID := client.CaptureCheckIn(context.Background(), &CheckIn{
 		MonitorSlug: "cron",
 		Status:      CheckInStatusOK,
-	}, nil, nil)
+	}, nil)
 
 	if checkInID != nil {
 		t.Errorf("expected nil check-in ID, got %s", *checkInID)
@@ -529,18 +530,18 @@ func TestCaptureCheckInExistingID(t *testing.T) {
 		Timezone:      "UTC",
 	}
 
-	checkInID := client.CaptureCheckIn(&CheckIn{
+	checkInID := client.CaptureCheckIn(context.Background(), &CheckIn{
 		MonitorSlug: "cron",
 		Status:      CheckInStatusInProgress,
 		Duration:    time.Second,
-	}, monitorConfig, nil)
+	}, monitorConfig)
 
-	checkInID2 := client.CaptureCheckIn(&CheckIn{
+	checkInID2 := client.CaptureCheckIn(context.Background(), &CheckIn{
 		ID:          *checkInID,
 		MonitorSlug: "cron",
 		Status:      CheckInStatusOK,
 		Duration:    time.Minute,
-	}, monitorConfig, nil)
+	}, monitorConfig)
 
 	if *checkInID != *checkInID2 {
 		t.Errorf("Expecting equivalent CheckInID: %s and %s", *checkInID, *checkInID2)
@@ -551,7 +552,7 @@ func TestSampleRateCanDropEvent(t *testing.T) {
 	client, scope, transport := setupClientTest()
 	client.options.SampleRate = 0.000000000000001
 
-	client.CaptureMessage("Foo", nil, scope)
+	client.CaptureMessage(contextWithScope(context.Background(), scope), "Foo")
 
 	if transport.lastEvent != nil {
 		t.Error("expected event to be dropped")
@@ -571,7 +572,7 @@ func TestApplyToScopeCanDropEvent(t *testing.T) {
 		return event
 	})
 
-	client.CaptureMessage("Foo", nil, scope)
+	client.CaptureMessage(contextWithScope(context.Background(), scope), "Foo")
 
 	if transport.lastEvent != nil {
 		t.Error("expected event to be dropped")
@@ -584,7 +585,7 @@ func TestBeforeSendCanDropEvent(t *testing.T) {
 		return nil
 	}
 
-	client.CaptureMessage("Foo", nil, scope)
+	client.CaptureMessage(contextWithScope(context.Background(), scope), "Foo")
 
 	if transport.lastEvent != nil {
 		t.Error("expected event to be dropped")
@@ -601,7 +602,7 @@ func TestBeforeSendGetAccessToEventHint(t *testing.T) {
 	}
 	ex := customComplexError{Message: "Foo"}
 
-	client.CaptureException(ex, &EventHint{OriginalException: ex}, scope)
+	client.CaptureException(contextWithScope(context.Background(), scope), ex, WithEventHint(&EventHint{OriginalException: ex}))
 
 	assertEqual(t, transport.lastEvent.Message, "customComplexError: Foo 42")
 }
@@ -705,7 +706,7 @@ func TestIgnoreErrors(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			client.CaptureMessage(tt.message, nil, scope)
+			client.CaptureMessage(contextWithScope(context.Background(), scope), tt.message)
 
 			dropped := transport.lastEvent == nil
 			if tt.expectDrop != dropped {
@@ -1054,7 +1055,7 @@ func TestRecover(t *testing.T) {
 		t.Run(fmt.Sprintf("Recover/%v", tt.v), func(t *testing.T) {
 			client, scope, transport := setupClientTest()
 			func() {
-				defer client.Recover(nil, nil, scope)
+				defer client.Recover(contextWithScope(context.Background(), scope))
 				panic(tt.v)
 			}()
 			tt.want.Level = LevelFatal
@@ -1062,16 +1063,17 @@ func TestRecover(t *testing.T) {
 		})
 		t.Run(fmt.Sprintf("RecoverWithContext/%v", tt.v), func(t *testing.T) {
 			client, scope, transport := setupClientTest()
+			captureCtx := contextWithScope(context.TODO(), scope)
 			var called bool
 			client.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
 				called = true
-				if hint.Context != context.TODO() {
+				if hint.Context != captureCtx {
 					t.Fatal("unexpected context value")
 				}
 				return event
 			})
 			func() {
-				defer client.RecoverWithContext(context.TODO(), nil, nil, scope)
+				defer client.Recover(captureCtx)
 				panic(tt.v)
 			}()
 			tt.want.Level = LevelFatal
@@ -1092,7 +1094,7 @@ func TestNoopClientRecover(t *testing.T) {
 				t.Fatalf("noop client did not recover panic: %v", recovered)
 			}
 		}()
-		defer client.Recover(nil, nil, nil)
+		defer client.Recover(context.Background())
 		panic("panic handled by noop client")
 	}()
 }
@@ -1170,7 +1172,7 @@ func TestTelemetryEnvelopeCarriesIntegrations(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { client.Close() })
 
-	client.CaptureMessage("ping", nil, NewScope())
+	client.CaptureMessage(context.Background(), "ping")
 	require.True(t, client.Flush(testutils.FlushTimeout()), "flush timed out")
 
 	select {

--- a/client_test.go
+++ b/client_test.go
@@ -470,6 +470,18 @@ func TestCaptureCheckIn(t *testing.T) {
 	}
 }
 
+func TestNoopClientCaptureCheckIn(t *testing.T) {
+	client := NewNoopClient()
+	checkInID := client.CaptureCheckIn(&CheckIn{
+		MonitorSlug: "cron",
+		Status:      CheckInStatusOK,
+	}, nil, nil)
+
+	if checkInID != nil {
+		t.Errorf("expected nil check-in ID, got %s", *checkInID)
+	}
+}
+
 func TestCaptureCheckInExistingID(t *testing.T) {
 	client, _, _ := setupClientTest()
 
@@ -1030,6 +1042,20 @@ func TestRecover(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNoopClientRecover(t *testing.T) {
+	client := NewNoopClient()
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("noop client did not recover panic: %v", recovered)
+			}
+		}()
+		defer client.Recover(nil, nil, nil)
+		panic("panic handled by noop client")
+	}()
 }
 
 func TestCustomMaxSpansProperty(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -97,7 +97,7 @@ func TestHelperCaptureLevelsRespectScope(t *testing.T) {
 		{
 			name: "recover",
 			capture: func(ctx context.Context, client *Client, scope *Scope) {
-				client.recoverValue(ctx, "panic", scope, resolveCaptureOptions(ctx, nil))
+				client.capturePanic(ctx, "panic", scope, resolveCaptureOptions(ctx, nil))
 			},
 		},
 	}

--- a/dynamic_sampling_context.go
+++ b/dynamic_sampling_context.go
@@ -43,7 +43,7 @@ func DynamicSamplingContextFromTransaction(span *Span) DynamicSamplingContext {
 	scope := hub.Scope()
 	client := hub.Client()
 
-	if client == nil || scope == nil {
+	if !client.IsEnabled() || scope == nil {
 		return DynamicSamplingContext{
 			Entries: map[string]string{},
 			Frozen:  false,
@@ -122,7 +122,7 @@ func (d DynamicSamplingContext) String() string {
 func DynamicSamplingContextFromScope(scope *Scope, client *Client) DynamicSamplingContext {
 	entries := map[string]string{}
 
-	if client == nil || scope == nil {
+	if !client.IsEnabled() || scope == nil {
 		return DynamicSamplingContext{
 			Entries: entries,
 			Frozen:  false,

--- a/dynamic_sampling_context.go
+++ b/dynamic_sampling_context.go
@@ -116,6 +116,15 @@ func (d DynamicSamplingContext) String() string {
 	return baggage.String()
 }
 
+func dynamicSamplingContextFromScope(scope *Scope, client *Client) DynamicSamplingContext {
+	if scope == nil {
+		return DynamicSamplingContextFromScope(nil, client)
+	}
+	scope.mu.RLock()
+	defer scope.mu.RUnlock()
+	return DynamicSamplingContextFromScope(scope, client)
+}
+
 // DynamicSamplingContextFromScope Constructs a new DynamicSamplingContext using a scope and client. Accessing
 // fields on the scope are not thread safe, and this function should only be
 // called within scope methods.

--- a/dynamic_sampling_context.go
+++ b/dynamic_sampling_context.go
@@ -39,11 +39,9 @@ func DynamicSamplingContextFromHeader(header []byte) (DynamicSamplingContext, er
 }
 
 func DynamicSamplingContextFromTransaction(span *Span) DynamicSamplingContext {
-	hub := hubFromContext(span.Context())
-	scope := hub.Scope()
-	client := hub.Client()
+	client := GetClient(span.Context())
 
-	if !client.IsEnabled() || scope == nil {
+	if !client.IsEnabled() {
 		return DynamicSamplingContext{
 			Entries: map[string]string{},
 			Frozen:  false,

--- a/dynamic_sampling_context.go
+++ b/dynamic_sampling_context.go
@@ -53,7 +53,7 @@ func DynamicSamplingContextFromTransaction(span *Span) DynamicSamplingContext {
 	entries := make(map[string]string)
 
 	if traceID := span.TraceID.String(); traceID != "" {
-		entries["trace_id"] = traceID
+		entries[traceIDContextKey] = traceID
 	}
 	if sampleRate := span.sampleRate; sampleRate != 0 {
 		entries["sample_rate"] = strconv.FormatFloat(sampleRate, 'f', -1, 64)
@@ -141,7 +141,7 @@ func DynamicSamplingContextFromScope(scope *Scope, client *Client) DynamicSampli
 	propagationContext := scope.propagationContext
 
 	if traceID := propagationContext.TraceID.String(); traceID != "" {
-		entries["trace_id"] = traceID
+		entries[traceIDContextKey] = traceID
 	}
 	if sampleRate := client.options.TracesSampleRate; sampleRate != 0 {
 		entries["sample_rate"] = strconv.FormatFloat(sampleRate, 'f', -1, 64)

--- a/dynamic_sampling_context_test.go
+++ b/dynamic_sampling_context_test.go
@@ -187,9 +187,11 @@ func TestDynamicSamplingContextFromScope(t *testing.T) {
 	}{
 		"Valid input": {
 			scope: &Scope{
-				propagationContext: PropagationContext{
-					TraceID: TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03"),
-					SpanID:  SpanIDFromHex("a9f442f9330b4e09"),
+				scopeData: scopeData{
+					propagationContext: PropagationContext{
+						TraceID: TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03"),
+						SpanID:  SpanIDFromHex("a9f442f9330b4e09"),
+					},
 				},
 			},
 			client: func() *Client {
@@ -215,9 +217,11 @@ func TestDynamicSamplingContextFromScope(t *testing.T) {
 		},
 		"Nil client": {
 			scope: &Scope{
-				propagationContext: PropagationContext{
-					TraceID: TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03"),
-					SpanID:  SpanIDFromHex("a9f442f9330b4e09"),
+				scopeData: scopeData{
+					propagationContext: PropagationContext{
+						TraceID: TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03"),
+						SpanID:  SpanIDFromHex("a9f442f9330b4e09"),
+					},
 				},
 			},
 			client: nil,

--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -79,7 +79,7 @@ func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		options := []sentry.SpanOption{
-			sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+			sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 			sentry.WithOpName("http.server"),
 			sentry.WithTransactionSource(transactionSource),
 			sentry.WithSpanOrigin(sentry.SpanOriginEcho),

--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -64,7 +64,7 @@ func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
 			hub = sentry.CurrentHub().Clone()
 		}
 
-		if client := hub.Client(); client != nil {
+		if client := hub.Client(); client.IsEnabled() {
 			client.SetSDKIdentifier(sdkIdentifier)
 		}
 

--- a/echo/sentryecho_test.go
+++ b/echo/sentryecho_test.go
@@ -44,6 +44,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "/panic/1",
 					Method: "GET",
@@ -454,6 +458,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/example_transportwithhooks_test.go
+++ b/example_transportwithhooks_test.go
@@ -1,6 +1,7 @@
 package sentry_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -59,5 +60,5 @@ func Example_transportWithHooks() {
 	}
 	defer sentry.Flush(2 * time.Second)
 
-	sentry.CaptureMessage("test")
+	sentry.CaptureMessage(context.Background(), "test")
 }

--- a/exception.go
+++ b/exception.go
@@ -20,7 +20,7 @@ type visited struct {
 
 func (v *visited) seenError(err error) bool {
 	t := reflect.ValueOf(err)
-	if t.Kind() == reflect.Ptr && !t.IsNil() {
+	if t.Kind() == reflect.Pointer && !t.IsNil() {
 		ptr := t.Pointer()
 		if _, ok := v.ptrs[ptr]; ok {
 			return true

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -172,7 +172,7 @@ func convert(ctx *fasthttp.RequestCtx) *http.Request {
 
 	// Cookies
 	for key, value := range ctx.Request.Header.Cookies() {
-		r.AddCookie(&http.Cookie{Name: string(key), Value: string(value)})
+		r.AddCookie(&http.Cookie{Name: string(key), Value: string(value)}) //nolint:gosec // G124: mirrors an inbound request cookie.
 	}
 
 	r.RemoteAddr = ctx.RemoteAddr().String()

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -64,7 +64,7 @@ func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandle
 			hub = sentry.CurrentHub().Clone()
 		}
 
-		if client := hub.Client(); client != nil {
+		if client := hub.Client(); client.IsEnabled() {
 			client.SetSDKIdentifier(sdkIdentifier)
 		}
 

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -71,7 +71,7 @@ func (h *Handler) Handle(handler fasthttp.RequestHandler) fasthttp.RequestHandle
 		r := convert(ctx)
 
 		options := []sentry.SpanOption{
-			sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+			sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 			sentry.WithOpName("http.server"),
 			sentry.WithTransactionSource(sentry.SourceURL),
 			sentry.WithSpanOrigin(sentry.SpanOriginFastHTTP),

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -43,6 +43,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "http://example.com/panic",
 					Method: http.MethodGet,
@@ -417,6 +421,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Exception{},
 			"Stacktrace",

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -73,7 +73,7 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 	transactionSource := sentry.SourceURL
 
 	options := []sentry.SpanOption{
-		sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+		sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 		sentry.WithOpName("http.server"),
 		sentry.WithTransactionSource(transactionSource),
 		sentry.WithSpanOrigin(sentry.SpanOriginFiber),

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -183,7 +183,7 @@ func convert(ctx *fiber.Ctx) *http.Request {
 
 	// Cookies
 	ctx.Request().Header.VisitAllCookie(func(key, value []byte) { // nolint: staticcheck // this is intentional to support older versions of fasthttp for fiber v2
-		r.AddCookie(&http.Cookie{Name: string(key), Value: string(value)})
+		r.AddCookie(&http.Cookie{Name: string(key), Value: string(value)}) //nolint:gosec // G124: mirrors an inbound request cookie.
 	})
 
 	r.RemoteAddr = ctx.Context().RemoteAddr().String()

--- a/fiber/sentryfiber.go
+++ b/fiber/sentryfiber.go
@@ -63,7 +63,7 @@ func (h *handler) handle(ctx *fiber.Ctx) error {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/fiber/sentryfiber_test.go
+++ b/fiber/sentryfiber_test.go
@@ -122,6 +122,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "http://example.com/panic",
 					Method: "GET",
@@ -448,6 +452,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/fiberv3/sentryfiber.go
+++ b/fiberv3/sentryfiber.go
@@ -63,7 +63,7 @@ func (h *handler) handle(ctx fiber.Ctx) error {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/fiberv3/sentryfiber.go
+++ b/fiberv3/sentryfiber.go
@@ -182,7 +182,7 @@ func convert(ctx fiber.Ctx) *http.Request {
 	}
 
 	for key, value := range ctx.Request().Header.Cookies() {
-		r.AddCookie(&http.Cookie{Name: string(key), Value: string(value)})
+		r.AddCookie(&http.Cookie{Name: string(key), Value: string(value)}) //nolint:gosec // G124: mirrors an inbound request cookie.
 	}
 
 	r.RemoteAddr = ctx.RequestCtx().RemoteAddr().String()

--- a/fiberv3/sentryfiber.go
+++ b/fiberv3/sentryfiber.go
@@ -73,7 +73,7 @@ func (h *handler) handle(ctx fiber.Ctx) error {
 	transactionSource := sentry.SourceURL
 
 	options := []sentry.SpanOption{
-		sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+		sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 		sentry.WithOpName("http.server"),
 		sentry.WithTransactionSource(transactionSource),
 		sentry.WithSpanOrigin(sentry.SpanOriginFiber),

--- a/fiberv3/sentryfiber_test.go
+++ b/fiberv3/sentryfiber_test.go
@@ -122,6 +122,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "http://example.com/panic",
 					Method: "GET",
@@ -447,6 +451,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -76,7 +76,7 @@ func (h *handler) handle(c *gin.Context) {
 	}
 
 	options := []sentry.SpanOption{
-		sentry.ContinueTrace(hub, c.GetHeader(sentry.SentryTraceHeader), c.GetHeader(sentry.SentryBaggageHeader)),
+		sentry.ContinueTrace(c.GetHeader(sentry.SentryTraceHeader), c.GetHeader(sentry.SentryBaggageHeader)),
 		sentry.WithOpName("http.server"),
 		sentry.WithTransactionSource(transactionSource),
 		sentry.WithSpanOrigin(sentry.SpanOriginGin),

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -63,7 +63,7 @@ func (h *handler) handle(c *gin.Context) {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/gin/sentrygin_test.go
+++ b/gin/sentrygin_test.go
@@ -68,6 +68,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "/panic/1",
 					Method: "GET",
@@ -443,6 +447,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -26,7 +26,7 @@ func hubFromClientContext(ctx context.Context) context.Context {
 		ctx = sentry.SetHubOnContext(ctx, hub)
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -84,7 +84,7 @@ func startServerTransaction(ctx context.Context, fullMethod string) (context.Con
 	transaction := sentry.StartTransaction(
 		sentry.SetHubOnContext(ctx, hub),
 		name,
-		sentry.ContinueTrace(hub, sentryTraceHeader, sentryBaggageHeader),
+		sentry.ContinueTrace(sentryTraceHeader, sentryBaggageHeader),
 		sentry.WithOpName(defaultServerOperationName),
 		sentry.WithDescription(name),
 		sentry.WithTransactionSource(sentry.SourceRoute),

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -62,7 +62,7 @@ func hubFromServerContext(ctx context.Context) *sentry.Hub {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -96,7 +96,7 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 		}
 
 		options := []sentry.SpanOption{
-			sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+			sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 			sentry.WithOpName("http.server"),
 			sentry.WithTransactionSource(sentry.SourceURL),
 			sentry.WithSpanOrigin(sentry.SpanOriginStdLib),

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -91,7 +91,7 @@ func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
-		if client := hub.Client(); client != nil {
+		if client := hub.Client(); client.IsEnabled() {
 			client.SetSDKIdentifier(sdkIdentifier)
 		}
 

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -40,6 +40,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "/panic",
 					Method: "GET",
@@ -371,6 +375,7 @@ func TestIntegration(t *testing.T) {
 			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
 		cmpopts.IgnoreFields(sentry.Event{}, "sdkMetaData", "serializedTags", "serializedContexts", "serializedBreadcrumbs", "serializedException", "serializedUser", "serializationSafe"),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -49,7 +49,7 @@ func NewSentryRoundTripper(originalRoundTripper http.RoundTripper, opts ...Sentr
 	var propagateTraceparent bool
 	if hub := sentry.CurrentHub(); hub != nil {
 		client := hub.Client()
-		if client != nil {
+		if client.IsEnabled() {
 			clientOptions := client.Options()
 			if clientOptions.TracePropagationTargets != nil {
 				tracePropagationTargets = clientOptions.TracePropagationTargets
@@ -83,12 +83,12 @@ type SentryRoundTripper struct {
 
 func dataCollectionFromRequest(request *http.Request) sentry.DataCollection {
 	if hub := sentry.GetHubFromContext(request.Context()); hub != nil {
-		if client := hub.Client(); client != nil {
+		if client := hub.Client(); client.IsEnabled() {
 			return client.GetDataCollection()
 		}
 	}
 	if hub := sentry.CurrentHub(); hub != nil {
-		if client := hub.Client(); client != nil {
+		if client := hub.Client(); client.IsEnabled() {
 			return client.GetDataCollection()
 		}
 	}

--- a/httpclient/sentryhttpclient.go
+++ b/httpclient/sentryhttpclient.go
@@ -82,15 +82,9 @@ type SentryRoundTripper struct {
 }
 
 func dataCollectionFromRequest(request *http.Request) sentry.DataCollection {
-	if hub := sentry.GetHubFromContext(request.Context()); hub != nil {
-		if client := hub.Client(); client.IsEnabled() {
-			return client.GetDataCollection()
-		}
-	}
-	if hub := sentry.CurrentHub(); hub != nil {
-		if client := hub.Client(); client.IsEnabled() {
-			return client.GetDataCollection()
-		}
+	client := sentry.GetClient(request.Context())
+	if client.IsEnabled() {
+		return client.GetDataCollection()
 	}
 	return sentry.DataCollection{}
 }

--- a/httpclient/sentryhttpclient_test.go
+++ b/httpclient/sentryhttpclient_test.go
@@ -66,6 +66,12 @@ func (c *captureRoundTripper) RoundTrip(request *http.Request) (*http.Response, 
 	}, nil
 }
 
+func contextWithClient(client *sentry.Client) context.Context {
+	ctx, scope := sentry.WithIsolationScope(context.Background())
+	scope.SetClient(client)
+	return ctx
+}
+
 func TestIntegration(t *testing.T) {
 	tests := []struct {
 		RequestMethod      string
@@ -255,8 +261,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		hub := sentry.NewHub(sentryClient, sentry.NewScope())
-		ctx := sentry.SetHubOnContext(context.Background(), hub)
+		ctx := contextWithClient(sentryClient)
 		span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
 		ctx = span.Context()
 
@@ -431,8 +436,7 @@ func TestDataCollectionCollectsHeadersAndBodies(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			hub := sentry.NewHub(sentryClient, sentry.NewScope())
-			ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx := contextWithClient(sentryClient)
 			span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
 			ctx = span.Context()
 
@@ -531,8 +535,7 @@ func TestSetCookieResponseHeadersPreserveAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hub := sentry.NewHub(sentryClient, sentry.NewScope())
-	ctx := sentry.SetHubOnContext(context.Background(), hub)
+	ctx := contextWithClient(sentryClient)
 	span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
 	ctx = span.Context()
 
@@ -592,7 +595,7 @@ func TestIntegration_GlobalClientOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := sentry.SetHubOnContext(context.Background(), sentry.CurrentHub())
+	ctx := context.Background()
 	span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
 	ctx = span.Context()
 
@@ -789,8 +792,7 @@ func TestRoundTripDoesNotMutateCallerRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hub := sentry.NewHub(sentryClient, sentry.NewScope())
-	ctx := sentry.SetHubOnContext(context.Background(), hub)
+	ctx := contextWithClient(sentryClient)
 	span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
 	t.Cleanup(span.Finish)
 
@@ -926,8 +928,7 @@ func TestDataCollectionFiltersQuerySpanData(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			hub := sentry.NewHub(sentryClient, sentry.NewScope())
-			ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx := contextWithClient(sentryClient)
 			span := sentry.StartSpan(ctx, "fake_parent", sentry.WithTransactionName("Fake Parent"))
 			ctx = span.Context()
 

--- a/hub.go
+++ b/hub.go
@@ -344,7 +344,7 @@ func (hub *Hub) Recover(err interface{}) *EventID {
 	}
 	ctx := captureHintContext(scope, nil)
 	opts := resolveCaptureOptions(ctx, []CaptureOption{WithEventHint(&EventHint{RecoveredException: err})})
-	return client.recoverValue(ctx, err, scope, opts)
+	return client.capturePanic(ctx, err, scope, opts)
 }
 
 // RecoverWithContext calls the method of a same name on currently bound Client instance
@@ -359,7 +359,7 @@ func (hub *Hub) RecoverWithContext(ctx context.Context, err interface{}) *EventI
 		return nil
 	}
 	opts := resolveCaptureOptions(ctx, []CaptureOption{WithEventHint(&EventHint{RecoveredException: err})})
-	return client.recoverValue(ctx, err, scope, opts)
+	return client.capturePanic(ctx, err, scope, opts)
 }
 
 // Flush waits until the underlying Transport sends any buffered events to the

--- a/hub.go
+++ b/hub.go
@@ -440,7 +440,7 @@ func GetHubFromContext(ctx context.Context) *Hub {
 
 // hubFromContext returns either a hub stored in the context or the current hub.
 // The return value is guaranteed to be non-nil, unlike GetHubFromContext.
-func hubFromContext(ctx context.Context) *Hub {
+func hubFromContext(ctx context.Context) *Hub { // nolint: unused
 	if hub, ok := ctx.Value(HubContextKey).(*Hub); ok {
 		return hub
 	}
@@ -449,5 +449,9 @@ func hubFromContext(ctx context.Context) *Hub {
 
 // SetHubOnContext stores given Hub instance on the Context struct and returns a new Context.
 func SetHubOnContext(ctx context.Context, hub *Hub) context.Context {
-	return context.WithValue(ctx, HubContextKey, hub)
+	ctx = context.WithValue(ctx, HubContextKey, hub)
+	if hub != nil && hub.Scope() != nil {
+		ctx = contextWithScope(ctx, hub.Scope())
+	}
+	return ctx
 }

--- a/hub.go
+++ b/hub.go
@@ -178,6 +178,12 @@ func (hub *Hub) PopScope() {
 func (hub *Hub) BindClient(client *Client) {
 	top := hub.stackTop()
 	top.SetClient(client)
+	// compatibility fallback. The new scope API should use GetClient to resolve the client chain.
+	// Integrations that currently use the hub should also set top.scope.client to continue resolving
+	// a non nil client.
+	if top.scope != nil {
+		top.scope.SetClient(client)
+	}
 }
 
 // WithScope runs f in an isolated temporary scope.
@@ -451,7 +457,9 @@ func hubFromContext(ctx context.Context) *Hub { // nolint: unused
 func SetHubOnContext(ctx context.Context, hub *Hub) context.Context {
 	ctx = context.WithValue(ctx, HubContextKey, hub)
 	if hub != nil && hub.Scope() != nil {
-		ctx = contextWithScope(ctx, hub.Scope())
+		scope := hub.Scope()
+		scope.SetClient(hub.Client())
+		ctx = contextWithScope(ctx, scope)
 	}
 	return ctx
 }

--- a/hub.go
+++ b/hub.go
@@ -221,7 +221,8 @@ func (hub *Hub) CaptureEventWithHint(event *Event, hint *EventHint) *EventID {
 	if scope == nil {
 		return nil
 	}
-	eventID := client.CaptureEvent(event, hint, scope)
+	ctx := captureHintContext(scope, hint)
+	eventID := client.captureEvent(ctx, event, scope, resolveCaptureOptions(ctx, []CaptureOption{WithEventHint(hint)}))
 
 	if event.Type != transactionType && eventID != nil {
 		hub.mu.Lock()
@@ -239,7 +240,9 @@ func (hub *Hub) CaptureMessage(message string) *EventID {
 	if scope == nil {
 		return nil
 	}
-	eventID := client.CaptureMessage(message, nil, scope)
+	ctx := captureHintContext(scope, nil)
+	event := client.EventFromMessage(message, LevelInfo)
+	eventID := client.captureEvent(ctx, event, scope, resolveCaptureOptions(ctx, nil))
 
 	if eventID != nil {
 		hub.mu.Lock()
@@ -257,7 +260,10 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 	if scope == nil {
 		return nil
 	}
-	eventID := client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
+	ctx := captureHintContext(scope, nil)
+	opts := resolveCaptureOptions(ctx, []CaptureOption{WithEventHint(&EventHint{OriginalException: exception})})
+	event := client.EventFromException(exception, LevelError)
+	eventID := client.captureEvent(ctx, event, scope, opts)
 
 	if eventID != nil {
 		hub.mu.Lock()
@@ -272,7 +278,23 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 // Returns CheckInID if the check-in was captured successfully, or nil otherwise.
 func (hub *Hub) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig) *EventID {
 	client, scope := hub.Client(), hub.Scope()
-	return client.CaptureCheckIn(checkIn, monitorConfig, scope)
+	ctx := captureHintContext(scope, nil)
+	return client.CaptureCheckIn(ctx, checkIn, monitorConfig)
+}
+
+func captureHintContext(scope *Scope, hint *EventHint) context.Context {
+	if hint != nil && hint.Context != nil {
+		return hint.Context
+	}
+	if scope != nil {
+		scope.mu.RLock()
+		request := scope.request
+		scope.mu.RUnlock()
+		if request != nil {
+			return request.Context()
+		}
+	}
+	return context.Background()
 }
 
 // AddBreadcrumb records a new breadcrumb.
@@ -314,7 +336,9 @@ func (hub *Hub) Recover(err interface{}) *EventID {
 	if scope == nil {
 		return nil
 	}
-	return client.Recover(err, &EventHint{RecoveredException: err}, scope)
+	ctx := captureHintContext(scope, nil)
+	opts := resolveCaptureOptions(ctx, []CaptureOption{WithEventHint(&EventHint{RecoveredException: err})})
+	return client.recoverValue(ctx, err, scope, opts)
 }
 
 // RecoverWithContext calls the method of a same name on currently bound Client instance
@@ -328,7 +352,8 @@ func (hub *Hub) RecoverWithContext(ctx context.Context, err interface{}) *EventI
 	if scope == nil {
 		return nil
 	}
-	return client.RecoverWithContext(ctx, err, &EventHint{RecoveredException: err}, scope)
+	opts := resolveCaptureOptions(ctx, []CaptureOption{WithEventHint(&EventHint{RecoveredException: err})})
+	return client.recoverValue(ctx, err, scope, opts)
 }
 
 // Flush waits until the underlying Transport sends any buffered events to the

--- a/hub.go
+++ b/hub.go
@@ -21,7 +21,7 @@ const (
 )
 
 // currentHub is the initial Hub with no Client bound and an empty Scope.
-var currentHub = NewHub(nil, NewScope())
+var currentHub = NewHub(NewNoopClient(), NewScope())
 
 // Hub is the central object that manages scopes and clients.
 //
@@ -51,14 +51,14 @@ type layer struct {
 func (l *layer) Client() *Client {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	return l.client
+	return normalizeClient(l.client)
 }
 
 // SetClient sets the layer's client. Safe for concurrent use.
 func (l *layer) SetClient(c *Client) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.client = c
+	l.client = normalizeClient(c)
 }
 
 type stack []*layer
@@ -67,7 +67,7 @@ type stack []*layer
 func NewHub(client *Client, scope *Scope) *Hub {
 	hub := Hub{
 		stack: &stack{{
-			client: client,
+			client: normalizeClient(client),
 			scope:  scope,
 		}},
 	}
@@ -218,7 +218,7 @@ func (hub *Hub) CaptureEvent(event *Event) *EventID {
 // CaptureEventWithHint is like CaptureEvent but additionally accepts an EventHint.
 func (hub *Hub) CaptureEventWithHint(event *Event, hint *EventHint) *EventID {
 	client, scope := hub.Client(), hub.Scope()
-	if client == nil || scope == nil {
+	if scope == nil {
 		return nil
 	}
 	eventID := client.CaptureEvent(event, hint, scope)
@@ -236,7 +236,7 @@ func (hub *Hub) CaptureEventWithHint(event *Event, hint *EventHint) *EventID {
 // Returns EventID if successfully, or nil if there's no Scope or Client available.
 func (hub *Hub) CaptureMessage(message string) *EventID {
 	client, scope := hub.Client(), hub.Scope()
-	if client == nil || scope == nil {
+	if scope == nil {
 		return nil
 	}
 	eventID := client.CaptureMessage(message, nil, scope)
@@ -254,7 +254,7 @@ func (hub *Hub) CaptureMessage(message string) *EventID {
 // Returns EventID if successfully, or nil if there's no Scope or Client available.
 func (hub *Hub) CaptureException(exception error) *EventID {
 	client, scope := hub.Client(), hub.Scope()
-	if client == nil || scope == nil {
+	if scope == nil {
 		return nil
 	}
 	eventID := client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
@@ -272,10 +272,6 @@ func (hub *Hub) CaptureException(exception error) *EventID {
 // Returns CheckInID if the check-in was captured successfully, or nil otherwise.
 func (hub *Hub) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig) *EventID {
 	client, scope := hub.Client(), hub.Scope()
-	if client == nil {
-		return nil
-	}
-
 	return client.CaptureCheckIn(checkIn, monitorConfig, scope)
 }
 
@@ -285,12 +281,6 @@ func (hub *Hub) CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig) *
 // configuration on the client.
 func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 	client := hub.Client()
-
-	// If there's no client, just store it on the scope straight away
-	if client == nil {
-		hub.Scope().AddBreadcrumb(breadcrumb, defaultMaxBreadcrumbs)
-		return
-	}
 
 	limit := client.options.MaxBreadcrumbs
 	switch {
@@ -321,7 +311,7 @@ func (hub *Hub) Recover(err interface{}) *EventID {
 		err = recover()
 	}
 	client, scope := hub.Client(), hub.Scope()
-	if client == nil || scope == nil {
+	if scope == nil {
 		return nil
 	}
 	return client.Recover(err, &EventHint{RecoveredException: err}, scope)
@@ -335,7 +325,7 @@ func (hub *Hub) RecoverWithContext(ctx context.Context, err interface{}) *EventI
 		err = recover()
 	}
 	client, scope := hub.Client(), hub.Scope()
-	if client == nil || scope == nil {
+	if scope == nil {
 		return nil
 	}
 	return client.RecoverWithContext(ctx, err, &EventHint{RecoveredException: err}, scope)
@@ -353,13 +343,7 @@ func (hub *Hub) RecoverWithContext(ctx context.Context, err interface{}) *EventI
 // the network synchronously, configure it to use the HTTPSyncTransport in the
 // call to Init.
 func (hub *Hub) Flush(timeout time.Duration) bool {
-	client := hub.Client()
-
-	if client == nil {
-		return false
-	}
-
-	return client.Flush(timeout)
+	return hub.Client().Flush(timeout)
 }
 
 // FlushWithContext waits until the underlying Transport sends any buffered events
@@ -375,13 +359,7 @@ func (hub *Hub) Flush(timeout time.Duration) bool {
 // configure the SDK to use HTTPSyncTransport during initialization with Init.
 
 func (hub *Hub) FlushWithContext(ctx context.Context) bool {
-	client := hub.Client()
-
-	if client == nil {
-		return false
-	}
-
-	return client.FlushWithContext(ctx)
+	return hub.Client().FlushWithContext(ctx)
 }
 
 // GetTraceparent returns the current Sentry traceparent string, to be used as a HTTP header value

--- a/hub_test.go
+++ b/hub_test.go
@@ -509,10 +509,8 @@ func TestHub_Flush(t *testing.T) {
 
 func TestHub_Flush_NoClient(t *testing.T) {
 	hub := NewHub(nil, nil)
-	flushed := hub.Flush(20 * time.Millisecond)
-
-	if flushed != false {
-		t.Fatalf("expected flush to be false, got %v", flushed)
+	if !hub.Flush(20 * time.Millisecond) {
+		t.Fatal("noop client flush should succeed")
 	}
 }
 
@@ -520,10 +518,8 @@ func TestHub_FlushWithCtx_NoClient(t *testing.T) {
 	hub := NewHub(nil, nil)
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	flushed := hub.FlushWithContext(cancelCtx)
-
-	if flushed != false {
-		t.Fatalf("expected flush to be false, got %v", flushed)
+	if !hub.FlushWithContext(cancelCtx) {
+		t.Fatal("noop client flush should succeed")
 	}
 }
 

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"regexp"
@@ -400,7 +401,7 @@ func TestGlobalTagsIntegration(t *testing.T) {
 
 	event := NewEvent()
 	event.Message = "event message"
-	client.CaptureEvent(event, nil, scope)
+	client.CaptureEvent(contextWithScope(context.Background(), scope), event)
 
 	assertEqual(t,
 		transport.lastEvent.Tags["foo"],

--- a/interfaces.go
+++ b/interfaces.go
@@ -156,7 +156,7 @@ type MeterOption func(*meterOptions)
 type meterOptions struct {
 	unit       string
 	scope      *Scope
-	attributes map[string]attribute.Value
+	attributes []attribute.Builder
 }
 
 // WithUnit sets the unit for the metric (e.g., "millisecond", "byte").
@@ -176,15 +176,12 @@ func WithScopeOverride(scope *Scope) MeterOption {
 // WithAttributes sets attributes for the metric.
 func WithAttributes(attrs ...attribute.Builder) MeterOption {
 	return func(o *meterOptions) {
-		if o.attributes == nil {
-			o.attributes = make(map[string]attribute.Value, len(attrs))
-		}
 		for _, a := range attrs {
 			if a.Value.Type() == attribute.INVALID {
 				debuglog.Printf("invalid attribute: %v", a)
 				continue
 			}
-			o.attributes[a.Key] = a.Value
+			o.attributes = append(o.attributes, a)
 		}
 	}
 }

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -179,13 +179,15 @@ func (f *Fixture) Flush() {
 	}
 }
 
-// NewContext returns parent with the fixture's hub attached. If parent is nil,
-// [context.Background] is used.
+// NewContext returns a derived context with an isolated scope using the
+// fixture's client. If parent is nil, [context.Background] is used.
 func (f *Fixture) NewContext(parent context.Context) context.Context {
 	if parent == nil {
 		parent = context.Background()
 	}
-	return sentry.SetHubOnContext(parent, f.Hub)
+	ctx, scope := sentry.WithIsolationScope(parent)
+	scope.SetClient(f.Client)
+	return ctx
 }
 
 // Events returns all captured events, including transactions.

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -10,6 +10,7 @@ package sentrytest
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"testing/synctest"
 
@@ -241,14 +242,25 @@ func (f *Fixture) AssertHubIsolation(requestHub *sentry.Hub) {
 	f.Hub.Scope().SetTag(sentinel, "leaked")
 	defer f.Hub.Scope().RemoveTag(sentinel)
 
-	// Apply the request scope to a probe event to read its tags.
-	probe := &sentry.Event{}
-	applied := requestHub.Scope().ApplyToEvent(probe, nil, nil)
-	if applied == nil {
+	transport := &sentry.MockTransport{}
+	probeClient, err := sentry.NewClient(sentry.ClientOptions{Dsn: testDsn, Transport: transport})
+	if err != nil {
+		f.T.Errorf("probe client: %v", err)
+		return
+	}
+	if eventID := probeClient.CaptureException(errIsolationProbe, nil, requestHub.Scope()); eventID == nil {
 		f.T.Error("event dropped by event processor")
 		return
 	}
-	if _, ok := applied.Tags[sentinel]; ok {
+
+	events := transport.Events()
+	if len(events) == 0 {
+		f.T.Error("probe event was not delivered")
+		return
+	}
+	if _, ok := events[len(events)-1].Tags[sentinel]; ok {
 		f.T.Error("scope mutation leaked into request hub; scopes are not independent")
 	}
 }
+
+var errIsolationProbe = errors.New("sentrytest isolation probe")

--- a/internal/sentrytest/fixture.go
+++ b/internal/sentrytest/fixture.go
@@ -248,7 +248,7 @@ func (f *Fixture) AssertHubIsolation(requestHub *sentry.Hub) {
 		f.T.Errorf("probe client: %v", err)
 		return
 	}
-	if eventID := probeClient.CaptureException(errIsolationProbe, nil, requestHub.Scope()); eventID == nil {
+	if eventID := sentry.NewHub(probeClient, requestHub.Scope()).CaptureException(errIsolationProbe); eventID == nil {
 		f.T.Error("event dropped by event processor")
 		return
 	}

--- a/internal/sentrytest/fixture_test.go
+++ b/internal/sentrytest/fixture_test.go
@@ -38,10 +38,7 @@ func TestNewSentryFixture_WithClientOptions_Tracing(t *testing.T) {
 		TracesSampleRate: 1.0,
 	}))
 
-	span := sentry.StartTransaction(
-		sentry.SetHubOnContext(t.Context(), f.Hub),
-		"test-transaction",
-	)
+	span := sentry.StartTransaction(f.NewContext(t.Context()), "test-transaction")
 	span.Finish()
 	f.Flush()
 
@@ -76,7 +73,8 @@ func TestFixture_NewContext(t *testing.T) {
 	ctx := f.NewContext(parent)
 
 	assert.Equal(t, "value", ctx.Value(contextKey{}), "context value")
-	assert.Same(t, f.Hub, sentry.GetHubFromContext(ctx), "context hub")
+	assert.NotNil(t, sentry.ScopeFromContext(ctx), "context scope")
+	assert.Same(t, f.Client, sentry.GetClient(ctx), "context client")
 }
 
 func TestNewContext(t *testing.T) {
@@ -86,7 +84,7 @@ func TestNewContext(t *testing.T) {
 	ctx := NewContext(parent, t)
 
 	assert.Equal(t, "value", ctx.Value(contextKey{}), "context value")
-	assert.NotNil(t, sentry.GetHubFromContext(ctx), "context hub")
+	assert.NotNil(t, sentry.ScopeFromContext(ctx), "context scope")
 }
 
 func TestNewContext_NilParent(t *testing.T) {
@@ -94,7 +92,7 @@ func TestNewContext_NilParent(t *testing.T) {
 
 	ctx := NewContext(nil, t) // nolint: staticcheck // SA1012: passing nil context for the test
 
-	assert.NotNil(t, sentry.GetHubFromContext(ctx), "context hub")
+	assert.NotNil(t, sentry.ScopeFromContext(ctx), "context scope")
 	assert.Nil(t, ctx.Value(contextKey{}), "context value")
 }
 
@@ -105,8 +103,8 @@ func TestSentryFixture_Events_IncludesTransactions(t *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 	}))
-	ctx := sentry.SetHubOnContext(t.Context(), f.Hub)
-	f.Hub.CaptureMessage("error event")
+	ctx := f.NewContext(t.Context())
+	sentry.CaptureMessage(ctx, "error event")
 	span := sentry.StartTransaction(ctx, "test-tx")
 	span.Finish()
 

--- a/internal/telemetry/attachments_regression_test.go
+++ b/internal/telemetry/attachments_regression_test.go
@@ -13,10 +13,6 @@ import (
 )
 
 func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
-	event := sentry.NewEvent()
-	event.Message = "test with attachment"
-	event.Level = sentry.LevelInfo
-
 	scope := sentry.NewScope()
 	scope.AddAttachment(&sentry.Attachment{
 		Filename:    "test.txt",
@@ -24,7 +20,22 @@ func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
 		Payload:     []byte("hello world"),
 	})
 
-	event = scope.ApplyToEvent(event, nil, nil)
+	mockTransport := &sentry.MockTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://whatever@sentry.io/1337",
+		Transport: mockTransport,
+	})
+	require.NoError(t, err)
+	event := sentry.NewEvent()
+	event.Message = "test with attachment"
+	event.Level = sentry.LevelInfo
+	require.NotNil(t, client.CaptureEvent(event, nil, scope))
+	require.True(t, client.Flush(testutils.FlushTimeout()), "flush timed out")
+	client.Close()
+
+	events := mockTransport.Events()
+	require.Len(t, events, 1, "expected a single captured event")
+	event = events[0]
 
 	transport := &testutils.MockTelemetryTransport{}
 	processor := telemetry.NewProcessor(

--- a/internal/telemetry/attachments_regression_test.go
+++ b/internal/telemetry/attachments_regression_test.go
@@ -1,6 +1,7 @@
 package telemetry_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/getsentry/sentry-go"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
-	scope := sentry.NewScope()
+	ctx, scope := sentry.WithIsolationScope(context.Background())
 	scope.AddAttachment(&sentry.Attachment{
 		Filename:    "test.txt",
 		ContentType: "text/plain",
@@ -29,7 +30,7 @@ func TestProcessorFlush_EnvelopeCarriesScopeAttachments(t *testing.T) {
 	event := sentry.NewEvent()
 	event.Message = "test with attachment"
 	event.Level = sentry.LevelInfo
-	require.NotNil(t, client.CaptureEvent(event, nil, scope))
+	require.NotNil(t, client.CaptureEvent(ctx, event))
 	require.True(t, client.Flush(testutils.FlushTimeout()), "flush timed out")
 	client.Close()
 

--- a/internal/util/map.go
+++ b/internal/util/map.go
@@ -2,6 +2,23 @@ package util
 
 import "sync"
 
+// FillMap copies keys from src that are absent in dst. It allocates dst when
+// needed and never aliases src.
+func FillMap[M ~map[K]V, K comparable, V any](dst M, src M) M {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(M, len(src))
+	}
+	for k, v := range src {
+		if _, ok := dst[k]; !ok {
+			dst[k] = v
+		}
+	}
+	return dst
+}
+
 type SyncMap[K comparable, V any] struct {
 	m sync.Map
 }

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -67,7 +67,7 @@ func (h *handler) handle(ctx iris.Context) {
 	r := ctx.Request()
 
 	options := []sentry.SpanOption{
-		sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+		sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 		sentry.WithOpName("http.server"),
 		sentry.WithTransactionSource(sentry.SourceRoute),
 		sentry.WithSpanOrigin(sentry.SpanOriginIris),

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -60,7 +60,7 @@ func (h *handler) handle(ctx iris.Context) {
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/iris/sentryiris_test.go
+++ b/iris/sentryiris_test.go
@@ -68,6 +68,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "/panic/1",
 					Method: "GET",
@@ -442,6 +446,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/log.go
+++ b/log.go
@@ -60,7 +60,7 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 	}
 
 	client := hub.Client()
-	if client != nil {
+	if client.IsEnabled() {
 		// Build default attrs
 		serverAddr := client.options.ServerName
 		if serverAddr == "" {
@@ -111,7 +111,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		hub = l.hub
 	}
 	client := hub.Client()
-	if client == nil {
+	if !client.IsEnabled() {
 		return
 	}
 

--- a/log.go
+++ b/log.go
@@ -35,7 +35,6 @@ const (
 
 type sentryLogger struct {
 	ctx               context.Context
-	hub               *Hub
 	attributes        map[string]attribute.Value
 	defaultAttributes map[string]attribute.Value
 	mu                sync.RWMutex
@@ -53,13 +52,7 @@ type logEntry struct {
 
 // NewLogger returns a Logger that emits logs to Sentry.
 func NewLogger(ctx context.Context) Logger { // nolint: dupl
-	var hub *Hub
-	hub = GetHubFromContext(ctx)
-	if hub == nil {
-		hub = CurrentHub()
-	}
-
-	client := hub.Client()
+	client := GetClient(ctx)
 	options := client.options
 	if client.IsEnabled() {
 		// Build default attrs
@@ -85,7 +78,6 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 
 		return &sentryLogger{
 			ctx:               ctx,
-			hub:               hub,
 			attributes:        make(map[string]attribute.Value),
 			defaultAttributes: defaultAttrs,
 			mu:                sync.RWMutex{},
@@ -107,12 +99,8 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		return
 	}
 
-	hub := hubFromContexts(ctx, l.ctx)
-	if hub == nil {
-		hub = l.hub
-	}
-	client := hub.Client()
-	scope := hub.Scope()
+	client := GetClient(ctx)
+	scope := ScopeFromContext(ctx)
 	l.mu.RLock()
 	attrs := copySignalAttributes(entryAttrs, l.attributes)
 	l.mu.RUnlock()
@@ -139,7 +127,6 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 	client.captureLog(log, signalCaptureContext{
 		scope:             scope,
 		ctx:               ctx,
-		fallback:          l.ctx,
 		defaultAttributes: l.defaultAttributes,
 	})
 	if client.options.Debug {
@@ -148,7 +135,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 }
 
 func prepareLog(log *Log, client *Client, capture signalCaptureContext) {
-	trace := resolveTrace(capture.scope, client, capture.ctx, capture.fallback)
+	trace := resolveTrace(capture.scope, client, capture.ctx)
 	log.TraceID = trace.traceID
 	log.SpanID = trace.telemetrySpanID
 	log.Attributes = mergeScopeAttributes(log.Attributes, capture.defaultAttributes, capture.scope)

--- a/log.go
+++ b/log.go
@@ -60,19 +60,20 @@ func NewLogger(ctx context.Context) Logger { // nolint: dupl
 	}
 
 	client := hub.Client()
+	options := client.options
 	if client.IsEnabled() {
 		// Build default attrs
-		serverAddr := client.options.ServerName
+		serverAddr := options.ServerName
 		if serverAddr == "" {
 			serverAddr, _ = os.Hostname()
 		}
 
 		defaults := map[string]string{
-			"sentry.release":        client.options.Release,
-			"sentry.environment":    client.options.Environment,
+			"sentry.release":        options.Release,
+			"sentry.environment":    options.Environment,
 			"sentry.server.address": serverAddr,
-			"sentry.sdk.name":       client.sdkIdentifier,
-			"sentry.sdk.version":    client.sdkVersion,
+			"sentry.sdk.name":       client.GetSDKIdentifier(),
+			"sentry.sdk.version":    client.GetSDKVersion(),
 		}
 
 		defaultAttrs := make(map[string]attribute.Value, len(defaults))
@@ -111,32 +112,10 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		hub = l.hub
 	}
 	client := hub.Client()
-	if !client.IsEnabled() {
-		return
-	}
-
 	scope := hub.Scope()
-	traceID, spanID := resolveTrace(scope, client, ctx, l.ctx)
-
-	// Pre-allocate with capacity hint to avoid map growth reallocations
-	estimatedCap := len(l.defaultAttributes) + len(entryAttrs) + len(args) + 8 // scope ~3 + instance ~5
-	attrs := make(map[string]attribute.Value, estimatedCap)
-
-	// attribute precedence: default -> scope -> instance (from SetAttrs) -> entry-specific
-	for k, v := range l.defaultAttributes {
-		attrs[k] = v
-	}
-	scope.populateAttrs(attrs)
-
 	l.mu.RLock()
-	for k, v := range l.attributes {
-		attrs[k] = v
-	}
+	attrs := copySignalAttributes(entryAttrs, l.attributes, l.defaultAttributes)
 	l.mu.RUnlock()
-
-	for k, v := range entryAttrs {
-		attrs[k] = v
-	}
 
 	body := message
 	if format {
@@ -152,19 +131,23 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 
 	log := &Log{
 		Timestamp:  time.Now(),
-		TraceID:    traceID,
-		SpanID:     spanID,
 		Level:      level,
 		Severity:   severity,
 		Body:       body,
 		Attributes: attrs,
 	}
-	log.approximateSize = computeLogSize(log)
-
-	client.captureLog(log, scope)
+	client.captureLog(log, signalCaptureContext{scope: scope, ctx: ctx, fallback: l.ctx})
 	if client.options.Debug {
 		debuglog.Print(body)
 	}
+}
+
+func prepareLog(log *Log, client *Client, capture signalCaptureContext) {
+	trace := resolveTrace(capture.scope, client, capture.ctx, capture.fallback)
+	log.TraceID = trace.traceID
+	log.SpanID = trace.telemetrySpanID
+	log.Attributes = mergeScopeAttributes(log.Attributes, capture.scope)
+	log.approximateSize = computeLogSize(log)
 }
 
 func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {

--- a/log.go
+++ b/log.go
@@ -114,7 +114,7 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 	client := hub.Client()
 	scope := hub.Scope()
 	l.mu.RLock()
-	attrs := copySignalAttributes(entryAttrs, l.attributes, l.defaultAttributes)
+	attrs := copySignalAttributes(entryAttrs, l.attributes)
 	l.mu.RUnlock()
 
 	body := message
@@ -136,7 +136,12 @@ func (l *sentryLogger) log(ctx context.Context, level LogLevel, severity int, me
 		Body:       body,
 		Attributes: attrs,
 	}
-	client.captureLog(log, signalCaptureContext{scope: scope, ctx: ctx, fallback: l.ctx})
+	client.captureLog(log, signalCaptureContext{
+		scope:             scope,
+		ctx:               ctx,
+		fallback:          l.ctx,
+		defaultAttributes: l.defaultAttributes,
+	})
 	if client.options.Debug {
 		debuglog.Print(body)
 	}
@@ -146,7 +151,7 @@ func prepareLog(log *Log, client *Client, capture signalCaptureContext) {
 	trace := resolveTrace(capture.scope, client, capture.ctx, capture.fallback)
 	log.TraceID = trace.traceID
 	log.SpanID = trace.telemetrySpanID
-	log.Attributes = mergeScopeAttributes(log.Attributes, capture.scope)
+	log.Attributes = mergeScopeAttributes(log.Attributes, capture.defaultAttributes, capture.scope)
 	log.approximateSize = computeLogSize(log)
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -554,6 +554,10 @@ func Test_sentryLogger_AttributePrecedence(t *testing.T) {
 	hub := GetHubFromContext(ctx)
 
 	hub.Scope().SetUser(User{ID: "user456", Name: "TestUser"})
+	hub.Scope().SetAttributes(
+		attribute.String("key", "scope-value"),
+		attribute.String("sentry.sdk.name", "scope-sdk"),
+	)
 
 	logger := NewLogger(ctx)
 	logger.SetAttributes(attribute.String("key", "instance-value"))
@@ -601,8 +605,10 @@ func Test_sentryLogger_AttributePrecedence(t *testing.T) {
 		t.Errorf("expected user.id=user456, got %v", val.AsString())
 	}
 
-	if _, ok := attrs["sentry.sdk.name"]; !ok {
-		t.Error("missing sentry.sdk.name default attribute")
+	if val, ok := attrs["sentry.sdk.name"]; !ok {
+		t.Error("missing sentry.sdk.name attribute")
+	} else if val.AsString() != "scope-sdk" {
+		t.Errorf("expected scope to override SDK default, got %v", val.AsString())
 	}
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -20,14 +20,9 @@ const (
 	LogTraceID = "d49d9bf66f13450b81f65bc51cf49c03"
 )
 
-// flushFromContext flushes the hub from the given context.
-// This is needed for tests that use a cloned hub for isolation.
+// flushFromContext flushes the client from the given context.
 func flushFromContext(ctx context.Context, timeout time.Duration) {
-	hub := GetHubFromContext(ctx)
-	if hub == nil {
-		hub = CurrentHub()
-	}
-	hub.Flush(timeout)
+	GetClient(ctx).Flush(timeout)
 }
 
 func setupMockTransport() (context.Context, *MockTransport) {
@@ -43,11 +38,9 @@ func setupMockTransport() (context.Context, *MockTransport) {
 	})
 	mockClient.sdkIdentifier = "sentry.go"
 	mockClient.sdkVersion = "0.10.0"
-	hub := CurrentHub().Clone()
-	hub.BindClient(mockClient)
-	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
-
-	ctx = SetHubOnContext(ctx, hub)
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(mockClient)
+	scope.propagationContext.TraceID = TraceIDFromHex(LogTraceID)
 	return ctx, mockTransport
 }
 
@@ -551,10 +544,9 @@ func TestSentryLogger_LogEntryAttributes(t *testing.T) {
 
 func Test_sentryLogger_AttributePrecedence(t *testing.T) {
 	ctx, mockTransport := setupMockTransport()
-	hub := GetHubFromContext(ctx)
-
-	hub.Scope().SetUser(User{ID: "user456", Name: "TestUser"})
-	hub.Scope().SetAttributes(
+	scope := ScopeFromContext(ctx)
+	scope.SetUser(User{ID: "user456", Name: "TestUser"})
+	scope.SetAttributes(
 		attribute.String("key", "scope-value"),
 		attribute.String("sentry.sdk.name", "scope-sdk"),
 	)
@@ -631,8 +623,7 @@ func Test_batchLogger_FlushWithContext(t *testing.T) {
 
 	cancelCtx, cancel := context.WithTimeout(context.Background(), testutils.FlushTimeout())
 	defer cancel()
-	hub := GetHubFromContext(ctx)
-	hub.FlushWithContext(cancelCtx)
+	GetClient(ctx).FlushWithContext(cancelCtx)
 
 	events := mockTransport.Events()
 	if len(events) != 1 {
@@ -693,16 +684,14 @@ func Test_batchLogger_Shutdown(t *testing.T) {
 		Transport:              mockTransport,
 		DisableTelemetryBuffer: true,
 	})
-	hub := CurrentHub()
-	hub.BindClient(mockClient)
-	ctx := SetHubOnContext(context.Background(), hub)
+	ctx, scope := WithIsolationScope(context.Background())
+	scope.SetClient(mockClient)
 	l := NewLogger(ctx)
 	for i := 0; i < 3; i++ {
 		l.Info().WithCtx(ctx).Emit("test")
 	}
 
-	hub = GetHubFromContext(ctx)
-	hub.Client().batchLogger.Shutdown()
+	mockClient.batchLogger.Shutdown()
 
 	events := mockTransport.Events()
 	if len(events) != 1 {
@@ -715,8 +704,8 @@ func Test_batchLogger_Shutdown(t *testing.T) {
 	mockTransport.events = nil
 
 	// Test that shutdown can be called multiple times safely
-	hub.Client().batchLogger.Shutdown()
-	hub.Client().batchLogger.Shutdown()
+	mockClient.batchLogger.Shutdown()
+	mockClient.batchLogger.Shutdown()
 
 	events = mockTransport.Events()
 	if len(events) != 0 {
@@ -746,11 +735,9 @@ func Test_sentryLogger_BeforeSendLog(t *testing.T) {
 	})
 	mockClient.sdkIdentifier = "sentry.go"
 	mockClient.sdkVersion = "0.10.0"
-	hub := CurrentHub()
-	hub.BindClient(mockClient)
-	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
-
-	ctx = SetHubOnContext(ctx, hub)
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(mockClient)
+	scope.propagationContext.TraceID = TraceIDFromHex(LogTraceID)
 
 	l := NewLogger(ctx)
 	l.Info().WithCtx(ctx).Emit("context done log")
@@ -826,13 +813,12 @@ func TestSentryLogger_DebugLogging(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 
-			ctx := context.Background()
 			mockClient, _ := NewClient(ClientOptions{
 				Transport: &MockTransport{},
 				Debug:     true,
 			})
-			hub := CurrentHub()
-			hub.BindClient(mockClient)
+			ctx, scope := WithIsolationScope(context.Background())
+			scope.SetClient(mockClient)
 
 			// set the debug logger output after NewClient, so that it doesn't change.
 			debuglog.SetOutput(&buf)
@@ -861,17 +847,14 @@ func Test_sentryLogger_UserAttributes(t *testing.T) {
 	})
 	mockClient.sdkIdentifier = "sentry.go"
 	mockClient.sdkVersion = "0.10.0"
-	hub := CurrentHub().Clone()
-	hub.BindClient(mockClient)
-	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
-
-	hub.Scope().SetUser(User{
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(mockClient)
+	scope.propagationContext.TraceID = TraceIDFromHex(LogTraceID)
+	scope.SetUser(User{
 		ID:    "user123",
 		Name:  "Test User",
 		Email: "test@example.com",
 	})
-
-	ctx = SetHubOnContext(ctx, hub)
 
 	l := NewLogger(ctx)
 	l.Info().Emit("test message with PII")
@@ -912,12 +895,11 @@ func Test_sentryLogger_UserAttributes(t *testing.T) {
 func TestSentryLogger_ScopeSetAttributesNoLeak(t *testing.T) {
 	ctx, mockTransport := setupMockTransport()
 
-	clonedHub := GetHubFromContext(ctx).Clone()
-	clonedHub.Scope().SetAttributes(
+	scopedCtx, clonedScope := WithIsolationScope(ctx)
+	clonedScope.SetAttributes(
 		attribute.String("key.string", "str"),
 		attribute.Bool("key.bool", true),
 	)
-	scopedCtx := SetHubOnContext(ctx, clonedHub)
 	txn := StartTransaction(scopedCtx, "test-transaction")
 	defer txn.Finish()
 

--- a/metrics.go
+++ b/metrics.go
@@ -55,19 +55,20 @@ func NewMeter(ctx context.Context) Meter {
 		hub = CurrentHub()
 	}
 	client := hub.Client()
+	options := client.options
 	if client.IsEnabled() {
 		// build default attrs
-		serverAddr := client.options.ServerName
+		serverAddr := options.ServerName
 		if serverAddr == "" {
 			serverAddr, _ = os.Hostname()
 		}
 
 		defaults := map[string]string{
-			"sentry.release":        client.options.Release,
-			"sentry.environment":    client.options.Environment,
+			"sentry.release":        options.Release,
+			"sentry.environment":    options.Environment,
 			"sentry.server.address": serverAddr,
-			"sentry.sdk.name":       client.sdkIdentifier,
-			"sentry.sdk.version":    client.sdkVersion,
+			"sentry.sdk.name":       client.GetSDKIdentifier(),
+			"sentry.sdk.version":    client.GetSDKVersion(),
 		}
 
 		defaultAttrs := make(map[string]attribute.Value)
@@ -98,7 +99,7 @@ type sentryMeter struct {
 	mu                sync.RWMutex
 }
 
-func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name string, value MetricValue, unit string, attributes map[string]attribute.Value, customScope *Scope) {
+func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name string, value MetricValue, unit string, attributes []attribute.Builder, customScope *Scope) {
 	if name == "" {
 		debuglog.Println("empty name provided, dropping metric")
 		return
@@ -110,40 +111,16 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 	}
 
 	client := hub.Client()
-	if !client.IsEnabled() {
-		return
-	}
-
 	scope := hub.Scope()
 	if customScope != nil {
 		scope = customScope
 	}
-	traceID, spanID := resolveTrace(scope, client, ctx, m.ctx)
-
-	// Pre-allocate with capacity hint to avoid map growth reallocations
-	estimatedCap := len(m.defaultAttributes) + len(attributes) + 8 // scope ~3 + call-specific ~5
-	attrs := make(map[string]attribute.Value, estimatedCap)
-
-	// attribute precedence: default -> scope -> instance (from SetAttrs) -> entry-specific
-	for k, v := range m.defaultAttributes {
-		attrs[k] = v
-	}
-	scope.populateAttrs(attrs)
-
 	m.mu.RLock()
-	for k, v := range m.attributes {
-		attrs[k] = v
-	}
+	attrs := buildMetricAttributes(attributes, m.attributes, m.defaultAttributes)
 	m.mu.RUnlock()
-
-	for k, v := range attributes {
-		attrs[k] = v
-	}
 
 	metric := &Metric{
 		Timestamp:  time.Now(),
-		TraceID:    traceID,
-		SpanID:     spanID,
 		Type:       metricType,
 		Name:       name,
 		Value:      value,
@@ -151,9 +128,16 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 		Attributes: attrs,
 	}
 
-	if client.captureMetric(metric, scope) && client.options.Debug {
+	if client.captureMetric(metric, signalCaptureContext{scope: scope, ctx: ctx, fallback: m.ctx}) && client.options.Debug {
 		debuglog.Printf("Metric %s [%s]: %v %s", metricType, name, value.AsInterface(), unit)
 	}
+}
+
+func prepareMetric(metric *Metric, client *Client, capture signalCaptureContext) {
+	trace := resolveTrace(capture.scope, client, capture.ctx, capture.fallback)
+	metric.TraceID = trace.traceID
+	metric.SpanID = trace.telemetrySpanID
+	metric.Attributes = mergeScopeAttributes(metric.Attributes, capture.scope)
 }
 
 // WithCtx returns a new Meter that uses the given context for trace/span association.

--- a/metrics.go
+++ b/metrics.go
@@ -47,14 +47,10 @@ const (
 	UnitPercent = "percent"
 )
 
-// NewMeter returns a new Meter. If there is no Client bound to the current hub,
+// NewMeter returns a new Meter. If there is no enabled Client available from the current context,
 // it returns a no-op Meter that discards all metrics.
 func NewMeter(ctx context.Context) Meter {
-	hub := GetHubFromContext(ctx)
-	if hub == nil {
-		hub = CurrentHub()
-	}
-	client := hub.Client()
+	client := GetClient(ctx)
 	options := client.options
 	if client.IsEnabled() {
 		// build default attrs
@@ -80,7 +76,6 @@ func NewMeter(ctx context.Context) Meter {
 
 		return &sentryMeter{
 			ctx:               ctx,
-			hub:               hub,
 			attributes:        make(map[string]attribute.Value),
 			defaultAttributes: defaultAttrs,
 			mu:                sync.RWMutex{},
@@ -93,7 +88,6 @@ func NewMeter(ctx context.Context) Meter {
 
 type sentryMeter struct {
 	ctx               context.Context
-	hub               *Hub
 	attributes        map[string]attribute.Value
 	defaultAttributes map[string]attribute.Value
 	mu                sync.RWMutex
@@ -105,13 +99,8 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 		return
 	}
 
-	hub := hubFromContexts(ctx, m.ctx)
-	if hub == nil {
-		hub = m.hub
-	}
-
-	client := hub.Client()
-	scope := hub.Scope()
+	client := GetClient(ctx)
+	scope := ScopeFromContext(ctx)
 	if customScope != nil {
 		scope = customScope
 	}
@@ -131,7 +120,6 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 	if client.captureMetric(metric, signalCaptureContext{
 		scope:             scope,
 		ctx:               ctx,
-		fallback:          m.ctx,
 		defaultAttributes: m.defaultAttributes,
 	}) && client.options.Debug {
 		debuglog.Printf("Metric %s [%s]: %v %s", metricType, name, value.AsInterface(), unit)
@@ -139,7 +127,7 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 }
 
 func prepareMetric(metric *Metric, client *Client, capture signalCaptureContext) {
-	trace := resolveTrace(capture.scope, client, capture.ctx, capture.fallback)
+	trace := resolveTrace(capture.scope, client, capture.ctx)
 	metric.TraceID = trace.traceID
 	metric.SpanID = trace.telemetrySpanID
 	metric.Attributes = mergeScopeAttributes(metric.Attributes, capture.defaultAttributes, capture.scope)
@@ -153,7 +141,6 @@ func (m *sentryMeter) WithCtx(ctx context.Context) Meter {
 
 	return &sentryMeter{
 		ctx:               ctx,
-		hub:               m.hub,
 		attributes:        attrsCopy,
 		defaultAttributes: m.defaultAttributes,
 		mu:                sync.RWMutex{},

--- a/metrics.go
+++ b/metrics.go
@@ -55,7 +55,7 @@ func NewMeter(ctx context.Context) Meter {
 		hub = CurrentHub()
 	}
 	client := hub.Client()
-	if client != nil {
+	if client.IsEnabled() {
 		// build default attrs
 		serverAddr := client.options.ServerName
 		if serverAddr == "" {
@@ -110,7 +110,7 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 	}
 
 	client := hub.Client()
-	if client == nil {
+	if !client.IsEnabled() {
 		return
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -116,7 +116,7 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 		scope = customScope
 	}
 	m.mu.RLock()
-	attrs := buildMetricAttributes(attributes, m.attributes, m.defaultAttributes)
+	attrs := buildMetricAttributes(attributes, m.attributes)
 	m.mu.RUnlock()
 
 	metric := &Metric{
@@ -128,7 +128,12 @@ func (m *sentryMeter) emit(ctx context.Context, metricType MetricType, name stri
 		Attributes: attrs,
 	}
 
-	if client.captureMetric(metric, signalCaptureContext{scope: scope, ctx: ctx, fallback: m.ctx}) && client.options.Debug {
+	if client.captureMetric(metric, signalCaptureContext{
+		scope:             scope,
+		ctx:               ctx,
+		fallback:          m.ctx,
+		defaultAttributes: m.defaultAttributes,
+	}) && client.options.Debug {
 		debuglog.Printf("Metric %s [%s]: %v %s", metricType, name, value.AsInterface(), unit)
 	}
 }
@@ -137,7 +142,7 @@ func prepareMetric(metric *Metric, client *Client, capture signalCaptureContext)
 	trace := resolveTrace(capture.scope, client, capture.ctx, capture.fallback)
 	metric.TraceID = trace.traceID
 	metric.SpanID = trace.telemetrySpanID
-	metric.Attributes = mergeScopeAttributes(metric.Attributes, capture.scope)
+	metric.Attributes = mergeScopeAttributes(metric.Attributes, capture.defaultAttributes, capture.scope)
 }
 
 // WithCtx returns a new Meter that uses the given context for trace/span association.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -592,6 +592,10 @@ func Test_sentryMeter_AttributePrecedence(t *testing.T) {
 	hub := GetHubFromContext(ctx)
 
 	hub.Scope().SetUser(User{ID: "user123", Name: "TestUser"})
+	hub.Scope().SetAttributes(
+		attribute.String("key", "scope-value"),
+		attribute.String("sentry.sdk.name", "scope-sdk"),
+	)
 
 	meter := NewMeter(ctx)
 	meter.SetAttributes(attribute.String("key", "instance-value"))
@@ -642,8 +646,10 @@ func Test_sentryMeter_AttributePrecedence(t *testing.T) {
 		t.Errorf("expected user.id=user123, got %v", val.AsString())
 	}
 
-	if _, ok := attrs["sentry.sdk.name"]; !ok {
-		t.Error("missing sentry.sdk.name default attribute")
+	if val, ok := attrs["sentry.sdk.name"]; !ok {
+		t.Error("missing sentry.sdk.name attribute")
+	} else if val.AsString() != "scope-sdk" {
+		t.Errorf("expected scope to override SDK default, got %v", val.AsString())
 	}
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -25,11 +25,9 @@ func setupMetricsTest() (context.Context, *MockTransport) {
 	})
 	mockClient.sdkIdentifier = "sentry.go"
 	mockClient.sdkVersion = "0.10.0"
-	hub := CurrentHub().Clone()
-	hub.BindClient(mockClient)
-	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
-
-	ctx = SetHubOnContext(ctx, hub)
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(mockClient)
+	scope.propagationContext.TraceID = TraceIDFromHex(LogTraceID)
 	return ctx, mockTransport
 }
 
@@ -296,8 +294,7 @@ func Test_batchMeter_FlushWithContext(t *testing.T) {
 
 	cancelCtx, cancel := context.WithTimeout(context.Background(), testutils.FlushTimeout())
 	defer cancel()
-	hub := GetHubFromContext(ctx)
-	hub.FlushWithContext(cancelCtx)
+	GetClient(ctx).FlushWithContext(cancelCtx)
 
 	events := mockTransport.Events()
 	if len(events) != 1 {
@@ -321,11 +318,9 @@ func Test_sentryMeter_BeforeSendMetric(t *testing.T) {
 	})
 	mockClient.sdkIdentifier = "sentry.go"
 	mockClient.sdkVersion = "0.10.0"
-	hub := CurrentHub().Clone()
-	hub.BindClient(mockClient)
-	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
-
-	ctx = SetHubOnContext(ctx, hub)
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(mockClient)
+	scope.propagationContext.TraceID = TraceIDFromHex(LogTraceID)
 
 	meter := NewMeter(ctx)
 	meter.Count("test.count", 1)
@@ -401,16 +396,14 @@ func Test_batchMeter_Shutdown(t *testing.T) {
 		Transport:              mockTransport,
 		DisableTelemetryBuffer: true,
 	})
-	hub := CurrentHub()
-	hub.BindClient(mockClient)
-	ctx := SetHubOnContext(context.Background(), hub)
+	ctx, scope := WithIsolationScope(context.Background())
+	scope.SetClient(mockClient)
 	meter := NewMeter(ctx)
 	for i := 0; i < 3; i++ {
 		meter.Count("test.count", 1)
 	}
 
-	hub = GetHubFromContext(ctx)
-	hub.Client().batchMeter.Shutdown()
+	mockClient.batchMeter.Shutdown()
 
 	events := mockTransport.Events()
 	if len(events) != 1 {
@@ -423,8 +416,8 @@ func Test_batchMeter_Shutdown(t *testing.T) {
 	mockTransport.events = nil
 
 	// Test that shutdown can be called multiple times safely
-	hub.Client().batchMeter.Shutdown()
-	hub.Client().batchMeter.Shutdown()
+	mockClient.batchMeter.Shutdown()
+	mockClient.batchMeter.Shutdown()
 
 	events = mockTransport.Events()
 	if len(events) != 0 {
@@ -485,17 +478,14 @@ func Test_sentryMeter_UserAttributes(t *testing.T) {
 	})
 	mockClient.sdkIdentifier = "sentry.go"
 	mockClient.sdkVersion = "0.10.0"
-	hub := CurrentHub().Clone()
-	hub.BindClient(mockClient)
-	hub.Scope().propagationContext.TraceID = TraceIDFromHex(LogTraceID)
-
-	hub.Scope().SetUser(User{
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(mockClient)
+	scope.propagationContext.TraceID = TraceIDFromHex(LogTraceID)
+	scope.SetUser(User{
 		ID:    "user123",
 		Name:  "Test User",
 		Email: "test@example.com",
 	})
-
-	ctx = SetHubOnContext(ctx, hub)
 
 	meter := NewMeter(ctx)
 	meter.Count("test.count", 1)
@@ -589,10 +579,9 @@ func Test_sentryMeter_SetAttributes_Persistence(t *testing.T) {
 
 func Test_sentryMeter_AttributePrecedence(t *testing.T) {
 	ctx, mockTransport := setupMetricsTest()
-	hub := GetHubFromContext(ctx)
-
-	hub.Scope().SetUser(User{ID: "user123", Name: "TestUser"})
-	hub.Scope().SetAttributes(
+	scope := ScopeFromContext(ctx)
+	scope.SetUser(User{ID: "user123", Name: "TestUser"})
+	scope.SetAttributes(
 		attribute.String("key", "scope-value"),
 		attribute.String("sentry.sdk.name", "scope-sdk"),
 	)
@@ -670,9 +659,8 @@ func Test_sentryMeter_EmptyName(t *testing.T) {
 }
 
 func Test_noopMeter_Methods(t *testing.T) {
-	hub := NewHub(nil, NewScope())
-	ctx := SetHubOnContext(context.Background(), hub)
-	meter := NewMeter(ctx)
+	ctx := context.Background()
+	var meter Meter = &noopMeter{}
 
 	meter = meter.WithCtx(ctx)
 	meter.Count("test.count", 1)
@@ -727,12 +715,11 @@ func Test_sentryMeter_WithScopeOverride(t *testing.T) {
 func TestSentryMeter_ScopeSetAttributesNoLeak(t *testing.T) {
 	ctx, mockTransport := setupMetricsTest()
 
-	clonedHub := GetHubFromContext(ctx).Clone()
-	clonedHub.Scope().SetAttributes(
+	scopedCtx, clonedScope := WithIsolationScope(ctx)
+	clonedScope.SetAttributes(
 		attribute.String("key.string", "str"),
 		attribute.Bool("key.bool", true),
 	)
-	scopedCtx := SetHubOnContext(ctx, clonedHub)
 	txn := StartTransaction(scopedCtx, "test-transaction")
 	defer txn.Finish()
 

--- a/mocks.go
+++ b/mocks.go
@@ -6,23 +6,6 @@ import (
 	"time"
 )
 
-// MockScope implements [Scope] for use in tests.
-type MockScope struct {
-	breadcrumb      *Breadcrumb
-	shouldDropEvent bool
-}
-
-func (scope *MockScope) AddBreadcrumb(breadcrumb *Breadcrumb, _ int) {
-	scope.breadcrumb = breadcrumb
-}
-
-func (scope *MockScope) ApplyToEvent(event *Event, _ *EventHint, _ *Client) *Event {
-	if scope.shouldDropEvent {
-		return nil
-	}
-	return event
-}
-
 // MockTransport implements [Transport] for use in tests.
 type MockTransport struct {
 	mu        sync.Mutex

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -52,7 +52,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 		hub = sentry.CurrentHub().Clone()
 	}
 
-	if client := hub.Client(); client != nil {
+	if client := hub.Client(); client.IsEnabled() {
 		client.SetSDKIdentifier(sdkIdentifier)
 	}
 

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -57,7 +57,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 	}
 
 	options := []sentry.SpanOption{
-		sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+		sentry.ContinueTrace(r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
 		sentry.WithOpName("http.server"),
 		sentry.WithTransactionSource(sentry.SourceURL),
 		sentry.WithSpanOrigin(sentry.SpanOriginNegroni),

--- a/negroni/sentrynegroni_test.go
+++ b/negroni/sentrynegroni_test.go
@@ -41,6 +41,10 @@ func TestIntegration(t *testing.T) {
 			WantEvent: &sentry.Event{
 				Level:   sentry.LevelFatal,
 				Message: "test",
+				Threads: []sentry.Thread{{
+					Stacktrace: &sentry.Stacktrace{},
+					Current:    true,
+				}},
 				Request: &sentry.Request{
 					URL:    "/panic",
 					Method: "GET",
@@ -376,6 +380,7 @@ func TestIntegration(t *testing.T) {
 			"serializedContexts", "serializedBreadcrumbs",
 			"serializedException", "serializedUser", "serializationSafe",
 		),
+		cmpopts.IgnoreFields(sentry.Stacktrace{}, "Frames"),
 		cmpopts.IgnoreFields(
 			sentry.Request{},
 			"Env",

--- a/propagation_context.go
+++ b/propagation_context.go
@@ -5,6 +5,11 @@ import (
 	"maps"
 )
 
+const (
+	traceIDContextKey = "trace_id"
+	spanIDContextKey  = "span_id"
+)
+
 type PropagationContext struct {
 	TraceID                TraceID                `json:"trace_id"`
 	SpanID                 SpanID                 `json:"span_id"`
@@ -19,8 +24,8 @@ func (p PropagationContext) clone() PropagationContext {
 
 func (p PropagationContext) Map() map[string]interface{} {
 	m := map[string]interface{}{
-		"trace_id": p.TraceID,
-		"span_id":  p.SpanID,
+		traceIDContextKey: p.TraceID,
+		spanIDContextKey:  p.SpanID,
 	}
 
 	if p.ParentSpanID != zeroSpanID {

--- a/propagation_context.go
+++ b/propagation_context.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"crypto/rand"
+	"maps"
 )
 
 type PropagationContext struct {
@@ -9,6 +10,11 @@ type PropagationContext struct {
 	SpanID                 SpanID                 `json:"span_id"`
 	ParentSpanID           SpanID                 `json:"parent_span_id,omitzero"`
 	DynamicSamplingContext DynamicSamplingContext `json:"-"`
+}
+
+func (p PropagationContext) clone() PropagationContext {
+	p.DynamicSamplingContext.Entries = maps.Clone(p.DynamicSamplingContext.Entries)
+	return p
 }
 
 func (p PropagationContext) Map() map[string]interface{} {

--- a/recover_external_test.go
+++ b/recover_external_test.go
@@ -45,99 +45,44 @@ func panicWithArbitraryValue() {
 
 //go:noinline
 func recoverPanic(client *sentry.Client, panicFunc func()) {
-	defer client.Recover(context.Background())
+	ctx := sentry.SetHubOnContext(context.Background(), sentry.NewHub(client, sentry.NewScope()))
+	defer sentry.Recover(ctx)
 	panicFunc()
 }
 
-func newRecoverTestClient(t *testing.T) (*sentry.Client, *sentry.MockTransport) {
-	t.Helper()
-
-	transport := &sentry.MockTransport{}
-	client, err := sentry.NewClient(sentry.ClientOptions{
-		Transport:        transport,
-		AttachStacktrace: true,
-		Integrations: func([]sentry.Integration) []sentry.Integration {
-			return nil
-		},
-	})
-	require.NoError(t, err)
-
-	return client, transport
+//go:noinline
+func capturePanic(client *sentry.Client, panicFunc func()) {
+	ctx := sentry.SetHubOnContext(context.Background(), sentry.NewHub(client, sentry.NewScope()))
+	defer func() {
+		sentry.CapturePanic(ctx, recover())
+	}()
+	panicFunc()
 }
 
-func requireTopFrame(t *testing.T, stacktrace *sentry.Stacktrace, function string) {
+func requirePanicStacktrace(t *testing.T, stacktrace *sentry.Stacktrace, topFrame string) {
 	t.Helper()
 	require.NotNil(t, stacktrace)
 	require.NotEmpty(t, stacktrace.Frames)
-	assert.Equal(t, function, stacktrace.Frames[len(stacktrace.Frames)-1].Function)
-}
-
-func TestRecoverUsesPanicOriginStacktrace(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		panicFunc      func()
-		topFrame       string
-		preservesStack bool
-	}{
-		{
-			name:      "error",
-			panicFunc: panicWithError,
-			topFrame:  "panicWithError",
-		},
-		{
-			name:      "runtime error",
-			panicFunc: panicWithNilPointer,
-			topFrame:  "panicWithNilPointer",
-		},
-		{
-			name:           "error with stacktrace",
-			panicFunc:      panicWithErrorStacktrace,
-			topFrame:       "newErrorWithStacktrace",
-			preservesStack: true,
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			client, transport := newRecoverTestClient(t)
-			recoverPanic(client, test.panicFunc)
-
-			events := transport.Events()
-			require.Len(t, events, 1)
-			require.NotEmpty(t, events[0].Exception)
-			exception := events[0].Exception[len(events[0].Exception)-1]
-			requireTopFrame(t, exception.Stacktrace, test.topFrame)
-
-			if test.preservesStack {
-				assert.NotEqual(t, "panicWithErrorStacktrace", exception.Stacktrace.Frames[len(exception.Stacktrace.Frames)-1].Function)
-			}
-		})
+	assert.Equal(t, topFrame, stacktrace.Frames[len(stacktrace.Frames)-1].Function)
+	for _, frame := range stacktrace.Frames {
+		assert.NotEqual(t, "github.com/getsentry/sentry-go", frame.Module)
 	}
 }
 
-func TestRecoverValueAlwaysUsesPanicOriginStacktrace(t *testing.T) {
-	t.Parallel()
+func testPanicCapture(t *testing.T, capture func(*sentry.Client, func())) {
+	t.Helper()
 
 	tests := []struct {
 		name      string
 		panicFunc func()
 		topFrame  string
+		exception bool
 	}{
-		{
-			name:      "string",
-			panicFunc: panicWithString,
-			topFrame:  "panicWithString",
-		},
-		{
-			name:      "arbitrary value",
-			panicFunc: panicWithArbitraryValue,
-			topFrame:  "panicWithArbitraryValue",
-		},
+		{name: "error", panicFunc: panicWithError, topFrame: "panicWithError", exception: true},
+		{name: "runtime error", panicFunc: panicWithNilPointer, topFrame: "panicWithNilPointer", exception: true},
+		{name: "error with stacktrace", panicFunc: panicWithErrorStacktrace, topFrame: "panicWithErrorStacktrace", exception: true},
+		{name: "string", panicFunc: panicWithString, topFrame: "panicWithString"},
+		{name: "arbitrary value", panicFunc: panicWithArbitraryValue, topFrame: "panicWithArbitraryValue"},
 	}
 
 	for _, test := range tests {
@@ -145,13 +90,38 @@ func TestRecoverValueAlwaysUsesPanicOriginStacktrace(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			client, transport := newRecoverTestClient(t)
-			recoverPanic(client, test.panicFunc)
+			transport := &sentry.MockTransport{}
+			client, err := sentry.NewClient(sentry.ClientOptions{
+				Transport: transport,
+				Integrations: func([]sentry.Integration) []sentry.Integration {
+					return nil
+				},
+			})
+			require.NoError(t, err)
+			capture(client, test.panicFunc)
 
 			events := transport.Events()
 			require.Len(t, events, 1)
-			require.Len(t, events[0].Threads, 1)
-			requireTopFrame(t, events[0].Threads[0].Stacktrace, test.topFrame)
+
+			var stacktrace *sentry.Stacktrace
+			if test.exception {
+				require.NotEmpty(t, events[0].Exception)
+				stacktrace = events[0].Exception[len(events[0].Exception)-1].Stacktrace
+			} else {
+				require.Len(t, events[0].Threads, 1)
+				stacktrace = events[0].Threads[0].Stacktrace
+			}
+			requirePanicStacktrace(t, stacktrace, test.topFrame)
 		})
 	}
+}
+
+func TestRecoverUsesPanicOriginStacktrace(t *testing.T) {
+	t.Parallel()
+	testPanicCapture(t, recoverPanic)
+}
+
+func TestCapturePanicUsesPanicOriginStacktrace(t *testing.T) {
+	t.Parallel()
+	testPanicCapture(t, capturePanic)
 }

--- a/recover_external_test.go
+++ b/recover_external_test.go
@@ -1,6 +1,7 @@
 package sentry_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -44,18 +45,8 @@ func panicWithArbitraryValue() {
 
 //go:noinline
 func recoverPanic(client *sentry.Client, panicFunc func()) {
-	defer func() {
-		if err := recover(); err != nil {
-			client.Recover(err, nil, nil)
-		}
-	}()
-
+	defer client.Recover(context.Background())
 	panicFunc()
-}
-
-//go:noinline
-func recoverHandledError(client *sentry.Client) {
-	client.Recover(errors.New("boom"), nil, nil)
 }
 
 func newRecoverTestClient(t *testing.T) (*sentry.Client, *sentry.MockTransport) {
@@ -163,16 +154,4 @@ func TestRecoverValueAlwaysUsesPanicOriginStacktrace(t *testing.T) {
 			requireTopFrame(t, events[0].Threads[0].Stacktrace, test.topFrame)
 		})
 	}
-}
-
-func TestRecoverOutsidePanicKeepsCallerStacktrace(t *testing.T) {
-	t.Parallel()
-
-	client, transport := newRecoverTestClient(t)
-	recoverHandledError(client)
-
-	events := transport.Events()
-	require.Len(t, events, 1)
-	require.Len(t, events[0].Exception, 1)
-	requireTopFrame(t, events[0].Exception[0].Stacktrace, "recoverHandledError")
 }

--- a/scope.go
+++ b/scope.go
@@ -30,7 +30,14 @@ import (
 // an event for reporting, the current client adds information from the current
 // scope into the event.
 type Scope struct {
-	mu          sync.RWMutex
+	mu              sync.RWMutex
+	eventProcessors []EventProcessor
+
+	// scopeData keeps track of all scope specific data
+	scopeData
+}
+
+type scopeData struct {
 	attributes  map[string]attribute.Value
 	breadcrumbs []*Breadcrumb
 	attachments []*Attachment
@@ -49,7 +56,6 @@ type Scope struct {
 		// size.
 		Overflow() bool
 	}
-	eventProcessors []EventProcessor
 
 	propagationContext PropagationContext
 	span               *Span
@@ -57,7 +63,11 @@ type Scope struct {
 
 // NewScope creates a new Scope.
 func NewScope() *Scope {
-	return &Scope{
+	return &Scope{scopeData: newScopeData()}
+}
+
+func newScopeData() scopeData {
+	return scopeData{
 		attributes:         make(map[string]attribute.Value),
 		breadcrumbs:        make([]*Breadcrumb, 0),
 		attachments:        make([]*Attachment, 0),
@@ -280,29 +290,33 @@ func (scope *Scope) Clone() *Scope {
 	scope.mu.RLock()
 	defer scope.mu.RUnlock()
 
-	clone := NewScope()
-	clone.user = scope.user
-	clone.breadcrumbs = make([]*Breadcrumb, len(scope.breadcrumbs))
-	copy(clone.breadcrumbs, scope.breadcrumbs)
-	clone.attachments = make([]*Attachment, len(scope.attachments))
-	copy(clone.attachments, scope.attachments)
-	clone.attributes = maps.Clone(scope.attributes)
-	clone.contexts = maps.Clone(scope.contexts)
-	clone.tags = maps.Clone(scope.tags)
-	clone.fingerprint = make([]string, len(scope.fingerprint))
-	copy(clone.fingerprint, scope.fingerprint)
-	clone.level = scope.level
-	clone.request = scope.request
-	clone.requestBody = scope.requestBody
-	clone.eventProcessors = scope.eventProcessors[:len(scope.eventProcessors):len(scope.eventProcessors)]
-	clone.propagationContext = scope.propagationContext
-	clone.span = scope.span
+	data := scope.scopeData
+	return &Scope{
+		scopeData:       data.clone(),
+		eventProcessors: scope.eventProcessors[:len(scope.eventProcessors):len(scope.eventProcessors)],
+	}
+}
+
+func (data scopeData) clone() scopeData {
+	clone := data
+	clone.breadcrumbs = make([]*Breadcrumb, len(data.breadcrumbs))
+	copy(clone.breadcrumbs, data.breadcrumbs)
+	clone.attachments = make([]*Attachment, len(data.attachments))
+	copy(clone.attachments, data.attachments)
+	clone.attributes = maps.Clone(data.attributes)
+	clone.contexts = maps.Clone(data.contexts)
+	clone.tags = maps.Clone(data.tags)
+	clone.fingerprint = make([]string, len(data.fingerprint))
+	copy(clone.fingerprint, data.fingerprint)
 	return clone
 }
 
-// Clear removes the data from the current scope. Not safe for concurrent use.
+// Clear removes data from the scope while retaining event processors.
 func (scope *Scope) Clear() {
-	*scope = *NewScope()
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+
+	scope.scopeData = newScopeData()
 }
 
 // AddEventProcessor adds an event processor to the current scope.

--- a/scope.go
+++ b/scope.go
@@ -618,21 +618,7 @@ func cloneContext(c Context) Context {
 type signalCaptureContext struct {
 	scope             *Scope
 	ctx               context.Context
-	fallback          context.Context
 	defaultAttributes map[string]attribute.Value
-}
-
-// hubFromContexts is a helper to return the first hub found in the given contexts.
-func hubFromContexts(ctxs ...context.Context) *Hub {
-	for _, ctx := range ctxs {
-		if ctx == nil {
-			continue
-		}
-		if hub := GetHubFromContext(ctx); hub != nil {
-			return hub
-		}
-	}
-	return nil
 }
 
 // resolveTrace resolves trace IDs and dynamic sampling context from the given

--- a/scope.go
+++ b/scope.go
@@ -15,23 +15,22 @@ import (
 	"github.com/getsentry/sentry-go/report"
 )
 
-// Scope holds contextual data for the current scope.
+// Scope holds contextual data for an operation.
 //
-// The scope is an object that can cloned efficiently and stores data that is
-// locally relevant to an event. For instance the scope will hold recorded
-// breadcrumbs and similar information.
+// The scope is an object that can be cloned efficiently and stores data that is
+// locally relevant to an event. It also holds the client and event processor in
+// which the scope data should be applied to.
 //
-// The scope can be interacted with in two ways. First, the scope is routinely
-// updated with information by functions such as AddBreadcrumb which will modify
-// the current scope. Second, the current scope can be configured through the
-// ConfigureScope function or Hub method of the same name.
-//
-// The scope is meant to be modified but not inspected directly. When preparing
-// an event for reporting, the current client adds information from the current
-// scope into the event.
+// Clearing or cloning the scope only affects the underlying data. To set a new
+// client or event processor, SetClient or AddEventProcessor should be used.
 type Scope struct {
-	mu              sync.RWMutex
+	mu sync.RWMutex
+	// clientOverride is an explicit client binding set with SetClient. Having
+	// no override defaults to the global scope client.
+	clientOverride *Client
+	// eventProcessors are retained by Clear and inherited by Clone.
 	eventProcessors []EventProcessor
+	lastEventID     EventID
 
 	// scopeData keeps track of all scope specific data
 	scopeData
@@ -58,12 +57,19 @@ type scopeData struct {
 	}
 
 	propagationContext PropagationContext
-	span               *Span
+	span               *Span // TODO: this should be removed when the span API is introduced. Currently kept for compatibility.
 }
 
 // NewScope creates a new Scope.
 func NewScope() *Scope {
 	return &Scope{scopeData: newScopeData()}
+}
+
+// newScopeWithClient creates a Scope with an explicit client override.
+func newScopeWithClient(client *Client) *Scope {
+	scope := NewScope()
+	scope.SetClient(client)
+	return scope
 }
 
 func newScopeData() scopeData {
@@ -92,6 +98,54 @@ func (scope *Scope) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
 	if len(scope.breadcrumbs) > limit {
 		scope.breadcrumbs = scope.breadcrumbs[1 : limit+1]
 	}
+}
+
+// SetClient sets an explicit client override on the scope. Passing nil clears
+// the override so client resolution falls back to GlobalScope.
+func (scope *Scope) SetClient(client *Client) {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+
+	scope.clientOverride = normalizeClient(client)
+}
+
+func (scope *Scope) clientOverrideSnapshot() *Client {
+	scope.mu.RLock()
+	defer scope.mu.RUnlock()
+
+	return scope.clientOverride
+}
+
+// Client returns the first enabled client in the scope chain.
+func (scope *Scope) Client() *Client {
+	if scope != nil {
+		if client := normalizeClient(scope.clientOverrideSnapshot()); client.IsEnabled() {
+			return client
+		}
+	}
+
+	global := GlobalScope()
+	if scope != global {
+		if client := normalizeClient(global.clientOverrideSnapshot()); client.IsEnabled() {
+			return client
+		}
+	}
+	return NewNoopClient()
+}
+
+func (scope *Scope) setLastEventID(id EventID) {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+
+	scope.lastEventID = id
+}
+
+// LastEventID returns the last event ID associated with this scope.
+func (scope *Scope) LastEventID() EventID {
+	scope.mu.RLock()
+	defer scope.mu.RUnlock()
+
+	return scope.lastEventID
 }
 
 // ClearBreadcrumbs clears all breadcrumbs from the current scope.
@@ -259,14 +313,14 @@ func (scope *Scope) SetPropagationContext(propagationContext PropagationContext)
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
-	scope.propagationContext = propagationContext
+	scope.propagationContext = propagationContext.clone()
 }
 
 func (scope *Scope) propagationContextSnapshot() PropagationContext {
 	scope.mu.RLock()
 	defer scope.mu.RUnlock()
 
-	return scope.propagationContext
+	return scope.propagationContext.clone()
 }
 
 // GetSpan returns the span from the current scope.
@@ -294,6 +348,8 @@ func (scope *Scope) Clone() *Scope {
 	return &Scope{
 		scopeData:       data.clone(),
 		eventProcessors: scope.eventProcessors[:len(scope.eventProcessors):len(scope.eventProcessors)],
+		clientOverride:  scope.clientOverride,
+		lastEventID:     scope.lastEventID,
 	}
 }
 
@@ -308,6 +364,7 @@ func (data scopeData) clone() scopeData {
 	clone.tags = maps.Clone(data.tags)
 	clone.fingerprint = make([]string, len(data.fingerprint))
 	copy(clone.fingerprint, data.fingerprint)
+	clone.propagationContext = data.propagationContext.clone()
 	return clone
 }
 

--- a/scope.go
+++ b/scope.go
@@ -427,7 +427,7 @@ func (state *captureState) mergeScope(event *Event, scope *Scope, prepend bool) 
 	}
 	event.Tags = util.FillMap(event.Tags, scope.tags)
 	for key, value := range scope.contexts {
-		if key == "trace" {
+		if key == "trace" && event.Type == transactionType {
 			continue
 		}
 		if event.Contexts == nil {
@@ -448,17 +448,12 @@ func (state *captureState) mergeScope(event *Event, scope *Scope, prepend bool) 
 		state.requestBody = scope.requestBody
 	}
 
-	if len(scope.breadcrumbs) > 0 {
-		if len(state.breadcrumbs) == 0 {
-			state.breadcrumbs = append([]*Breadcrumb(nil), scope.breadcrumbs...)
-		} else {
-			state.breadcrumbs = mergeTwoBreadcrumbLayers(scope.breadcrumbs, state.breadcrumbs)
-		}
-	}
 	if prepend {
+		state.breadcrumbs = prependSlice(scope.breadcrumbs, state.breadcrumbs)
 		state.attachments = prependSlice(scope.attachments, state.attachments)
 		state.processors = prependSlice(scope.eventProcessors, state.processors)
 	} else {
+		state.breadcrumbs = append(state.breadcrumbs, scope.breadcrumbs...)
 		state.attachments = append(state.attachments, scope.attachments...)
 		state.processors = append(state.processors, scope.eventProcessors...)
 	}
@@ -482,23 +477,21 @@ func setAttributeIfAbsent(attrs map[string]attribute.Value, key, value string) {
 	}
 }
 
-func copySignalAttributes(specific, instance, defaults map[string]attribute.Value) map[string]attribute.Value {
-	attrs := make(map[string]attribute.Value, len(specific)+len(instance)+len(defaults)+8)
+func copySignalAttributes(specific, instance map[string]attribute.Value) map[string]attribute.Value {
+	attrs := make(map[string]attribute.Value, len(specific)+len(instance)+8)
 	attrs = util.FillMap(attrs, specific)
-	attrs = util.FillMap(attrs, instance)
-	return util.FillMap(attrs, defaults)
+	return util.FillMap(attrs, instance)
 }
 
-func buildMetricAttributes(specific []attribute.Builder, instance, defaults map[string]attribute.Value) map[string]attribute.Value {
-	attrs := make(map[string]attribute.Value, len(specific)+len(instance)+len(defaults)+8)
+func buildMetricAttributes(specific []attribute.Builder, instance map[string]attribute.Value) map[string]attribute.Value {
+	attrs := make(map[string]attribute.Value, len(specific)+len(instance)+8)
 	for _, attr := range specific {
 		attrs[attr.Key] = attr.Value
 	}
-	attrs = util.FillMap(attrs, instance)
-	return util.FillMap(attrs, defaults)
+	return util.FillMap(attrs, instance)
 }
 
-func mergeScopeAttributes(attrs map[string]attribute.Value, scope *Scope) map[string]attribute.Value {
+func mergeScopeAttributes(attrs, defaults map[string]attribute.Value, scope *Scope) map[string]attribute.Value {
 	global := GlobalScope()
 	var user User
 	if scope != nil && scope != global {
@@ -518,7 +511,7 @@ func mergeScopeAttributes(attrs map[string]attribute.Value, scope *Scope) map[st
 	setAttributeIfAbsent(attrs, "user.id", user.ID)
 	setAttributeIfAbsent(attrs, "user.name", user.Name)
 	setAttributeIfAbsent(attrs, "user.email", user.Email)
-	return attrs
+	return util.FillMap(attrs, defaults)
 }
 
 // applyToEvent handles capture work that must run after Scope locks are
@@ -576,6 +569,8 @@ func resolveLevel(event *Event, scopeLevel Level, opts captureOptions) Level {
 		return opts.level
 	case scopeLevel != "" && event.Type != transactionType:
 		return scopeLevel
+	case opts.defaultLevel != "":
+		return opts.defaultLevel
 	default:
 		return LevelInfo
 	}
@@ -589,37 +584,22 @@ func mergeBreadcrumbs(limit int, own []*Breadcrumb, layers [][]*Breadcrumb) []*B
 		limit = defaultMaxBreadcrumbs
 	}
 
-	merged := own
+	total := len(own)
 	for _, layer := range layers {
-		merged = mergeTwoBreadcrumbLayers(merged, layer)
+		total += len(layer)
+	}
+	if total == 0 {
+		return own
+	}
+	merged := make([]*Breadcrumb, 0, total)
+	merged = append(merged, own...)
+	for _, layer := range layers {
+		merged = append(merged, layer...)
 	}
 	if len(merged) > limit {
 		merged = merged[len(merged)-limit:]
 	}
 	return merged
-}
-
-func mergeTwoBreadcrumbLayers(a, b []*Breadcrumb) []*Breadcrumb {
-	if len(a) == 0 {
-		return b
-	}
-	if len(b) == 0 {
-		return a
-	}
-	out := make([]*Breadcrumb, 0, len(a)+len(b))
-	i, j := 0, 0
-	for i < len(a) && j < len(b) {
-		if b[j].Timestamp.Before(a[i].Timestamp) {
-			out = append(out, b[j])
-			j++
-		} else {
-			out = append(out, a[i])
-			i++
-		}
-	}
-	out = append(out, a[i:]...)
-	out = append(out, b[j:]...)
-	return out
 }
 
 // cloneContext returns a new context with keys and values copied from the passed one.
@@ -636,9 +616,10 @@ func cloneContext(c Context) Context {
 }
 
 type signalCaptureContext struct {
-	scope    *Scope
-	ctx      context.Context
-	fallback context.Context
+	scope             *Scope
+	ctx               context.Context
+	fallback          context.Context
+	defaultAttributes map[string]attribute.Value
 }
 
 // hubFromContexts is a helper to return the first hub found in the given contexts.
@@ -752,7 +733,7 @@ func applyTraceToEvent(event *Event, trace traceResolution) {
 		if trace.external {
 			traceID, spanID = trace.traceID.String(), trace.spanID.String()
 		}
-		event.Contexts["trace"] = Context{"trace_id": traceID, "span_id": spanID}
+		event.Contexts["trace"] = Context{traceIDContextKey: traceID, spanIDContextKey: spanID}
 	}
 	event.sdkMetaData.dsc = trace.dsc
 }

--- a/scope.go
+++ b/scope.go
@@ -375,7 +375,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		event.Contexts["trace"] = scope.propagationContext.Map()
 
 		dsc := scope.propagationContext.DynamicSamplingContext
-		if !dsc.HasEntries() && client != nil {
+		if !dsc.HasEntries() && client.IsEnabled() {
 			dsc = DynamicSamplingContextFromScope(scope, client)
 		}
 		event.sdkMetaData.dsc = dsc
@@ -383,7 +383,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 
 	// If an external trace resolver is registered (e.g. OTel), override
 	// trace/span IDs from the hint context or the scope's request context.
-	if client != nil {
+	if client.IsEnabled() {
 		var ctx context.Context
 		if hint != nil {
 			ctx = hint.Context
@@ -434,7 +434,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		event = processor(event, hint)
 		if event == nil {
 			debuglog.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
-			if client != nil {
+			if client.IsEnabled() {
 				client.reportRecorder.RecordOne(report.ReasonEventProcessor, category)
 				if category == ratelimit.CategoryTransaction {
 					client.reportRecorder.Record(report.ReasonEventProcessor, ratelimit.CategorySpan, int64(spanCountBefore))
@@ -443,7 +443,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 			return nil
 		}
 		if droppedSpans := spanCountBefore - event.GetSpanCount(); droppedSpans > 0 {
-			if client != nil {
+			if client.IsEnabled() {
 				client.reportRecorder.Record(report.ReasonEventProcessor, ratelimit.CategorySpan, int64(droppedSpans))
 			}
 		}
@@ -524,7 +524,7 @@ func resolveTrace(scope *Scope, client *Client, ctxs ...context.Context) (traceI
 		if ctx == nil {
 			continue
 		}
-		if client != nil {
+		if client.IsEnabled() {
 			if traceID, spanID, ok := client.externalTraceContextFromContext(ctx); ok {
 				return traceID, spanID
 			}

--- a/scope.go
+++ b/scope.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getsentry/sentry-go/internal/debuglog"
 	"github.com/getsentry/sentry-go/internal/httputils"
 	"github.com/getsentry/sentry-go/internal/ratelimit"
+	"github.com/getsentry/sentry-go/internal/util"
 	"github.com/getsentry/sentry-go/report"
 )
 
@@ -106,7 +107,7 @@ func (scope *Scope) SetClient(client *Client) {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
-	scope.clientOverride = normalizeClient(client)
+	scope.clientOverride = client
 }
 
 func (scope *Scope) clientOverrideSnapshot() *Client {
@@ -134,6 +135,9 @@ func (scope *Scope) Client() *Client {
 }
 
 func (scope *Scope) setLastEventID(id EventID) {
+	if scope == nil {
+		return
+	}
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
@@ -373,7 +377,11 @@ func (scope *Scope) Clear() {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
 
+	propagationContext := scope.propagationContext
+	span := scope.span
 	scope.scopeData = newScopeData()
+	scope.propagationContext = propagationContext
+	scope.span = span
 }
 
 // AddEventProcessor adds an event processor to the current scope.
@@ -384,105 +392,142 @@ func (scope *Scope) AddEventProcessor(processor EventProcessor) {
 	scope.eventProcessors = append(scope.eventProcessors, processor)
 }
 
-// ApplyToEvent takes the data from the current scope and attaches it to the event.
-func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) *Event { //nolint:gocyclo
+// captureState retains only data that must be used after Scope locks are
+// released. Maps and replacement fields are applied directly to the event.
+type captureState struct {
+	level       Level
+	request     *http.Request
+	requestBody interface {
+		Bytes() []byte
+		Overflow() bool
+	}
+	breadcrumbs []*Breadcrumb
+	attachments []*Attachment
+	processors  []EventProcessor
+}
+
+// resolveCaptureState applies the operation Scope first so it wins, then fills
+// gaps from GlobalScope. Each Scope is read under one short lock.
+func resolveCaptureState(event *Event, scope *Scope) captureState {
+	var state captureState
+	global := GlobalScope()
+	if scope != nil && scope != global {
+		state.mergeScope(event, scope, false)
+	}
+	state.mergeScope(event, global, true)
+	return state
+}
+
+func (state *captureState) mergeScope(event *Event, scope *Scope, prepend bool) {
 	scope.mu.RLock()
 	defer scope.mu.RUnlock()
 
-	if len(scope.breadcrumbs) > 0 {
-		event.Breadcrumbs = append(event.Breadcrumbs, scope.breadcrumbs...)
-	}
-
-	if len(scope.attachments) > 0 {
-		event.Attachments = append(event.Attachments, scope.attachments...)
-	}
-
-	if len(scope.tags) > 0 {
-		if event.Tags == nil {
-			event.Tags = make(map[string]string, len(scope.tags))
-		}
-
-		for key, value := range scope.tags {
-			event.Tags[key] = value
-		}
-	}
-
-	if len(scope.contexts) > 0 {
-		if event.Contexts == nil {
-			event.Contexts = make(map[string]Context)
-		}
-
-		for key, value := range scope.contexts {
-			if key == "trace" && event.Type == transactionType {
-				// Do not override trace context of
-				// transactions, otherwise it breaks the
-				// transaction event representation.
-				// For error events, the trace context is used
-				// to link errors and traces/spans in Sentry.
-				continue
-			}
-
-			// Ensure we are not overwriting event fields
-			if _, ok := event.Contexts[key]; !ok {
-				event.Contexts[key] = cloneContext(value)
-			}
-		}
-	}
-
-	if event.Contexts == nil {
-		event.Contexts = make(map[string]Context)
-	}
-
-	if scope.span != nil {
-		if _, ok := event.Contexts["trace"]; !ok {
-			event.Contexts["trace"] = scope.span.traceContext().Map()
-		}
-
-		transaction := scope.span.GetTransaction()
-		if transaction != nil {
-			event.sdkMetaData.dsc = DynamicSamplingContextFromTransaction(transaction)
-		}
-	} else {
-		event.Contexts["trace"] = scope.propagationContext.Map()
-
-		dsc := scope.propagationContext.DynamicSamplingContext
-		if !dsc.HasEntries() && client.IsEnabled() {
-			dsc = DynamicSamplingContextFromScope(scope, client)
-		}
-		event.sdkMetaData.dsc = dsc
-	}
-
-	// If an external trace resolver is registered (e.g. OTel), override
-	// trace/span IDs from the hint context or the scope's request context.
-	if client.IsEnabled() {
-		var ctx context.Context
-		if hint != nil {
-			ctx = hint.Context
-		}
-		if ctx == nil && scope.request != nil {
-			ctx = scope.request.Context()
-		}
-		if traceID, spanID, ok := client.externalTraceContextFromContext(ctx); event.Type != transactionType && ok {
-			traceCtx := event.Contexts["trace"]
-			traceCtx["trace_id"] = traceID.String()
-			traceCtx["span_id"] = spanID.String()
-		}
-	}
-
-	if event.User.IsEmpty() {
+	if event.User.IsEmpty() && !scope.user.IsEmpty() {
 		event.User = scope.user
 	}
-
-	if len(event.Fingerprint) == 0 {
+	event.Tags = util.FillMap(event.Tags, scope.tags)
+	for key, value := range scope.contexts {
+		if key == "trace" {
+			continue
+		}
+		if event.Contexts == nil {
+			event.Contexts = make(map[string]Context, len(scope.contexts))
+		}
+		if _, ok := event.Contexts[key]; !ok {
+			event.Contexts[key] = cloneContext(value)
+		}
+	}
+	if len(event.Fingerprint) == 0 && len(scope.fingerprint) > 0 {
 		event.Fingerprint = append(event.Fingerprint, scope.fingerprint...)
 	}
-
-	if scope.level != "" {
-		event.Level = scope.level
+	if state.level == "" {
+		state.level = scope.level
+	}
+	if state.request == nil && scope.request != nil {
+		state.request = scope.request
+		state.requestBody = scope.requestBody
 	}
 
-	if event.Request == nil && scope.request != nil {
-		event.Request = newRequest(scope.request, client)
+	if len(scope.breadcrumbs) > 0 {
+		if len(state.breadcrumbs) == 0 {
+			state.breadcrumbs = append([]*Breadcrumb(nil), scope.breadcrumbs...)
+		} else {
+			state.breadcrumbs = mergeTwoBreadcrumbLayers(scope.breadcrumbs, state.breadcrumbs)
+		}
+	}
+	if prepend {
+		state.attachments = prependSlice(scope.attachments, state.attachments)
+		state.processors = prependSlice(scope.eventProcessors, state.processors)
+	} else {
+		state.attachments = append(state.attachments, scope.attachments...)
+		state.processors = append(state.processors, scope.eventProcessors...)
+	}
+}
+
+func prependSlice[T any](prefix, values []T) []T {
+	if len(prefix) == 0 {
+		return values
+	}
+	result := make([]T, 0, len(prefix)+len(values))
+	result = append(result, prefix...)
+	return append(result, values...)
+}
+
+func setAttributeIfAbsent(attrs map[string]attribute.Value, key, value string) {
+	if value == "" {
+		return
+	}
+	if _, ok := attrs[key]; !ok {
+		attrs[key] = attribute.StringValue(value)
+	}
+}
+
+func copySignalAttributes(specific, instance, defaults map[string]attribute.Value) map[string]attribute.Value {
+	attrs := make(map[string]attribute.Value, len(specific)+len(instance)+len(defaults)+8)
+	attrs = util.FillMap(attrs, specific)
+	attrs = util.FillMap(attrs, instance)
+	return util.FillMap(attrs, defaults)
+}
+
+func buildMetricAttributes(specific []attribute.Builder, instance, defaults map[string]attribute.Value) map[string]attribute.Value {
+	attrs := make(map[string]attribute.Value, len(specific)+len(instance)+len(defaults)+8)
+	for _, attr := range specific {
+		attrs[attr.Key] = attr.Value
+	}
+	attrs = util.FillMap(attrs, instance)
+	return util.FillMap(attrs, defaults)
+}
+
+func mergeScopeAttributes(attrs map[string]attribute.Value, scope *Scope) map[string]attribute.Value {
+	global := GlobalScope()
+	var user User
+	if scope != nil && scope != global {
+		scope.mu.RLock()
+		attrs = util.FillMap(attrs, scope.attributes)
+		user = scope.user
+		scope.mu.RUnlock()
+	}
+
+	global.mu.RLock()
+	attrs = util.FillMap(attrs, global.attributes)
+	if user.IsEmpty() {
+		user = global.user
+	}
+	global.mu.RUnlock()
+
+	setAttributeIfAbsent(attrs, "user.id", user.ID)
+	setAttributeIfAbsent(attrs, "user.name", user.Name)
+	setAttributeIfAbsent(attrs, "user.email", user.Email)
+	return attrs
+}
+
+// applyToEvent handles capture work that must run after Scope locks are
+// released, including callbacks and request conversion.
+func (state captureState) applyToEvent(event *Event, hint *EventHint, opts captureOptions, client *Client) *Event {
+	event.Attachments = append(event.Attachments, state.attachments...)
+
+	if event.Request == nil && state.request != nil {
+		event.Request = newRequest(state.request, client)
 		// NOTE: The SDK does not attempt to send partial request body data.
 		//
 		// The reason being that Sentry's ingest pipeline and UI are optimized
@@ -493,34 +538,88 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		// Users can still send more data along their events if they want to,
 		// for example using Event.Contexts.
 		dc := client.GetDataCollection()
-		if scope.requestBody != nil && !scope.requestBody.Overflow() && dc.CollectHTTPBody(BodyIncomingRequest) {
-			event.Request.Data = dc.FilterHTTPBody(scope.requestBody.Bytes(), scope.request.Header.Get("Content-Type"))
+		body := state.requestBody
+		if body != nil && !body.Overflow() && dc.CollectHTTPBody(BodyIncomingRequest) {
+			event.Request.Data = dc.FilterHTTPBody(body.Bytes(), state.request.Header.Get("Content-Type"))
 		}
 	}
 
-	for _, processor := range scope.eventProcessors {
+	event.Breadcrumbs = mergeBreadcrumbs(client.options.MaxBreadcrumbs, event.Breadcrumbs, [][]*Breadcrumb{state.breadcrumbs})
+	event.Level = resolveLevel(event, opts, state.level)
+
+	for _, processor := range state.processors {
 		id := event.EventID
 		category := event.toCategory()
 		spanCountBefore := event.GetSpanCount()
 		event = processor(event, hint)
 		if event == nil {
 			debuglog.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
-			if client.IsEnabled() {
-				client.reportRecorder.RecordOne(report.ReasonEventProcessor, category)
-				if category == ratelimit.CategoryTransaction {
-					client.reportRecorder.Record(report.ReasonEventProcessor, ratelimit.CategorySpan, int64(spanCountBefore))
-				}
+			client.recordDiscard(report.ReasonEventProcessor, category, 1)
+			if category == ratelimit.CategoryTransaction {
+				client.recordDiscard(report.ReasonEventProcessor, ratelimit.CategorySpan, int64(spanCountBefore))
 			}
 			return nil
 		}
 		if droppedSpans := spanCountBefore - event.GetSpanCount(); droppedSpans > 0 {
-			if client.IsEnabled() {
-				client.reportRecorder.Record(report.ReasonEventProcessor, ratelimit.CategorySpan, int64(droppedSpans))
-			}
+			client.recordDiscard(report.ReasonEventProcessor, ratelimit.CategorySpan, int64(droppedSpans))
 		}
 	}
 
 	return event
+}
+
+func resolveLevel(event *Event, opts captureOptions, scopeLevel Level) Level {
+	switch {
+	case event.Level != "":
+		return event.Level
+	case opts.level != "":
+		return opts.level
+	case scopeLevel != "" && event.Type != transactionType:
+		return scopeLevel
+	default:
+		return LevelInfo
+	}
+}
+
+func mergeBreadcrumbs(limit int, own []*Breadcrumb, layers [][]*Breadcrumb) []*Breadcrumb {
+	if limit < 0 {
+		return nil
+	}
+	if limit == 0 {
+		limit = defaultMaxBreadcrumbs
+	}
+
+	merged := own
+	for _, layer := range layers {
+		merged = mergeTwoBreadcrumbLayers(merged, layer)
+	}
+	if len(merged) > limit {
+		merged = merged[len(merged)-limit:]
+	}
+	return merged
+}
+
+func mergeTwoBreadcrumbLayers(a, b []*Breadcrumb) []*Breadcrumb {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make([]*Breadcrumb, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if b[j].Timestamp.Before(a[i].Timestamp) {
+			out = append(out, b[j])
+			j++
+		} else {
+			out = append(out, a[i])
+			i++
+		}
+	}
+	out = append(out, a[i:]...)
+	out = append(out, b[j:]...)
+	return out
 }
 
 // cloneContext returns a new context with keys and values copied from the passed one.
@@ -536,30 +635,10 @@ func cloneContext(c Context) Context {
 	return res
 }
 
-func (scope *Scope) populateAttrs(attrs map[string]attribute.Value) {
-	if scope == nil {
-		return
-	}
-
-	scope.mu.RLock()
-	defer scope.mu.RUnlock()
-
-	// Add user-related attributes
-	if !scope.user.IsEmpty() {
-		if scope.user.ID != "" {
-			attrs["user.id"] = attribute.StringValue(scope.user.ID)
-		}
-		if scope.user.Name != "" {
-			attrs["user.name"] = attribute.StringValue(scope.user.Name)
-		}
-		if scope.user.Email != "" {
-			attrs["user.email"] = attribute.StringValue(scope.user.Email)
-		}
-	}
-
-	for k, v := range scope.attributes {
-		attrs[k] = v
-	}
+type signalCaptureContext struct {
+	scope    *Scope
+	ctx      context.Context
+	fallback context.Context
 }
 
 // hubFromContexts is a helper to return the first hub found in the given contexts.
@@ -575,49 +654,105 @@ func hubFromContexts(ctxs ...context.Context) *Hub {
 	return nil
 }
 
-// resolveTrace resolves trace ID and span ID from the given scope and contexts.
+// resolveTrace resolves trace IDs and dynamic sampling context from the given
+// contexts and scope. It is the single trace-policy function used by every
+// signal. The precedence is external resolver, span in a supplied context,
+// scope span, then scope propagation context.
 //
-// The resolution order follows a most-specific-to-least-specific pattern:
-//  1. If an external trace resolver was registered (eg. OTel), we prioritise trace context
-//     information from that
-//  2. Check for span directly in contexts (SpanFromContext) - this is the most specific
-//     source as it represents a span explicitly attached to the current operation's context
-//  3. Check scope's span - provides access to span set on the hub's scope
-//  4. Fall back to scope's propagation context trace ID
-//
-// This ordering ensures we always use the most contextually relevant tracing information.
-// For example, if a specific span is active for an operation, we use that span's trace/span IDs
-// rather than accidentally using a different span that might be set on the hub's scope.
-func resolveTrace(scope *Scope, client *Client, ctxs ...context.Context) (traceID TraceID, spanID SpanID) {
-	var span *Span
+// TODO: this should be removed when the span API is introduced. Currently kept for compatibility. The span
+// and trace should only be resolved through context.
+func resolveTrace(scope *Scope, client *Client, ctxs ...context.Context) traceResolution {
+	client = normalizeClient(client)
+	var (
+		resolved traceResolution
+		span     *Span
+		external bool
+	)
 
 	for _, ctx := range ctxs {
 		if ctx == nil {
 			continue
 		}
-		if client.IsEnabled() {
-			if traceID, spanID, ok := client.externalTraceContextFromContext(ctx); ok {
-				return traceID, spanID
-			}
+		if traceID, spanID, ok := client.externalTraceContextFromContext(ctx); ok {
+			resolved.traceID, resolved.spanID, resolved.telemetrySpanID = traceID, spanID, spanID
+			resolved.valid, resolved.external, external = true, true, true
+			break
 		}
 		if span = SpanFromContext(ctx); span != nil {
 			break
 		}
 	}
 
-	if scope != nil {
-		scope.mu.RLock()
-		if span == nil {
-			span = scope.span
-		}
-		if span != nil {
-			traceID = span.TraceID
-			spanID = span.SpanID
-		} else {
-			traceID = scope.propagationContext.TraceID
-		}
-		scope.mu.RUnlock()
+	if scope == nil {
+		return resolved
 	}
 
-	return traceID, spanID
+	scope.mu.RLock()
+	scopeSpan := scope.span
+	propagation := scope.propagationContext
+	request := scope.request
+	scope.mu.RUnlock()
+
+	// The request context is a fallback caller context.
+	if !external && span == nil && request != nil {
+		if traceID, spanID, ok := client.externalTraceContextFromContext(request.Context()); ok {
+			resolved.traceID, resolved.spanID, resolved.telemetrySpanID = traceID, spanID, spanID
+			resolved.valid, resolved.external, external = true, true, true
+		}
+	}
+	if span == nil && !external {
+		span = scopeSpan
+	}
+
+	if !external {
+		if span != nil {
+			resolved.traceID, resolved.spanID, resolved.telemetrySpanID = span.TraceID, span.SpanID, span.SpanID
+			resolved.valid = true
+		} else {
+			resolved.traceID, resolved.spanID = propagation.TraceID, propagation.SpanID
+			resolved.valid = propagation.TraceID != (TraceID{})
+		}
+	}
+
+	if span != nil {
+		if transaction := span.GetTransaction(); transaction != nil {
+			resolved.dsc = DynamicSamplingContextFromTransaction(transaction)
+			return resolved
+		}
+	}
+	resolved.dsc = propagation.DynamicSamplingContext
+	if !resolved.dsc.HasEntries() {
+		// DynamicSamplingContextFromScope only reads propagationContext. Re-read
+		// under its documented locking contract rather than duplicating its
+		// client-option/DSN logic here.
+		resolved.dsc = dynamicSamplingContextFromScope(scope, client)
+	}
+
+	return resolved
+}
+
+type traceResolution struct {
+	traceID         TraceID
+	spanID          SpanID // event projection, including propagation SpanID
+	telemetrySpanID SpanID // only an active/external span belongs on logs/metrics
+	dsc             DynamicSamplingContext
+	valid           bool
+	external        bool
+}
+
+func applyTraceToEvent(event *Event, trace traceResolution) {
+	if event.Type == transactionType || !trace.valid {
+		return
+	}
+	if event.Contexts == nil {
+		event.Contexts = make(map[string]Context)
+	}
+	if _, ok := event.Contexts["trace"]; !ok {
+		traceID, spanID := any(trace.traceID), any(trace.spanID)
+		if trace.external {
+			traceID, spanID = trace.traceID.String(), trace.spanID.String()
+		}
+		event.Contexts["trace"] = Context{"trace_id": traceID, "span_id": spanID}
+	}
+	event.sdkMetaData.dsc = trace.dsc
 }

--- a/scope.go
+++ b/scope.go
@@ -523,7 +523,7 @@ func mergeScopeAttributes(attrs map[string]attribute.Value, scope *Scope) map[st
 
 // applyToEvent handles capture work that must run after Scope locks are
 // released, including callbacks and request conversion.
-func (state captureState) applyToEvent(event *Event, hint *EventHint, opts captureOptions, client *Client) *Event {
+func (state captureState) applyToEvent(event *Event, hint *EventHint, client *Client, opts captureOptions) *Event {
 	event.Attachments = append(event.Attachments, state.attachments...)
 
 	if event.Request == nil && state.request != nil {
@@ -545,7 +545,7 @@ func (state captureState) applyToEvent(event *Event, hint *EventHint, opts captu
 	}
 
 	event.Breadcrumbs = mergeBreadcrumbs(client.options.MaxBreadcrumbs, event.Breadcrumbs, [][]*Breadcrumb{state.breadcrumbs})
-	event.Level = resolveLevel(event, opts, state.level)
+	event.Level = resolveLevel(event, state.level, opts)
 
 	for _, processor := range state.processors {
 		id := event.EventID
@@ -568,7 +568,7 @@ func (state captureState) applyToEvent(event *Event, hint *EventHint, opts captu
 	return event
 }
 
-func resolveLevel(event *Event, opts captureOptions, scopeLevel Level) Level {
+func resolveLevel(event *Event, scopeLevel Level, opts captureOptions) Level {
 	switch {
 	case event.Level != "":
 		return event.Level

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -110,3 +110,38 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.ClearBreadcrumbs()
 	scope.Clone()
 }
+
+func TestConcurrentCaptureAndMutate(_ *testing.T) {
+	global := sentry.GlobalScope()
+	leaf := sentry.NewScope()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func(x int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				event := sentry.NewEvent()
+				event.Message = fmt.Sprintf("capture-%d-%d", x, j)
+				sentry.NewNoopClient().CaptureEvent(event, nil, leaf)
+			}
+		}(i)
+		go func(x int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				leaf.SetTag(fmt.Sprintf("tag-%d", x), fmt.Sprint(j))
+				leaf.AddBreadcrumb(&sentry.Breadcrumb{Message: fmt.Sprint(j)}, 100)
+				leaf.SetContext(fmt.Sprintf("ctx-%d", x), sentry.Context{"v": j})
+				leaf.SetAttributes(attribute.Int("v", j))
+				global.SetTag(fmt.Sprintf("gtag-%d", x), fmt.Sprint(j))
+				global.AddBreadcrumb(&sentry.Breadcrumb{Message: fmt.Sprint(j)}, 100)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	global.RemoveTag("gtag-0") // best-effort cleanup of keys set above
+	for i := 0; i < 8; i++ {
+		global.RemoveTag(fmt.Sprintf("gtag-%d", i))
+	}
+}

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -105,7 +105,7 @@ func touchScope(scope *sentry.Scope, x int) {
 	scope.SetPropagationContext(sentry.NewPropagationContext())
 	scope.SetSpan(&sentry.Span{TraceID: sentry.TraceIDFromHex("d49d9bf66f13450b81f65bc51cf49c03")})
 
-	sentry.CaptureException(fmt.Errorf("error %d", x))
+	sentry.CaptureException(context.Background(), fmt.Errorf("error %d", x))
 
 	scope.ClearBreadcrumbs()
 	scope.Clone()
@@ -123,7 +123,7 @@ func TestConcurrentCaptureAndMutate(_ *testing.T) {
 			for j := 0; j < 50; j++ {
 				event := sentry.NewEvent()
 				event.Message = fmt.Sprintf("capture-%d-%d", x, j)
-				sentry.NewNoopClient().CaptureEvent(event, nil, leaf)
+				sentry.NewNoopClient().CaptureEvent(context.Background(), event)
 			}
 		}(i)
 		go func(x int) {

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -1,6 +1,7 @@
 package sentry_test
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"sync"
@@ -45,6 +46,48 @@ func TestConcurrentScopeUsage(_ *testing.T) {
 	}
 
 	// wait for goroutines to finish
+	wg.Wait()
+}
+
+func TestConcurrentSharedIsolation(_ *testing.T) {
+	ctx, scope := sentry.WithIsolationScope(context.Background())
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			scope.SetTag(fmt.Sprintf("tag-%d", x), "value")
+			scope.SetUser(sentry.User{ID: fmt.Sprint(x)})
+			scope.SetContext(fmt.Sprintf("context-%d", x), sentry.Context{"value": x})
+			scope.SetAttributes(attribute.Int("value", x))
+			scope.AddBreadcrumb(&sentry.Breadcrumb{Message: fmt.Sprint(x)}, 100)
+			shared := sentry.ScopeFromContext(ctx)
+			shared.Clone()
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestConcurrentSharedIsolationClearAndClone(_ *testing.T) {
+	_, scope := sentry.WithIsolationScope(context.Background())
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				scope.SetTag(fmt.Sprintf("tag-%d", x), fmt.Sprint(j))
+				scope.Clone()
+				if j%5 == 0 {
+					scope.Clear()
+				}
+			}
+		}(i)
+	}
+
 	wg.Wait()
 }
 

--- a/scope_context.go
+++ b/scope_context.go
@@ -1,0 +1,63 @@
+package sentry
+
+import "context"
+
+type scopeContextKey struct{}
+
+// globalScope is the process-wide global scope.
+var globalScope = newScopeWithClient(NewNoopClient())
+
+// GlobalScope returns the process-wide global scope.
+func GlobalScope() *Scope {
+	return globalScope
+}
+
+// ScopeFromContext returns the scope carried by ctx, or nil when ctx
+// does not carry one.
+func ScopeFromContext(ctx context.Context) *Scope {
+	if ctx == nil {
+		return nil
+	}
+	scope, _ := ctx.Value(scopeContextKey{}).(*Scope)
+	return scope
+}
+
+func contextWithScope(ctx context.Context, scope *Scope) context.Context {
+	return context.WithValue(ctx, scopeContextKey{}, scope)
+}
+
+// WithIsolationScope returns a derived context and an independent scope.
+// It clones a carried scope or creates an empty scope when ctx does not carry
+// one. Trace state carried by ctx is preserved.
+func WithIsolationScope(ctx context.Context) (context.Context, *Scope) {
+	parent := ScopeFromContext(ctx)
+	var scope *Scope
+	if parent == nil {
+		scope = NewScope()
+	} else {
+		scope = parent.Clone()
+	}
+	return contextWithScope(ctx, scope), scope
+}
+
+// WithScopeContext invokes fn with a derived context carrying a cloned scope.
+func WithScopeContext(ctx context.Context, fn func(context.Context, *Scope)) { // TODO: should remove WithScope when hub is removed.
+	if fn == nil {
+		return
+	}
+
+	parent := ScopeFromContext(ctx)
+	if parent == nil {
+		parent = NewScope()
+	}
+	scope := parent.Clone()
+	fn(contextWithScope(ctx, scope), scope)
+}
+
+// GetClient returns the first enabled client for ctx.
+func GetClient(ctx context.Context) *Client {
+	if scope := ScopeFromContext(ctx); scope != nil {
+		return scope.Client()
+	}
+	return GlobalScope().Client()
+}

--- a/scope_context_test.go
+++ b/scope_context_test.go
@@ -1,0 +1,191 @@
+package sentry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestScopeFromContext(t *testing.T) {
+	if scope := ScopeFromContext(context.Background()); scope != nil {
+		t.Fatalf("ScopeFromContext returned %p for an unscoped context", scope)
+	}
+
+	ctx, scope := WithIsolationScope(context.Background())
+	if got := ScopeFromContext(ctx); got != scope {
+		t.Fatalf("ScopeFromContext returned %p, want %p", got, scope)
+	}
+}
+
+func TestIsolationScopeSharesDownstreamMutations(t *testing.T) {
+	type contextKey struct{}
+
+	ctx, scope := WithIsolationScope(context.Background())
+	child := context.WithValue(ctx, contextKey{}, "value")
+	childScope := ScopeFromContext(child)
+	childScope.SetUser(User{ID: "123"})
+
+	if scope.user.ID != "123" {
+		t.Fatal("downstream mutation was not visible to the boundary owner")
+	}
+}
+
+func TestWithIsolationScopeCreatesIndependentBoundaries(t *testing.T) {
+	parentCtx, parent := WithIsolationScope(context.Background())
+	parent.SetTag("inherited", "yes")
+	parent.SetPropagationContext(PropagationContext{
+		TraceID: TraceIDFromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		SpanID:  SpanIDFromHex("bbbbbbbbbbbbbbbb"),
+		DynamicSamplingContext: DynamicSamplingContext{
+			Entries: map[string]string{"release": "parent"},
+			Frozen:  true,
+		},
+	})
+	parentPropagation := parent.propagationContextSnapshot()
+
+	firstCtx, first := WithIsolationScope(parentCtx)
+	secondCtx, second := WithIsolationScope(parentCtx)
+	first.SetTag("worker", "first")
+	second.SetTag("worker", "second")
+
+	if ScopeFromContext(firstCtx) != first || ScopeFromContext(secondCtx) != second {
+		t.Fatal("derived contexts do not carry their returned isolation scopes")
+	}
+	if first == parent || second == parent || first == second {
+		t.Fatal("isolation boundaries alias")
+	}
+	if first.tags["inherited"] != "yes" || second.tags["inherited"] != "yes" {
+		t.Fatal("isolation boundaries did not inherit parent enrichment")
+	}
+	if _, ok := parent.tags["worker"]; ok {
+		t.Fatal("child mutation leaked into parent")
+	}
+	if first.tags["worker"] != "first" || second.tags["worker"] != "second" {
+		t.Fatal("sibling isolation mutations leaked")
+	}
+	if first.propagationContext.TraceID != parentPropagation.TraceID ||
+		second.propagationContext.TraceID != parentPropagation.TraceID {
+		t.Fatal("scope isolation changed the propagation trace ID")
+	}
+	firstPropagation := first.propagationContextSnapshot()
+	firstPropagation.DynamicSamplingContext.Entries["release"] = "first"
+	first.SetPropagationContext(firstPropagation)
+	if got := parent.propagationContextSnapshot().DynamicSamplingContext.Entries["release"]; got != "parent" {
+		t.Fatalf("child propagation mutation leaked into parent: %q", got)
+	}
+	if got := second.propagationContextSnapshot().DynamicSamplingContext.Entries["release"]; got != "parent" {
+		t.Fatalf("child propagation mutation leaked into sibling: %q", got)
+	}
+}
+
+func TestWithIsolationScopeDoesNotCloneGlobalScope(t *testing.T) {
+	global := GlobalScope()
+	global.SetTag("global-only", "yes")
+	t.Cleanup(func() { global.RemoveTag("global-only") })
+
+	ctx, scope := WithIsolationScope(context.Background())
+	if ScopeFromContext(ctx) != scope {
+		t.Fatal("derived context does not carry the returned scope")
+	}
+	if scope == global {
+		t.Fatal("isolation scope aliases global scope")
+	}
+	if _, ok := scope.tags["global-only"]; ok {
+		t.Fatal("isolation scope cloned global data")
+	}
+}
+
+func TestWithScopeContextCreatesTemporaryFork(t *testing.T) {
+	ctx, parent := WithIsolationScope(context.Background())
+	parent.SetTag("parent", "yes")
+	propagation := parent.propagationContextSnapshot()
+
+	WithScopeContext(ctx, func(childCtx context.Context, child *Scope) {
+		if ScopeFromContext(childCtx) != child {
+			t.Fatal("callback context does not carry callback scope")
+		}
+		if child == parent || child.tags["parent"] != "yes" {
+			t.Fatal("callback scope did not inherit an independent enrichment copy")
+		}
+		if child.propagationContext.TraceID != propagation.TraceID {
+			t.Fatal("temporary scope fork did not continue propagation")
+		}
+		child.SetTag("temporary", "yes")
+	})
+
+	if _, ok := parent.tags["temporary"]; ok {
+		t.Fatal("temporary mutation leaked into parent")
+	}
+}
+
+func TestScopeClientResolution(t *testing.T) {
+	globalClient, err := NewClient(ClientOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	operationClient, err := NewClient(ClientOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherGlobalClient, err := NewClient(ClientOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	global := GlobalScope()
+	previousGlobal := global.clientOverrideSnapshot()
+	global.SetClient(globalClient)
+	t.Cleanup(func() { global.SetClient(previousGlobal) })
+
+	standalone := NewScope()
+	if standalone.clientOverrideSnapshot() != nil {
+		t.Fatal("NewScope has an unexpected client override")
+	}
+	if standalone.Client() != globalClient {
+		t.Fatal("standalone scope did not resolve the global client")
+	}
+
+	ctx, scope := WithIsolationScope(context.Background())
+	if GetClient(ctx) != globalClient || scope.Client() != globalClient || scope.clientOverrideSnapshot() != nil {
+		t.Fatal("new operation scope did not inherit the global client dynamically")
+	}
+
+	global.SetClient(otherGlobalClient)
+	if GetClient(ctx) != otherGlobalClient || scope.Client() != otherGlobalClient {
+		t.Fatal("existing operation scope did not observe the updated global client")
+	}
+
+	scope.SetClient(NewNoopClient())
+	if GetClient(ctx) != otherGlobalClient || scope.Client() != otherGlobalClient {
+		t.Fatal("disabled operation client did not fall back to the enabled global client")
+	}
+
+	scope.SetClient(operationClient)
+	if GetClient(ctx) != operationClient || scope.Client() != operationClient {
+		t.Fatal("enabled operation client did not override the global client")
+	}
+
+	childCtx, child := WithIsolationScope(ctx)
+	if GetClient(childCtx) != operationClient {
+		t.Fatal("child isolation did not inherit the explicit client override")
+	}
+	child.SetClient(nil)
+	if GetClient(childCtx) != otherGlobalClient || GetClient(ctx) != operationClient {
+		t.Fatal("clearing the child override did not fall back to global independently")
+	}
+}
+
+func TestScopeLastEventIDSurvivesCloneAndClear(t *testing.T) {
+	scope := NewScope()
+	id := EventID("0123456789abcdef0123456789abcdef")
+	scope.setLastEventID(id)
+
+	clone := scope.Clone()
+	scope.Clear()
+
+	if got := scope.LastEventID(); got != id {
+		t.Fatalf("LastEventID after Clear = %q, want %q", got, id)
+	}
+	if got := clone.LastEventID(); got != id {
+		t.Fatalf("clone LastEventID = %q, want %q", got, id)
+	}
+}

--- a/scope_context_test.go
+++ b/scope_context_test.go
@@ -174,6 +174,39 @@ func TestScopeClientResolution(t *testing.T) {
 	}
 }
 
+func TestWithScopeContextLastEventIDIsLocal(t *testing.T) {
+	ctx, operation := WithIsolation(context.Background())
+	id := EventID("0123456789abcdef0123456789abcdef")
+
+	WithScopeContext(ctx, func(_ context.Context, fork *Scope) {
+		fork.setLastEventID(id)
+		if got := fork.LastEventID(); got != id {
+			t.Fatalf("fork LastEventID = %q, want %q", got, id)
+		}
+	})
+
+	if got := operation.LastEventID(); got != "" {
+		t.Fatalf("temporary fork update leaked to operation scope: %q", got)
+	}
+}
+
+func TestLastEventIDIsIndependentPerScope(t *testing.T) {
+	ctx, operation := WithIsolation(context.Background())
+	id := EventID("0123456789abcdef0123456789abcdef")
+
+	clone := operation.Clone()
+	clone.setLastEventID(id)
+	if got := operation.LastEventID(); got != "" {
+		t.Fatalf("clone update leaked to operation scope: %q", got)
+	}
+
+	_, child := WithIsolation(ctx)
+	child.setLastEventID(id)
+	if got := operation.LastEventID(); got != "" {
+		t.Fatalf("isolation update leaked to operation scope: %q", got)
+	}
+}
+
 func TestScopeLastEventIDSurvivesCloneAndClear(t *testing.T) {
 	scope := NewScope()
 	id := EventID("0123456789abcdef0123456789abcdef")

--- a/scope_context_test.go
+++ b/scope_context_test.go
@@ -175,7 +175,7 @@ func TestScopeClientResolution(t *testing.T) {
 }
 
 func TestWithScopeContextLastEventIDIsLocal(t *testing.T) {
-	ctx, operation := WithIsolation(context.Background())
+	ctx, operation := WithIsolationScope(context.Background())
 	id := EventID("0123456789abcdef0123456789abcdef")
 
 	WithScopeContext(ctx, func(_ context.Context, fork *Scope) {
@@ -191,7 +191,7 @@ func TestWithScopeContextLastEventIDIsLocal(t *testing.T) {
 }
 
 func TestLastEventIDIsIndependentPerScope(t *testing.T) {
-	ctx, operation := WithIsolation(context.Background())
+	ctx, operation := WithIsolationScope(context.Background())
 	id := EventID("0123456789abcdef0123456789abcdef")
 
 	clone := operation.Clone()
@@ -200,7 +200,7 @@ func TestLastEventIDIsIndependentPerScope(t *testing.T) {
 		t.Fatalf("clone update leaked to operation scope: %q", got)
 	}
 
-	_, child := WithIsolation(ctx)
+	_, child := WithIsolationScope(ctx)
 	child.setLastEventID(id)
 	if got := operation.LastEventID(); got != "" {
 		t.Fatalf("isolation update leaked to operation scope: %q", got)

--- a/scope_test.go
+++ b/scope_test.go
@@ -539,6 +539,8 @@ func TestScopeChildOverrideInheritance(t *testing.T) {
 
 func TestClear(t *testing.T) {
 	scope := fillScopeWithData(NewScope())
+	processor := func(event *Event, _ *EventHint) *Event { return event }
+	scope.AddEventProcessor(processor)
 	scope.Clear()
 
 	assertEqual(t, []*Breadcrumb{}, scope.breadcrumbs)
@@ -551,6 +553,7 @@ func TestClear(t *testing.T) {
 	assertEqual(t, Level(""), scope.level)
 	assertEqual(t, (*http.Request)(nil), scope.request)
 	assertEqual(t, (*Span)(nil), scope.GetSpan())
+	assertEqual(t, 1, len(scope.eventProcessors))
 }
 
 func TestClearAndReconfigure(t *testing.T) {

--- a/scope_test.go
+++ b/scope_test.go
@@ -166,7 +166,7 @@ func TestScopeRemoveAttributeNotInPopulateAttrs(t *testing.T) {
 	)
 	scope.RemoveAttribute("key.two")
 
-	attrs := mergeScopeAttributes(nil, scope)
+	attrs := mergeScopeAttributes(nil, nil, scope)
 
 	if _, ok := attrs["key.two"]; ok {
 		t.Error("removed attribute should not appear in populateAttrs output")
@@ -234,6 +234,33 @@ func TestApplyScopeChainProcessorOrder(t *testing.T) {
 
 	applyScopeChain(NewEvent(), NewNoopClient(), scope, captureOptions{})
 	assertEqual(t, []string{"global", "operation"}, order)
+}
+
+func TestApplyScopeChainPreservesBreadcrumbLayerOrder(t *testing.T) {
+	global := GlobalScope()
+	global.mu.Lock()
+	saved := global.breadcrumbs
+	global.breadcrumbs = nil
+	global.mu.Unlock()
+	defer func() {
+		global.mu.Lock()
+		global.breadcrumbs = saved
+		global.mu.Unlock()
+	}()
+
+	global.AddBreadcrumb(&Breadcrumb{Timestamp: testNow.Add(time.Hour), Message: "global"}, defaultMaxBreadcrumbs)
+	scope := NewScope()
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: testNow.Add(-time.Hour), Message: "operation"}, defaultMaxBreadcrumbs)
+	event := NewEvent()
+	event.Breadcrumbs = []*Breadcrumb{{Timestamp: testNow, Message: "event"}}
+
+	processed := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
+
+	messages := make([]string, len(processed.Breadcrumbs))
+	for i, breadcrumb := range processed.Breadcrumbs {
+		messages[i] = breadcrumb.Message
+	}
+	assertEqual(t, []string{"event", "global", "operation"}, messages)
 }
 
 func TestScopeRemoveTag(t *testing.T) {
@@ -706,6 +733,20 @@ func TestApplyToEventUsingEmptyScope(t *testing.T) {
 	assertEqual(t, processedEvent.Fingerprint, event.Fingerprint, "should use event fingerprint")
 	assertEqual(t, processedEvent.Level, event.Level, "should use event level")
 	assertEqual(t, processedEvent.Request, event.Request, "should use event request")
+}
+
+func TestApplyToEventUsesManuallyConfiguredTraceContext(t *testing.T) {
+	manualTrace := Context{
+		"trace_id": "d49d9bf66f13450b81f65bc51cf49c03",
+		"span_id":  "2fa730c8b757c9a3",
+		"op":       "manual",
+	}
+	scope := NewScope()
+	scope.SetContext("trace", manualTrace)
+
+	processed := applyScopeChain(NewEvent(), NewNoopClient(), scope, captureOptions{})
+
+	assertEqual(t, manualTrace, processed.Contexts["trace"])
 }
 
 func TestApplyToEventUsingEmptyEvent(t *testing.T) {

--- a/scope_test.go
+++ b/scope_test.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -165,13 +166,74 @@ func TestScopeRemoveAttributeNotInPopulateAttrs(t *testing.T) {
 	)
 	scope.RemoveAttribute("key.two")
 
-	attrs := make(map[string]attribute.Value)
-	scope.populateAttrs(attrs)
+	attrs := mergeScopeAttributes(nil, scope)
 
 	if _, ok := attrs["key.two"]; ok {
 		t.Error("removed attribute should not appear in populateAttrs output")
 	}
 	assertEqual(t, attribute.StringValue("val1"), attrs["key.one"])
+}
+
+func TestResolveCaptureStatePrecedence(t *testing.T) {
+	global := GlobalScope()
+	global.mu.Lock()
+	savedTags := global.tags
+	savedUser := global.user
+	global.tags = maps.Clone(savedTags)
+	global.mu.Unlock()
+	defer func() {
+		global.mu.Lock()
+		global.tags = savedTags
+		global.user = savedUser
+		global.mu.Unlock()
+	}()
+
+	global.SetTag("key", "global")
+	global.SetTag("global-only", "g")
+	global.SetUser(User{ID: "global-user"})
+
+	scope := NewScope()
+	scope.SetTag("key", "operation")
+	scope.SetTag("op-only", "o")
+
+	event := NewEvent()
+	resolveCaptureState(event, scope)
+	assertEqual(t, "operation", event.Tags["key"])
+	assertEqual(t, "g", event.Tags["global-only"])
+	assertEqual(t, "o", event.Tags["op-only"])
+	assertEqual(t, "global-user", event.User.ID)
+
+	scope.SetTag("key", "changed")
+	global.SetTag("global-only", "changed")
+	assertEqual(t, "operation", event.Tags["key"])
+	assertEqual(t, "g", event.Tags["global-only"])
+}
+
+func TestApplyScopeChainProcessorOrder(t *testing.T) {
+	global := GlobalScope()
+	global.mu.Lock()
+	saved := global.eventProcessors
+	global.eventProcessors = saved[:len(saved):len(saved)]
+	global.mu.Unlock()
+	defer func() {
+		global.mu.Lock()
+		global.eventProcessors = saved
+		global.mu.Unlock()
+	}()
+
+	var order []string
+	global.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
+		order = append(order, "global")
+		return event
+	})
+	scope := NewScope()
+	scope.AddEventProcessor(func(event *Event, _ *EventHint) *Event {
+		order = append(order, "operation")
+		return event
+	})
+
+	applyScopeChain(NewEvent(), NewNoopClient(), scope, captureOptions{})
+	assertEqual(t, []string{"global", "operation"}, order)
 }
 
 func TestScopeRemoveTag(t *testing.T) {
@@ -451,15 +513,15 @@ func TestScopeCloneEventProcessorsIsolation(t *testing.T) {
 	clone2.AddEventProcessor(mark("y"))
 
 	ran = nil
-	clone1.ApplyToEvent(NewEvent(), nil, nil)
+	applyScopeChain(NewEvent(), NewNoopClient(), clone1, captureOptions{})
 	assertEqual(t, []string{"a", "b", "c", "x"}, ran)
 
 	ran = nil
-	clone2.ApplyToEvent(NewEvent(), nil, nil)
+	applyScopeChain(NewEvent(), NewNoopClient(), clone2, captureOptions{})
 	assertEqual(t, []string{"a", "b", "c", "y"}, ran)
 
 	ran = nil
-	scope.ApplyToEvent(NewEvent(), nil, nil)
+	applyScopeChain(NewEvent(), NewNoopClient(), scope, captureOptions{})
 	assertEqual(t, []string{"a", "b", "c"}, ran)
 }
 
@@ -541,6 +603,12 @@ func TestClear(t *testing.T) {
 	scope := fillScopeWithData(NewScope())
 	processor := func(event *Event, _ *EventHint) *Event { return event }
 	scope.AddEventProcessor(processor)
+	client := NewNoopClient()
+	scope.SetClient(client)
+	span := &Span{TraceID: TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")}
+	scope.SetSpan(span)
+	propagation := scope.propagationContextSnapshot()
+	scope.setLastEventID(EventID("0123456789abcdef0123456789abcdef"))
 	scope.Clear()
 
 	assertEqual(t, []*Breadcrumb{}, scope.breadcrumbs)
@@ -552,8 +620,11 @@ func TestClear(t *testing.T) {
 	assertEqual(t, []string{}, scope.fingerprint)
 	assertEqual(t, Level(""), scope.level)
 	assertEqual(t, (*http.Request)(nil), scope.request)
-	assertEqual(t, (*Span)(nil), scope.GetSpan())
 	assertEqual(t, 1, len(scope.eventProcessors))
+	assertEqual(t, client, scope.clientOverrideSnapshot())
+	assertEqual(t, EventID("0123456789abcdef0123456789abcdef"), scope.LastEventID())
+	assertEqual(t, propagation, scope.propagationContextSnapshot())
+	assertEqual(t, span, scope.GetSpan())
 }
 
 func TestClearAndReconfigure(t *testing.T) {
@@ -606,14 +677,14 @@ func TestApplyToEventWithCorrectScopeAndEvent(t *testing.T) {
 	scope := fillScopeWithData(NewScope())
 	event := fillEventWithData(NewEvent())
 
-	processedEvent := scope.ApplyToEvent(event, nil, nil)
+	processedEvent := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 
 	assertEqual(t, 2, len(processedEvent.Breadcrumbs), "should merge breadcrumbs")
 	assertEqual(t, 2, len(processedEvent.Attachments), "should merge attachments")
 	assertEqual(t, 2, len(processedEvent.Tags), "should merge tags")
 	assertEqual(t, 4, len(processedEvent.Contexts), "should merge contexts")
 	assertEqual(t, event.Contexts[sharedContextsKey], processedEvent.Contexts[sharedContextsKey], "should not override event trace context")
-	assertEqual(t, LevelDebug, processedEvent.Level, "should use event level if set")
+	assertEqual(t, LevelInfo, processedEvent.Level, "should use event level if set")
 	assertEqual(t, event.User, processedEvent.User, "should use event user if one exists")
 	assertEqual(t, event.Request, processedEvent.Request, "should use event request if one exists")
 	assertEqual(t, event.Fingerprint, processedEvent.Fingerprint, "should use event fingerprints if they exist")
@@ -626,7 +697,7 @@ func TestApplyToEventUsingEmptyScope(t *testing.T) {
 	scope := NewScope()
 	event := fillEventWithData(NewEvent())
 
-	processedEvent := scope.ApplyToEvent(event, nil, nil)
+	processedEvent := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 	assertEqual(t, len(processedEvent.Breadcrumbs), 1, "should use event breadcrumbs")
 	assertEqual(t, len(processedEvent.Attachments), 1, "should use event attachments")
 	assertEqual(t, len(processedEvent.Tags), 1, "should use event tags")
@@ -641,7 +712,7 @@ func TestApplyToEventUsingEmptyEvent(t *testing.T) {
 	scope := fillScopeWithData(NewScope())
 	event := NewEvent()
 
-	processedEvent := scope.ApplyToEvent(event, nil, nil)
+	processedEvent := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 	assertEqual(t, len(processedEvent.Breadcrumbs), 1, "should use scope breadcrumbs")
 	assertEqual(t, len(processedEvent.Attachments), 1, "should use scope attachments")
 	assertEqual(t, len(processedEvent.Tags), 1, "should use scope tags")
@@ -678,7 +749,7 @@ func TestApplyToEventUsesClientPIISettingsForRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event := scope.ApplyToEvent(NewEvent(), nil, requestClient)
+	event := applyScopeChain(NewEvent(), requestClient, scope, captureOptions{})
 
 	if event.Request == nil {
 		t.Fatal("expected request to be attached")
@@ -719,7 +790,7 @@ func TestApplyToEventUsesExplicitDataCollectionForRequest(t *testing.T) {
 	request.Header.Set("Some-Header", "some-header value")
 	scope.SetRequest(request)
 
-	event := scope.ApplyToEvent(NewEvent(), nil, client)
+	event := applyScopeChain(NewEvent(), client, scope, captureOptions{})
 	if event.Request == nil {
 		t.Fatal("expected request to be attached")
 	}
@@ -771,7 +842,7 @@ func TestApplyToEventHTTPBodyCollection(t *testing.T) {
 			scope.SetRequest(request)
 			scope.SetRequestBody(tt.body)
 
-			event := scope.ApplyToEvent(NewEvent(), nil, client)
+			event := applyScopeChain(NewEvent(), client, scope, captureOptions{})
 			if event.Request == nil {
 				t.Fatal("expected request to be attached")
 			}
@@ -795,7 +866,7 @@ func TestEventProcessorsModifiesEvent(t *testing.T) {
 			return event
 		},
 	}
-	processedEvent := scope.ApplyToEvent(event, nil, nil)
+	processedEvent := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 
 	if processedEvent == nil {
 		t.Fatal("event should not be dropped")
@@ -812,7 +883,7 @@ func TestEventProcessorsCanDropEvent(t *testing.T) {
 			return nil
 		},
 	}
-	processedEvent := scope.ApplyToEvent(event, nil, nil)
+	processedEvent := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 
 	if processedEvent != nil {
 		t.Error("event should be dropped")
@@ -822,7 +893,7 @@ func TestEventProcessorsCanDropEvent(t *testing.T) {
 func TestEventProcessorsAddEventProcessor(t *testing.T) {
 	scope := NewScope()
 	event := NewEvent()
-	processedEvent := scope.ApplyToEvent(event, nil, nil)
+	processedEvent := applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 
 	if processedEvent == nil {
 		t.Error("event should not be dropped")
@@ -831,7 +902,7 @@ func TestEventProcessorsAddEventProcessor(t *testing.T) {
 	scope.AddEventProcessor(func(_ *Event, _ *EventHint) *Event {
 		return nil
 	})
-	processedEvent = scope.ApplyToEvent(event, nil, nil)
+	processedEvent = applyScopeChain(event, NewNoopClient(), scope, captureOptions{})
 
 	if processedEvent != nil {
 		t.Error("event should be dropped")

--- a/sentry.go
+++ b/sentry.go
@@ -24,6 +24,7 @@ func Init(options ClientOptions) error {
 		return err
 	}
 	hub.BindClient(client)
+	GlobalScope().SetClient(client)
 	return nil
 }
 

--- a/sentry.go
+++ b/sentry.go
@@ -47,6 +47,12 @@ func CaptureException(ctx context.Context, err error, options ...CaptureOption) 
 	return GetClient(ctx).CaptureException(ctx, err, options...)
 }
 
+// CapturePanic captures a panic value returned by recover.
+// It always attaches the stacktrace of the active panic.
+func CapturePanic(ctx context.Context, recovered any, options ...CaptureOption) *EventID {
+	return GetClient(ctx).CapturePanic(ctx, recovered, options...)
+}
+
 // CaptureCheckIn captures a (cron) monitor check-in.
 func CaptureCheckIn(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig, options ...CaptureOption) *EventID {
 	return GetClient(ctx).CaptureCheckIn(ctx, checkIn, monitorConfig, options...)
@@ -63,7 +69,7 @@ func CaptureEvent(ctx context.Context, event *Event, options ...CaptureOption) *
 
 // Recover captures a panic from the current goroutine. It must be deferred.
 func Recover(ctx context.Context, options ...CaptureOption) *EventID {
-	return GetClient(ctx).recoverValue(ctx, recover(), ScopeFromContext(ctx), resolveCaptureOptions(ctx, options))
+	return CapturePanic(ctx, recover(), options...)
 }
 
 // WithScope is a shorthand for CurrentHub().WithScope.

--- a/sentry.go
+++ b/sentry.go
@@ -38,21 +38,18 @@ func AddBreadcrumb(breadcrumb *Breadcrumb) {
 }
 
 // CaptureMessage captures an arbitrary message.
-func CaptureMessage(message string) *EventID {
-	hub := CurrentHub()
-	return hub.CaptureMessage(message)
+func CaptureMessage(ctx context.Context, message string, options ...CaptureOption) *EventID {
+	return GetClient(ctx).CaptureMessage(ctx, message, options...)
 }
 
 // CaptureException captures an error.
-func CaptureException(exception error) *EventID {
-	hub := CurrentHub()
-	return hub.CaptureException(exception)
+func CaptureException(ctx context.Context, err error, options ...CaptureOption) *EventID {
+	return GetClient(ctx).CaptureException(ctx, err, options...)
 }
 
 // CaptureCheckIn captures a (cron) monitor check-in.
-func CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig) *EventID {
-	hub := CurrentHub()
-	return hub.CaptureCheckIn(checkIn, monitorConfig)
+func CaptureCheckIn(ctx context.Context, checkIn *CheckIn, monitorConfig *MonitorConfig, options ...CaptureOption) *EventID {
+	return GetClient(ctx).CaptureCheckIn(ctx, checkIn, monitorConfig, options...)
 }
 
 // CaptureEvent captures an event on the currently active client if any.
@@ -60,33 +57,13 @@ func CaptureCheckIn(checkIn *CheckIn, monitorConfig *MonitorConfig) *EventID {
 // The event must already be assembled. Typically code would instead use
 // the utility methods like CaptureException. The return value is the
 // event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
-func CaptureEvent(event *Event) *EventID {
-	hub := CurrentHub()
-	return hub.CaptureEvent(event)
+func CaptureEvent(ctx context.Context, event *Event, options ...CaptureOption) *EventID {
+	return GetClient(ctx).CaptureEvent(ctx, event, options...)
 }
 
-// Recover captures a panic.
-func Recover() *EventID {
-	if err := recover(); err != nil {
-		hub := CurrentHub()
-		return hub.Recover(err)
-	}
-	return nil
-}
-
-// RecoverWithContext captures a panic and passes relevant context object.
-func RecoverWithContext(ctx context.Context) *EventID {
-	err := recover()
-	if err == nil {
-		return nil
-	}
-
-	hub := GetHubFromContext(ctx)
-	if hub == nil {
-		hub = CurrentHub()
-	}
-
-	return hub.RecoverWithContext(ctx, err)
+// Recover captures a panic from the current goroutine. It must be deferred.
+func Recover(ctx context.Context, options ...CaptureOption) *EventID {
+	return GetClient(ctx).recoverValue(ctx, recover(), ScopeFromContext(ctx), resolveCaptureOptions(ctx, options))
 }
 
 // WithScope is a shorthand for CurrentHub().WithScope.

--- a/span_recorder.go
+++ b/span_recorder.go
@@ -11,18 +11,27 @@ import (
 type spanRecorder struct {
 	mu           sync.Mutex
 	spans        []*Span
+	maxSpans     int
 	overflowOnce sync.Once
+}
+
+func newSpanRecorder(client *Client) *spanRecorder {
+	maxSpans := defaultMaxSpans
+	if client != nil && client.IsEnabled() {
+		maxSpans = client.options.MaxSpans
+	}
+	return &spanRecorder{maxSpans: maxSpans}
 }
 
 // record stores a span. The first stored span is assumed to be the root of a
 // span tree.
 func (r *spanRecorder) record(s *Span) {
-	maxSpans := defaultMaxSpans
-	if client := CurrentHub().Client(); client.IsEnabled() {
-		maxSpans = client.options.MaxSpans
-	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	maxSpans := r.maxSpans
+	if maxSpans == 0 {
+		maxSpans = defaultMaxSpans
+	}
 	if len(r.spans) >= maxSpans {
 		r.overflowOnce.Do(func() {
 			root := r.spans[0]

--- a/span_recorder.go
+++ b/span_recorder.go
@@ -18,7 +18,7 @@ type spanRecorder struct {
 // span tree.
 func (r *spanRecorder) record(s *Span) {
 	maxSpans := defaultMaxSpans
-	if client := CurrentHub().Client(); client != nil {
+	if client := CurrentHub().Client(); client.IsEnabled() {
 		maxSpans = client.options.MaxSpans
 	}
 	r.mu.Lock()

--- a/span_recorder_test.go
+++ b/span_recorder_test.go
@@ -36,7 +36,7 @@ func Test_spanRecorder_record(t *testing.T) {
 			logBuffer := bytes.Buffer{}
 			debuglog.SetOutput(&logBuffer)
 			defer debuglog.SetOutput(io.Discard)
-			spanRecorder := spanRecorder{}
+			spanRecorder := spanRecorder{maxSpans: tt.maxSpans}
 
 			currentHub.BindClient(&Client{
 				options: ClientOptions{

--- a/tracing.go
+++ b/tracing.go
@@ -45,7 +45,7 @@ const (
 // that is sent to Sentry when the root span is finished.
 //
 // Spans must be started with either StartSpan or Span.StartChild.
-type Span struct { //nolint: maligned // prefer readability over optimal memory layout (see note below *)
+type Span struct {
 	TraceID      TraceID                `json:"trace_id"`
 	SpanID       SpanID                 `json:"span_id"`
 	ParentSpanID SpanID                 `json:"parent_span_id,omitzero"`
@@ -933,8 +933,8 @@ type TraceContext struct {
 
 func (tc TraceContext) Map() map[string]interface{} {
 	m := map[string]interface{}{
-		"trace_id": tc.TraceID,
-		"span_id":  tc.SpanID,
+		traceIDContextKey: tc.TraceID,
+		spanIDContextKey:  tc.SpanID,
 	}
 
 	if tc.ParentSpanID != [8]byte{} {

--- a/tracing.go
+++ b/tracing.go
@@ -197,17 +197,20 @@ func StartSpan(ctx context.Context, operation string, options ...SpanOption) *Sp
 
 	span.Sampled = span.sample()
 
-	span.recorder = &spanRecorder{}
+	span.recorder = newSpanRecorder(GetClient(ctx))
 	if hasParent {
 		span.recorder = parent.spanRecorder()
 	}
 
 	span.recorder.record(&span)
 
-	clientOptions := span.clientOptions()
-	if clientOptions.EnableTracing {
-		hub := hubFromContext(ctx)
-		hub.Scope().SetSpan(&span)
+	if scope := ScopeFromContext(ctx); !hasParent && scope != nil {
+		scope.SetPropagationContext(PropagationContext{
+			TraceID:                span.TraceID,
+			SpanID:                 span.SpanID,
+			ParentSpanID:           span.ParentSpanID,
+			DynamicSamplingContext: span.dynamicSamplingContext,
+		})
 	}
 
 	return &span
@@ -392,7 +395,7 @@ func (s *Span) ToBaggage() string {
 
 	// In case there is currently no frozen DynamicSamplingContext attached to the transaction,
 	// create one from the properties of the transaction.
-	if !s.dynamicSamplingContext.IsFrozen() {
+	if !t.dynamicSamplingContext.IsFrozen() {
 		// This will return a frozen DynamicSamplingContext.
 		if dsc := DynamicSamplingContextFromTransaction(t); dsc.HasEntries() {
 			t.dynamicSamplingContext = dsc
@@ -468,29 +471,20 @@ func (s *Span) doFinish() {
 		s.EndTime = monotonicTimeSince(s.StartTime)
 	}
 
-	hub := hubFromContext(s.ctx)
-	if !s.IsTransaction() {
-		if s.parent != nil {
-			hub.Scope().SetSpan(s.parent)
-		}
-	}
-
 	if s.shouldIgnoreStatusCode() {
 		return
 	}
 
 	if !s.Sampled.Bool() {
-		c := hub.Client()
-		if c != nil {
-			if !s.IsTransaction() {
-				// we count the sampled spans from the transaction root. it is guaranteed that the whole transaction
-				// would be sampled
-				return
-			}
-			children := s.recorder.children()
-			c.reportRecorder.RecordOne(report.ReasonSampleRate, ratelimit.CategoryTransaction)
-			c.reportRecorder.Record(report.ReasonSampleRate, ratelimit.CategorySpan, int64(len(children)+1))
+		client := GetClient(s.ctx)
+		if !s.IsTransaction() {
+			// we count the sampled spans from the transaction root. it is guaranteed that the whole transaction
+			// would be sampled
+			return
 		}
+		children := s.recorder.children()
+		client.reportRecorder.RecordOne(report.ReasonSampleRate, ratelimit.CategoryTransaction)
+		client.reportRecorder.Record(report.ReasonSampleRate, ratelimit.CategorySpan, int64(len(children)+1))
 		return
 	}
 	event := s.toEvent()
@@ -501,7 +495,7 @@ func (s *Span) doFinish() {
 	// TODO(tracing): add breadcrumbs
 	// (see https://github.com/getsentry/sentry-python/blob/f6f3525f8812f609/sentry_sdk/tracing.py#L372)
 
-	hub.CaptureEvent(event)
+	GetClient(s.ctx).CaptureEvent(s.ctx, event)
 }
 
 // sentryTracePattern matches either
@@ -538,7 +532,7 @@ func (s *Span) updateFromSentryTrace(header []byte) (updated bool) {
 	return true
 }
 
-func (s *Span) updateFromBaggage(header []byte) {
+func (s *Span) updateFromBaggage(header []byte) { // nolint: unused
 	if s.IsTransaction() {
 		dsc, err := DynamicSamplingContextFromHeader(header)
 		if err != nil {
@@ -550,7 +544,7 @@ func (s *Span) updateFromBaggage(header []byte) {
 }
 
 func (s *Span) clientOptions() *ClientOptions {
-	client := hubFromContext(s.ctx).Client()
+	client := GetClient(s.ctx)
 	if client.IsEnabled() {
 		return &client.options
 	}
@@ -1042,23 +1036,40 @@ func WithSpanOrigin(origin SpanOrigin) SpanOption {
 	}
 }
 
-// ContinueTrace continues a trace based on traceparent and baggage values.
-// If the SDK is configured with tracing enabled,
-// this function returns populated SpanOption.
-// In any other cases, it populates the propagation context on the scope.
-func ContinueTrace(hub *Hub, traceparent, baggage string) SpanOption {
-	scope := hub.Scope()
-	propagationContext, _ := PropagationContextFromHeaders(traceparent, baggage)
-	client := hub.Client()
+// ContinueTrace returns a span option that continues a trace from sentry-trace
+// and baggage header values.
+func ContinueTrace(traceparent, baggage string) SpanOption {
+	return func(s *Span) {
+		if s.parent != nil || traceparent == "" {
+			return
+		}
 
-	if !shouldContinueTrace(client, propagationContext.DynamicSamplingContext) {
-		propagationContext = NewPropagationContext()
-		traceparent = ""
-		baggage = ""
+		trace, valid := ParseTraceParentContext([]byte(traceparent))
+		if !valid {
+			return
+		}
+
+		var dsc DynamicSamplingContext
+		if baggage != "" {
+			parsed, err := DynamicSamplingContextFromHeader([]byte(baggage))
+			if err == nil {
+				dsc = parsed
+			}
+		}
+		if !shouldContinueTrace(GetClient(s.ctx), dsc) {
+			return
+		}
+
+		s.TraceID = trace.TraceID
+		s.ParentSpanID = trace.ParentSpanID
+		s.Sampled = trace.Sampled
+		s.dynamicSamplingContext = dsc
+		// An incoming sentry-trace freezes the DSC even when no Sentry baggage
+		// entries were supplied.
+		if !s.dynamicSamplingContext.HasEntries() {
+			s.dynamicSamplingContext.Frozen = true
+		}
 	}
-
-	scope.SetPropagationContext(propagationContext)
-	return ContinueFromHeaders(traceparent, baggage)
 }
 
 // ContinueFromRequest returns a span option that updates the span to continue
@@ -1075,54 +1086,15 @@ func ContinueFromRequest(r *http.Request) SpanOption {
 // ContinueFromHeaders returns a span option that updates the span to continue
 // an existing TraceID and propagates the Dynamic Sampling context.
 func ContinueFromHeaders(trace, baggage string) SpanOption {
-	return func(s *Span) {
-		if trace == "" {
-			return
-		}
-
-		// Parse baggage first to get org_id for comparison
-		var dsc DynamicSamplingContext
-		if baggage != "" {
-			parsed, err := DynamicSamplingContextFromHeader([]byte(baggage))
-			if err == nil {
-				dsc = parsed
-			}
-		}
-
-		client := hubFromContext(s.ctx).Client()
-		if !shouldContinueTrace(client, dsc) {
-			return // leave span unchanged → behaves as head of trace
-		}
-
-		s.updateFromSentryTrace([]byte(trace))
-
-		if baggage != "" {
-			s.updateFromBaggage([]byte(baggage))
-		}
-
-		// In case a sentry-trace header is present but there are no sentry-related
-		// values in the baggage, create an empty, frozen DynamicSamplingContext.
-		if !s.dynamicSamplingContext.HasEntries() {
-			s.dynamicSamplingContext = DynamicSamplingContext{
-				Frozen: true,
-			}
-		}
-	}
+	// TODO: ContinueFromHeaders should be removed along with the hub, since
+	// it just becomes ContinueTrace now.
+	return ContinueTrace(trace, baggage)
 }
 
 // ContinueFromTrace returns a span option that updates the span to continue
 // an existing TraceID.
 func ContinueFromTrace(trace string) SpanOption {
-	return func(s *Span) {
-		if trace == "" {
-			return
-		}
-		client := hubFromContext(s.ctx).Client()
-		if !shouldContinueTrace(client, DynamicSamplingContext{}) {
-			return
-		}
-		s.updateFromSentryTrace([]byte(trace))
-	}
+	return ContinueTrace(trace, "")
 }
 
 // spanContextKey is used to store span values in contexts.
@@ -1149,10 +1121,12 @@ func SpanFromContext(ctx context.Context) *Span {
 // StartTransaction will create a transaction (root span) if there's no existing
 // transaction in the context otherwise, it will return the existing transaction.
 func StartTransaction(ctx context.Context, name string, options ...SpanOption) *Span {
-	currentTransaction, exists := ctx.Value(spanContextKey{}).(*Span)
-	if exists {
-		currentTransaction.ctx = ctx
-		return currentTransaction
+	if currentSpan, exists := ctx.Value(spanContextKey{}).(*Span); exists {
+		transaction := currentSpan.GetTransaction()
+		if transaction != nil {
+			transaction.ctx = context.WithValue(ctx, spanContextKey{}, transaction)
+		}
+		return transaction
 	}
 
 	options = append(options, WithTransactionName(name))

--- a/tracing.go
+++ b/tracing.go
@@ -1097,6 +1097,57 @@ func ContinueFromTrace(trace string) SpanOption {
 	return ContinueTrace(trace, "")
 }
 
+// GetTraceparent returns the Sentry trace header value for the active span or
+// propagation context carried by ctx. It does not fall back to Hub state.
+func GetTraceparent(ctx context.Context) string {
+	if span := SpanFromContext(ctx); span != nil {
+		return span.ToSentryTrace()
+	}
+
+	scope := ScopeFromContext(ctx)
+	if scope == nil {
+		return ""
+	}
+	propagation := scope.propagationContextSnapshot()
+	if propagation.TraceID == zeroTraceID || propagation.SpanID == zeroSpanID {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s", propagation.TraceID, propagation.SpanID)
+}
+
+// GetTraceparentW3C returns the W3C traceparent header value for the active
+// span or propagation context carried by ctx. It does not fall back to Hub
+// state.
+func GetTraceparentW3C(ctx context.Context) string {
+	if span := SpanFromContext(ctx); span != nil {
+		return span.ToTraceparent()
+	}
+
+	scope := ScopeFromContext(ctx)
+	if scope == nil {
+		return ""
+	}
+	propagation := scope.propagationContextSnapshot()
+	if propagation.TraceID == zeroTraceID || propagation.SpanID == zeroSpanID {
+		return ""
+	}
+	return fmt.Sprintf("00-%s-%s-00", propagation.TraceID, propagation.SpanID)
+}
+
+// GetBaggage returns the Sentry baggage header value for the active span or
+// propagation context carried by ctx. It does not fall back to Hub state.
+func GetBaggage(ctx context.Context) string {
+	if span := SpanFromContext(ctx); span != nil {
+		return span.ToBaggage()
+	}
+
+	scope := ScopeFromContext(ctx)
+	if scope == nil {
+		return ""
+	}
+	return scope.propagationContextSnapshot().DynamicSamplingContext.String()
+}
+
 // spanContextKey is used to store span values in contexts.
 type spanContextKey struct{}
 

--- a/tracing.go
+++ b/tracing.go
@@ -551,7 +551,7 @@ func (s *Span) updateFromBaggage(header []byte) {
 
 func (s *Span) clientOptions() *ClientOptions {
 	client := hubFromContext(s.ctx).Client()
-	if client != nil {
+	if client.IsEnabled() {
 		return &client.options
 	}
 	return &ClientOptions{}
@@ -1202,7 +1202,7 @@ func HTTPtoSpanStatus(code int) SpanStatus {
 }
 
 func shouldContinueTrace(client *Client, dsc DynamicSamplingContext) bool {
-	if client == nil {
+	if !client.IsEnabled() {
 		return true
 	}
 

--- a/tracing.go
+++ b/tracing.go
@@ -723,7 +723,7 @@ func (s *Span) toEvent() *Event {
 // traceContext returns a TraceContext snapshot for an active span.
 //
 // It needs to clone span Data to avoid holding any user mutable state.
-func (s *Span) traceContext() *TraceContext {
+func (s *Span) traceContext() *TraceContext { // nolint: unused
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return &TraceContext{

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -400,9 +400,10 @@ func NewTestContext(options ClientOptions) context.Context {
 	if err != nil {
 		panic(err)
 	}
-	hub := NewHub(client, NewScope())
 	ctx := context.WithValue(context.Background(), testContextKey{}, testContextValue{})
-	return SetHubOnContext(ctx, hub)
+	ctx, scope := WithIsolationScope(ctx)
+	scope.SetClient(client)
+	return ctx
 }
 
 // A SpanCheck is a test helper describing span properties that can be checked
@@ -554,6 +555,19 @@ func TestContinueTransactionFromHeaders(t *testing.T) {
 			},
 		},
 		{
+			name:       "sentry-trace and malformed baggage => continue with empty frozen DSC",
+			traceStr:   "bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1",
+			baggageStr: "invalid baggage @@@",
+			wantSpan: &Span{
+				TraceID:      TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4"),
+				ParentSpanID: SpanIDFromHex("b72fa28504b07285"),
+				Sampled:      1,
+				dynamicSamplingContext: DynamicSamplingContext{
+					Frozen: true,
+				},
+			},
+		},
+		{
 			name:       "sentry-trace and baggage with Sentry values => we freeze immediately.",
 			traceStr:   "bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1",
 			baggageStr: "sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-public_key=public,sentry-sample_rate=1",
@@ -666,7 +680,7 @@ func TestDoubleSampling(t *testing.T) {
 	span := StartSpan(ctx, "op", WithTransactionName("name"))
 
 	// CaptureException should not send any event because of SampleRate.
-	GetHubFromContext(ctx).CaptureException(errors.New("ignored"))
+	CaptureException(ctx, errors.New("ignored"))
 	if got := len(transport.Events()); got != 0 {
 		t.Fatalf("got %d events, want 0", got)
 	}
@@ -905,9 +919,8 @@ func TestSampleRatePropagation(t *testing.T) {
 				Transport:        transport,
 			})
 
-			hub := GetHubFromContext(ctx)
 			options := []SpanOption{
-				ContinueTrace(hub, tt.traceHeader, tt.baggageHeader),
+				ContinueTrace(tt.traceHeader, tt.baggageHeader),
 			}
 			transaction := StartTransaction(ctx, "test-transaction", options...)
 			transaction.Finish()
@@ -981,8 +994,7 @@ func TestTracesSamplerReceivesRemoteParent(t *testing.T) {
 				},
 			})
 
-			hub := GetHubFromContext(ctx)
-			txn := StartTransaction(ctx, "test-txn", ContinueTrace(hub, tt.traceHeader, tt.baggageHeader))
+			txn := StartTransaction(ctx, "test-txn", ContinueTrace(tt.traceHeader, tt.baggageHeader))
 			txn.Finish()
 
 			assert.Nil(t, gotCtx.Parent, "SamplingContext.Parent should be nil for remote parent")
@@ -1119,6 +1131,16 @@ func TestGetTransactionReturnsNilOnManuallyCreatedSpans(t *testing.T) {
 	}
 }
 
+func TestStartTransactionReturnsRootFromChildContext(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{EnableTracing: true})
+	transaction := StartTransaction(ctx, "transaction")
+	child := transaction.StartChild("child")
+
+	if got := StartTransaction(child.Context(), "ignored"); got != transaction {
+		t.Fatalf("StartTransaction(child.Context()) = %p, want root transaction %p", got, transaction)
+	}
+}
+
 func TestToBaggage(t *testing.T) {
 	ctx := NewTestContext(ClientOptions{
 		EnableTracing:    true,
@@ -1140,6 +1162,24 @@ func TestToBaggage(t *testing.T) {
 		t,
 		child.ToBaggage(),
 		"sentry-trace_id=f1a4c5c9071eca1cdf04e4132527ed16,sentry-release=test-release,sentry-transaction=transaction-name,sentry-sample_rate=1,sentry-sampled=true",
+	)
+}
+
+func TestChildToBaggagePreservesFrozenTransactionDSC(t *testing.T) {
+	ctx := NewTestContext(ClientOptions{
+		EnableTracing:    true,
+		TracesSampleRate: 1.0,
+	})
+	transaction := StartTransaction(ctx, "transaction", ContinueTrace(
+		"bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1",
+		"sentry-trace_id=bc6d53f15eb88f4320054569b8c553d4,sentry-public_key=upstream",
+	))
+	child := transaction.StartChild("child")
+
+	assertBaggageStringsEqual(
+		t,
+		child.ToBaggage(),
+		"sentry-trace_id=bc6d53f15eb88f4320054569b8c553d4,sentry-public_key=upstream",
 	)
 }
 
@@ -1184,7 +1224,7 @@ func TestConcurrentContextAccess(_ *testing.T) {
 		EnableTracing:    true,
 		TracesSampleRate: 1,
 	})
-	hub := GetHubFromContext(ctx)
+	scope := ScopeFromContext(ctx)
 
 	const writersNum = 200
 
@@ -1196,7 +1236,7 @@ func TestConcurrentContextAccess(_ *testing.T) {
 		go func() {
 			transaction := StartTransaction(ctx, "test")
 			c <- transaction
-			hub.Scope().SetContext("device", Context{"test": "bla"})
+			scope.SetContext("device", Context{"test": "bla"})
 		}()
 	}
 
@@ -1290,8 +1330,34 @@ func TestSpanFinishConcurrentlyWithoutRaces(_ *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-func TestSpanScopeManagement(t *testing.T) {
-	// Initialize a test hub and client
+func TestRootFinishUsesCurrentClient(t *testing.T) {
+	firstTransport := &MockTransport{}
+	first, err := NewClient(ClientOptions{EnableTracing: true, TracesSampleRate: 1, Transport: firstTransport})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondTransport := &MockTransport{}
+	second, err := NewClient(ClientOptions{EnableTracing: true, TracesSampleRate: 1, Transport: secondTransport})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, scope := WithIsolationScope(context.Background())
+	scope.SetClient(first)
+	transaction := StartTransaction(ctx, "current-client")
+	scope.SetClient(second)
+	transaction.Finish()
+
+	if got := len(firstTransport.Events()); got != 0 {
+		t.Fatalf("replaced client got %d transactions, want 0", got)
+	}
+	if got := len(secondTransport.Events()); got != 1 {
+		t.Fatalf("current client got %d transactions, want 1", got)
+	}
+}
+
+func TestSpanScopeIsNotActiveSpanStack(t *testing.T) {
+	// Initialize a test client.
 	transport := &MockTransport{}
 	client, err := NewClient(ClientOptions{
 		EnableTracing:    true,
@@ -1301,11 +1367,8 @@ func TestSpanScopeManagement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hub := NewHub(client, NewScope())
-
-	// Set the hub on the context
-	ctx := context.Background()
-	ctx = SetHubOnContext(ctx, hub)
+	ctx, scope := WithIsolationScope(context.Background())
+	scope.SetClient(client)
 
 	// Start a parent span (transaction)
 	transaction := StartTransaction(ctx, "parent-operation")
@@ -1316,12 +1379,16 @@ func TestSpanScopeManagement(t *testing.T) {
 	// Finish the child span
 	defer childSpan.Finish()
 
+	siblingSpan := StartSpan(transaction.Context(), "sibling-operation")
 	subChildSpan := StartSpan(childSpan.Context(), "sub_child-operation")
+	childSpan.Finish()
+	siblingSpan.Finish()
 	subChildSpan.Finish()
+	if got := scope.GetSpan(); got != nil {
+		t.Fatalf("scope active span = %p, want nil", got)
+	}
 
-	// Capture an event after finishing the child span
-	// This event should be associated with the first child span
-	hub.CaptureMessage("Test event")
+	CaptureMessage(childSpan.Context(), "Test event")
 
 	// Flush to ensure the event is sent
 	transport.Flush(time.Second)
@@ -1329,7 +1396,7 @@ func TestSpanScopeManagement(t *testing.T) {
 	// Verify that the event has the correct trace data
 	events := transport.Events()
 	if len(events) != 1 {
-		t.Fatalf("expected 2 event, got %d", len(events))
+		t.Fatalf("expected 1 event, got %d", len(events))
 	}
 	event := events[0]
 
@@ -1349,7 +1416,7 @@ func TestSpanScopeManagement(t *testing.T) {
 		t.Fatalf("span_id not found")
 	}
 
-	// Verify that the IDs match the first child span IDs
+	// Verify that the IDs match the explicitly supplied child context.
 	if traceID != childSpan.TraceID {
 		t.Errorf("expected TraceID %s, got %s", transaction.TraceID, traceID)
 	}
@@ -1404,9 +1471,8 @@ func TestStrictTraceContinuation(t *testing.T) {
 				baggage = baggageWithOrg(tt.baggageOrgID)
 			}
 
-			hub := GetHubFromContext(ctx)
 			transaction := StartTransaction(ctx, "test",
-				ContinueTrace(hub, sentryTrace, baggage),
+				ContinueTrace(sentryTrace, baggage),
 			)
 			transaction.Finish()
 

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1425,6 +1425,83 @@ func TestSpanScopeIsNotActiveSpanStack(t *testing.T) {
 	}
 }
 
+func TestContextPropagationHeaders(t *testing.T) {
+	t.Run("no propagation context", func(t *testing.T) {
+		ctx := context.Background()
+		if got := GetTraceparent(ctx); got != "" {
+			t.Fatalf("GetTraceparent = %q, want empty", got)
+		}
+		if got := GetTraceparentW3C(ctx); got != "" {
+			t.Fatalf("GetTraceparentW3C = %q, want empty", got)
+		}
+		if got := GetBaggage(ctx); got != "" {
+			t.Fatalf("GetBaggage = %q, want empty", got)
+		}
+	})
+
+	t.Run("scope propagation context", func(t *testing.T) {
+		ctx, scope := WithIsolationScope(context.Background())
+		propagation := PropagationContext{
+			TraceID: TraceIDFromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			SpanID:  SpanIDFromHex("bbbbbbbbbbbbbbbb"),
+			DynamicSamplingContext: DynamicSamplingContext{
+				Entries: map[string]string{"release": "scope-release"},
+				Frozen:  true,
+			},
+		}
+		scope.SetPropagationContext(propagation)
+
+		if got, want := GetTraceparent(ctx), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb"; got != want {
+			t.Fatalf("GetTraceparent = %q, want %q", got, want)
+		}
+		if got, want := GetTraceparentW3C(ctx), "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00"; got != want {
+			t.Fatalf("GetTraceparentW3C = %q, want %q", got, want)
+		}
+		assertBaggageStringsEqual(t, GetBaggage(ctx), "sentry-release=scope-release")
+	})
+
+	for _, test := range []struct {
+		name          string
+		release       string
+		enableTracing bool
+		wantSampled   Sampled
+		wantSuffix    string
+	}{
+		{name: "disabled tracing", release: "disabled-tracing", enableTracing: false, wantSampled: SampledFalse, wantSuffix: "-0"},
+		{name: "custom client", release: "custom-client", enableTracing: true, wantSampled: SampledTrue, wantSuffix: "-1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := NewClient(ClientOptions{
+				Dsn:              testDsn,
+				EnableTracing:    test.enableTracing,
+				TracesSampleRate: 1,
+				Release:          test.release,
+				Transport:        &MockTransport{},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, scope := WithIsolationScope(context.Background())
+			scope.SetClient(client)
+			transaction := StartTransaction(ctx, "transaction")
+
+			if transaction.Sampled != test.wantSampled {
+				t.Fatalf("transaction sampled = %s, want %s", transaction.Sampled, test.wantSampled)
+			}
+			if got := GetTraceparent(transaction.Context()); got != transaction.ToSentryTrace() || !strings.HasSuffix(got, test.wantSuffix) {
+				t.Fatalf("GetTraceparent = %q, want %q with suffix %q", got, transaction.ToSentryTrace(), test.wantSuffix)
+			}
+			if got, want := GetTraceparentW3C(transaction.Context()), transaction.ToTraceparent(); got != want {
+				t.Fatalf("GetTraceparentW3C = %q, want %q", got, want)
+			}
+			baggage := GetBaggage(transaction.Context())
+			if !strings.Contains(baggage, "sentry-release="+test.release) {
+				t.Fatalf("GetBaggage = %q, want custom client release", baggage)
+			}
+		})
+	}
+}
+
 func TestStrictTraceContinuation(t *testing.T) {
 	incomingTraceID := TraceIDFromHex("bc6d53f15eb88f4320054569b8c553d4")
 	sentryTrace := "bc6d53f15eb88f4320054569b8c553d4-b72fa28504b07285-1"

--- a/zap/converter.go
+++ b/zap/converter.go
@@ -83,7 +83,7 @@ func isSafeToCall(v interface{}) bool {
 	}
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func:
+	case reflect.Pointer, reflect.Interface, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func:
 		return !rv.IsNil()
 	default:
 		return true

--- a/zap/sentryzap_test.go
+++ b/zap/sentryzap_test.go
@@ -22,6 +22,7 @@ func newMockTransport() (context.Context, *sentry.MockTransport) {
 	})
 	hub := sentry.CurrentHub()
 	hub.BindClient(mockClient)
+	sentry.GlobalScope().SetClient(mockClient)
 	ctx = sentry.SetHubOnContext(ctx, hub)
 	return ctx, mockTransport
 }


### PR DESCRIPTION
### Description
This adds a convenience method to capture panics. Panics even as messages should always have an active stacktrace, so this PR also changes the old recover behavior to include stacktraces on captured string literals.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
