### PR TITLE
feat: Runtime metrics integration

### DIFF
--- a/runtime_metrics.go
+++ b/runtime_metrics.go
@@ -78,7 +78,7 @@ func StartRuntimeMetrics(config RuntimeMetricsConfig) {
 
 	// XXX(aldy505): Do we guard the `interval` when it's below or over a certain threshold?
 	// Javascript SDK defaults to 30 seconds.
-	if config.Interval == 0 {
+	if config.Interval <= 0 {
 		config.Interval = time.Second * 30
 	}
 

--- a/runtime_metrics.go
+++ b/runtime_metrics.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"context"
+	"runtime"
 	runtime_metrics "runtime/metrics"
 	"sync"
 	"time"
@@ -61,6 +62,52 @@ var runtimeMetricsSamples = []runtime_metrics.Sample{
 // > scratch, which is always safe, though may be inefficient.
 var onceRuntimeMetrics = sync.Once{}
 
+// A simple marker to guarantee that the runtime metrics integration is only
+// started once.
+var runtimeMetricsRunning = false
+
+type cpuUtilizationTracker struct {
+	lastCPUSeconds float64
+	lastSampleTime time.Time
+}
+
+var maxProcs = float64(runtime.GOMAXPROCS(-1))
+
+func (t *cpuUtilizationTracker) GetCPUUtilization(currentCPUSeconds float64) float64 {
+	now := time.Now()
+
+	// First sample — can't calculate yet
+	if t.lastSampleTime.IsZero() {
+		t.lastCPUSeconds = currentCPUSeconds
+		t.lastSampleTime = now
+		return 0.0
+	}
+
+	// Calculate deltas
+	cpuDelta := currentCPUSeconds - t.lastCPUSeconds
+	wallClockDelta := now.Sub(t.lastSampleTime).Seconds()
+
+	// Normalize by GOMAXPROCS to get utilization percentage
+	// cpuDelta represents CPU-seconds consumed across all GOMAXPROCS goroutines
+	// wallClockDelta is real time that passed
+	// Divide by GOMAXPROCS to account for parallel CPUs
+	utilization := cpuDelta / (wallClockDelta * maxProcs)
+
+	// Clamp to [0.0, 1.0] (shouldn't exceed unless there's jitter)
+	if utilization > 1.0 {
+		utilization = 1.0
+	}
+	if utilization < 0.0 {
+		utilization = 0.0
+	}
+
+	// Update state for next sample
+	t.lastCPUSeconds = currentCPUSeconds
+	t.lastSampleTime = now
+
+	return utilization
+}
+
 // StartRuntimeMetrics starts the runtime metrics integration.
 // This should be called using `go sentry.StartRuntimeMetrics(config)`.
 // When invoked multiple times, the integration is only started once.
@@ -76,49 +123,62 @@ func StartRuntimeMetrics(config RuntimeMetricsConfig) {
 		return
 	}
 
+	if runtimeMetricsRunning {
+		return
+	}
+
+	onceRuntimeMetrics.Do(func() {
+		runtimeMetricsRunning = true
+	})
+
 	// XXX(aldy505): Do we guard the `interval` when it's below or over a certain threshold?
 	// Javascript SDK defaults to 30 seconds.
 	if config.Interval <= 0 {
 		config.Interval = time.Second * 30
 	}
 
-	onceRuntimeMetrics.Do(func() {
-		hub := CurrentHub()
+	hub := CurrentHub()
 
-		if config.Context == nil {
-			config.Context = SetHubOnContext(context.Background(), hub)
-		}
+	if config.Context == nil {
+		config.Context = SetHubOnContext(context.Background(), hub)
+	}
 
-		meter := NewMeter(config.Context)
+	meter := NewMeter(config.Context)
 
-		timer := time.NewTicker(config.Interval)
-		defer timer.Stop()
+	timer := time.NewTicker(config.Interval)
+	defer timer.Stop()
+	cpuTracker := cpuUtilizationTracker{}
 
-		for {
-			select {
-			case <-config.Context.Done():
-				return
-			case <-timer.C:
-				runtime_metrics.Read(runtimeMetricsSamples)
-				for i, sample := range runtimeMetricsSamples {
-					switch sample.Value.Kind() {
-					case runtime_metrics.KindFloat64:
-						value := sample.Value.Float64()
-						meter.Gauge(runtimeMetricsKeys[i].Key, value, WithUnit(runtimeMetricsKeys[i].Unit))
-					case runtime_metrics.KindUint64:
-						value := sample.Value.Uint64()
-						meter.Gauge(runtimeMetricsKeys[i].Key, float64(value), WithUnit(runtimeMetricsKeys[i].Unit))
-					case runtime_metrics.KindFloat64Histogram:
-						// XXX(aldy505): we don't have any. see for metric samples
-						// that has "Distribution" on the description.
-					case runtime_metrics.KindBad:
-						// not supported on this Go version/platform
-						fallthrough
-					default:
-						continue
+	for {
+		select {
+		case <-config.Context.Done():
+			return
+		case <-timer.C:
+			runtime_metrics.Read(runtimeMetricsSamples)
+			for i, sample := range runtimeMetricsSamples {
+				switch sample.Value.Kind() {
+				case runtime_metrics.KindFloat64:
+					value := sample.Value.Float64()
+					if i == 6 {
+						value = cpuTracker.GetCPUUtilization(value)
 					}
+					meter.Gauge(runtimeMetricsKeys[i].Key, value, WithUnit(runtimeMetricsKeys[i].Unit))
+				case runtime_metrics.KindUint64:
+					value := float64(sample.Value.Uint64())
+					if i == 6 {
+						value = cpuTracker.GetCPUUtilization(value)
+					}
+					meter.Gauge(runtimeMetricsKeys[i].Key, value, WithUnit(runtimeMetricsKeys[i].Unit))
+				case runtime_metrics.KindFloat64Histogram:
+					// XXX(aldy505): we don't have any. see for metric samples
+					// that has "Distribution" on the description.
+				case runtime_metrics.KindBad:
+					// not supported on this Go version/platform
+					fallthrough
+				default:
+					continue
 				}
 			}
 		}
-	})
+	}
 }

--- a/runtime_metrics.go
+++ b/runtime_metrics.go
@@ -1,0 +1,124 @@
+package sentry
+
+import (
+	"context"
+	runtime_metrics "runtime/metrics"
+	"sync"
+	"time"
+
+	"github.com/getsentry/sentry-go/internal/debuglog"
+)
+
+// RuntimeMetricsConfig configures the runtime metrics integration.
+// You may leave this empty to use the default values. For proper graceful
+// shutdown, you should provide a context that is canceled when the program
+// exits.
+type RuntimeMetricsConfig struct {
+	// Disabled disables the runtime metrics integration.
+	Disabled bool
+	// Interval is the interval at which the runtime metrics are collected.
+	// Default is 30 seconds. You don't want to set this too low, as it will
+	// trigger a lot of "stop-the-world" activity.
+	Interval time.Duration
+	// Context is the context that is used to stop the runtime metrics
+	// integration. If you don't provide a context, the SDK will create
+	// an empty background context.
+	Context context.Context
+}
+
+// The following metrics are collected by the runtime metrics integration.
+// This should be synced with the `runtimeMetricsSamples` variable.
+var runtimeMetricsKeys = []struct {
+	Key  string
+	Unit string
+}{
+	{"go.runtime.mem.total", UnitByte},
+	{"go.runtime.mem.heap_objects", UnitByte},
+	{"go.runtime.mem.heap_free", UnitByte},
+	{"go.runtime.mem.heap_unused", UnitByte},
+	{"go.runtime.mem.other", UnitByte},
+	{"go.runtime.goroutines.total", "goroutines"},
+	{"go.runtime.cpu.utilization", UnitRatio},
+}
+
+// The following metrics are collected by the runtime metrics integration.
+// This should be synced with the `runtimeMetricsKeys` variable.
+var runtimeMetricsSamples = []runtime_metrics.Sample{
+	{Name: "/memory/classes/total:bytes"},
+	{Name: "/memory/classes/heap/objects:bytes"},
+	{Name: "/memory/classes/heap/free:bytes"},
+	{Name: "/memory/classes/heap/unused:bytes"},
+	{Name: "/memory/classes/other:bytes"},
+	{Name: "/sched/goroutines:goroutines"},
+	{Name: "/cpu/classes/total:cpu-seconds"},
+}
+
+// To ensure that the runtime metrics integration is only started once.
+// From the Go docs:
+//
+// > It is safe to execute multiple Read calls concurrently, but their arguments
+// > must share no underlying memory. When in doubt, create a new []Sample from
+// > scratch, which is always safe, though may be inefficient.
+var onceRuntimeMetrics = sync.Once{}
+
+// StartRuntimeMetrics starts the runtime metrics integration.
+// This should be called using `go sentry.StartRuntimeMetrics(config)`.
+// When invoked multiple times, the integration is only started once.
+func StartRuntimeMetrics(config RuntimeMetricsConfig) {
+	// ensure this would not crash the program
+	defer func() {
+		if r := recover(); r != nil {
+			debuglog.Printf("panic during runtime metrics integration: %v", r)
+		}
+	}()
+
+	if config.Disabled {
+		return
+	}
+
+	// XXX(aldy505): Do we guard the `interval` when it's below or over a certain threshold?
+	// Javascript SDK defaults to 30 seconds.
+	if config.Interval == 0 {
+		config.Interval = time.Second * 30
+	}
+
+	onceRuntimeMetrics.Do(func() {
+		hub := CurrentHub()
+
+		if config.Context == nil {
+			config.Context = SetHubOnContext(context.Background(), hub)
+		}
+
+		meter := NewMeter(config.Context)
+
+		timer := time.NewTicker(config.Interval)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-config.Context.Done():
+				return
+			case <-timer.C:
+				runtime_metrics.Read(runtimeMetricsSamples)
+				for i, sample := range runtimeMetricsSamples {
+					switch sample.Value.Kind() {
+					case runtime_metrics.KindFloat64:
+						value := sample.Value.Float64()
+						meter.Gauge(runtimeMetricsKeys[i].Key, value, WithUnit(runtimeMetricsKeys[i].Unit))
+					case runtime_metrics.KindUint64:
+						value := sample.Value.Uint64()
+						meter.Gauge(runtimeMetricsKeys[i].Key, float64(value), WithUnit(runtimeMetricsKeys[i].Unit))
+					case runtime_metrics.KindFloat64Histogram:
+						// XXX(aldy505): we don't have any. see for metric samples
+						// that has "Distribution" on the description.
+					case runtime_metrics.KindBad:
+						// not supported on this Go version/platform
+						fallthrough
+					default:
+						continue
+					}
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
### Description

This is a proof of concept that I talked really briefly on Slack. Might or might not be merged. NodeJS has [this integration](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/noderuntimemetrics/), and I thought, this is easy and really possible in Go. Let's just have it!

To use or test this feature/integration, just copy and paste the code into your codebase, and fix all the import bugs (stuff like `SetHubOnContext` should be `sentry.SetHubOnContext`, etc). Then use it, like so:

```go
// optional, but recommended. otherwise how would you handle graceful shutdown?
ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
defer cancel()

if err := sentry.Init(sentry.ClientOptions{}); err != nil {
  panic("yada yada yada")
}
defer sentry.FlushWithContext(ctx)
go sentry.StartRuntimeMetrics(sentry.RuntimeMetricsConfig{Context: ctx})

// the rest of your program
```

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
