### PR TITLE
chore: update keep-alive tests for go 1.27

### DIFF
--- a/internal/http/transport_test.go
+++ b/internal/http/transport_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/getsentry/sentry-go/internal/protocol"
 	"github.com/getsentry/sentry-go/internal/ratelimit"
 	"github.com/getsentry/sentry-go/internal/testutils"
-	"github.com/getsentry/sentry-go/internal/util"
 	"go.uber.org/goleak"
 )
 
@@ -485,13 +484,17 @@ func TestKeepAlive(t *testing.T) {
 		{"SyncTransport", false},
 	}
 
+	// After go 1.27, the runtime reuses http connections when the response body is less than 256 KiB automatically.
+	// To test keepalive we need a response body larger than this limit.
+	maxDrainResponseBytes := 256 << 11
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			largeResponse := false
+			largeResponseBody := strings.Repeat(" ", maxDrainResponseBytes)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				fmt.Fprintln(w, `{"id":"ec71d87189164e79ab1e61030c183af0"}`)
 				if largeResponse {
-					fmt.Fprintln(w, strings.Repeat(" ", util.MaxDrainResponseBytes))
+					fmt.Fprintln(w, largeResponseBody)
 				}
 			}))
 			defer server.Close()

--- a/transport_test.go
+++ b/transport_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/getsentry/sentry-go/attribute"
 	"github.com/getsentry/sentry-go/internal/testutils"
-	"github.com/getsentry/sentry-go/internal/util"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/goleak"
 )
@@ -568,12 +567,16 @@ func testKeepAlive(t *testing.T, tr Transport) {
 	// unexpectedly large response from Relay -- the SDK should not try to
 	// consume arbitrarily large responses.
 	largeResponse := false
+	// After go 1.27, the runtime reuses http connections when the response body is less than 256 KiB automatically.
+	// To test keepalive we need a response body larger than this limit.
+	maxDrainResponseBytes := 256 << 11
+	largeResponseBody := strings.Repeat(" ", maxDrainResponseBytes)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Simulates a response from Relay. The event_id is arbitrary,
 		// it doesn't matter for this test.
 		fmt.Fprintln(w, `{"id":"ec71d87189164e79ab1e61030c183af0"}`)
 		if largeResponse {
-			fmt.Fprintln(w, strings.Repeat(" ", util.MaxDrainResponseBytes))
+			fmt.Fprintln(w, largeResponseBody)
 		}
 	}))
 	defer srv.Close()


### PR DESCRIPTION
### Description
This updates the KeepAlive tests to send larger response bodies so that the net/http library doesn't automatically reuse connections after go1.27

#skip-changelog

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!-- Uncomment below to override auto-generated changelog (PR title is used by default)
### Changelog Entry
- Your changelog entry here
-->

<details>
<summary>Changelog Entry Instructions</summary>

To add a custom changelog entry, uncomment the section above. Supports:
- Single entry: just write text
- Multiple entries: use bullet points
- Nested bullets: indent 4+ spaces

For more details: [custom changelog entries](https://getsentry.github.io/craft/configuration/#custom-changelog-entries-from-pr-descriptions)
</details>

<details>
<summary>Reminders</summary>

- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
</details>
